### PR TITLE
Add structure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,10 @@ authors = ["Clima Land Team"]
 version = "0.1.0"
 
 [deps]
+ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
-  "ci 1.6.0 - ubuntu-latest",
-  "ci 1.6.0 - macOS-latest",
+  "ci 1.7.0 - ubuntu-latest",
+  "ci 1.7.0 - macOS-latest",
   "docbuild",
   "format",
 ]

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -1,5 +1,204 @@
 module ClimaLSM
 
-greet() = print("Hello World!")
+using ClimaCore
+import ClimaCore: Fields
+include("Domains.jl")
+using .Domains
+
+export AbstractModel,
+    make_rhs,
+    make_ode_function,
+    make_update_aux,
+    initialize_prognostic,
+    initialize_auxiliary,
+    initialize,
+    LandModel,
+    prognostic_vars,
+    auxiliary_vars
+## Default methods for all models - to be in a seperate module at some point.
+
+abstract type AbstractModel{FT <: AbstractFloat} end
+
+"""
+   prognostic_vars(m::AbstractModel)
+
+Returns the prognostic variable symbols for the model in the form of a tuple.
+"""
+prognostic_vars(m::AbstractModel) = ()
+
+"""
+   auxiliary_vars(m::AbstractModel)
+
+Returns the auxiliary variable symbols for the model in the form of a tuple.
+"""
+auxiliary_vars(m::AbstractModel) = ()
+
+"""
+    make_rhs(model::AbstractModel)
+
+Return a `rhs!` function that updates state variables.
+
+`rhs!` should be compatible with OrdinaryDiffEq.jl solvers.
+"""
+function make_rhs(model::AbstractModel)
+    function rhs!(dY, Y, p, t) end
+    return rhs!
+end
+
+"""
+    make_update_aux(model::AbstractModel)
+
+Return an `update_aux!` function that updates auxiliary parameters `p`.
+"""
+function make_update_aux(model::AbstractModel)
+    function update_aux!(p, Y, t) end
+    return update_aux!
+end
+
+"""
+    make_ode_function(model::AbstractModel)
+
+Returns an `ode_function` that updates auxiliary variables and
+updates the prognostic state.
+
+`ode_function!` should be compatible with OrdinaryDiffEq.jl solvers.
+"""
+function make_ode_function(model::AbstractModel)
+    rhs! = make_rhs(model)
+    update_aux! = make_update_aux(model)
+    function ode_function!(dY, Y, p, t)
+        update_aux!(p, Y, t)
+        rhs!(dY, Y, p, t)
+    end
+    return ode_function!
+end
+
+"""
+    initialize_prognostic(model::AbstractModel, state::Union{ClimaCore.Fields.Field, Vector{FT}, FT})
+
+Returns a FieldVector of prognostic variables for `model` with the required
+structure, with values equal to `state`. This assumes that all prognostic
+variables are defined over the entire domain. 
+
+The default is a model with no prognostic variables, in which case 
+the returned FieldVector contains only an empty array.
+
+Adjustments to this - for example because different prognostic variables
+have different dimensions - require defining a new method.
+"""
+function initialize_prognostic(
+    model::AbstractModel{FT},
+    state::Union{ClimaCore.Fields.Field, Vector{FT}, FT},
+) where {FT}
+    keys = prognostic_vars(model)
+    if length(keys) == 0
+        return ClimaCore.Fields.FieldVector(; model.model_name => FT[])
+    else
+        values = map((x) -> similar(state), keys)
+        return ClimaCore.Fields.FieldVector(;
+            model.model_name => (; zip(keys, values)...),
+        )
+    end
+
+end
+
+"""
+    initialize_auxiliary(model::AbstractModel,state::Union{ClimaCore.Fields.Field, Vector{FT}, FT})
+
+Returns a FieldVector of auxiliary variables for `model` with the required
+structure, with values equal to `state`. This assumes that all auxiliary
+variables are defined over the entire domain. 
+
+The default is a model with no auxiliary variables, in which case 
+the returned FieldVector contains only an empty array.
+
+Adjustments to this - for example because different auxiliary variables
+have different dimensions - require defining a new method.
+"""
+function initialize_auxiliary(
+    model::AbstractModel{FT},
+    state::Union{ClimaCore.Fields.Field, Vector{FT}, FT},
+) where {FT}
+    keys = auxiliary_vars(model)
+    if length(keys) == 0
+        return ClimaCore.Fields.FieldVector(; model.model_name => FT[])
+    else
+        values = map((x) -> similar(state), keys)
+        return ClimaCore.Fields.FieldVector(;
+            model.model_name => (; zip(keys, values)...),
+        )
+    end
+end
+
+"""
+    initialize(model::AbstractModel)
+
+Creates the prognostic and auxiliary states structures, but with unset values
+not set; constructs and returns the coordinates for the `model` domain.
+We may need to consider this default more as we add diverse components and 
+`Simulations`.
+"""
+function initialize(model::AbstractModel)
+    coords = coordinates(model.domain)
+    state = empty_state(coords)
+    Y = initialize_prognostic(model, state)
+    p = initialize_auxiliary(model, state)
+    return Y, p, coords
+end
+
+#### LandModel Specific
+
+"""
+    struct LandModel{FT, sm <: AbstractModel{FT}, rm <: AbstractModel{FT}} <: AbstractModel{FT}
+
+A concrete type of `AbstractModel` for use in land surface modeling. Each component model of the
+`LandModel` is itself an `AbstractModel`.
+"""
+struct LandModel{FT, sm <: AbstractModel{FT}, rm <: AbstractModel{FT}} <:
+       AbstractModel{FT}
+    soil::sm
+    roots::rm
+end
+
+function initialize(land::LandModel)
+    Y_soil, p_soil, coords_soil = initialize(land.soil)
+    Y_roots, p_roots, coords_roots = initialize(land.roots)
+    Y = ClimaCore.Fields.FieldVector(;
+        soil = Y_soil.soil,
+        roots = Y_roots.roots,
+    )
+    p = ClimaCore.Fields.FieldVector(;
+        soil = p_soil.soil,
+        roots = p_roots.roots,
+    )
+    coords =
+        ClimaCore.Fields.FieldVector(; soil = coords_soil, roots = coords_roots)
+    return Y, p, coords
+end
+
+function make_update_aux(land::LandModel)
+    soil_update_aux! = make_update_aux(land.soil)
+    roots_update_aux! = make_update_aux(land.roots)
+    function update_aux!(p, Y, t)
+        soil_update_aux!(p, Y, t)
+        roots_update_aux!(p, Y, t)
+    end
+    return update_aux!
+end
+
+function make_ode_function(land::LandModel)
+    rhs_soil! = make_rhs(land.soil)
+    rhs_roots! = make_rhs(land.roots)
+    update_aux! = make_update_aux(land)
+    function ode_function!(dY, Y, p, t)
+        update_aux!(p, Y, t)
+        rhs_soil!(dY.soil, Y.soil, p, t)
+        rhs_roots!(dY.roots, Y.roots, p, t)
+    end
+    return ode_function!
+end
+
+include("Soil.jl")
+include("Roots.jl")
 
 end # module

--- a/src/Domains.jl
+++ b/src/Domains.jl
@@ -1,0 +1,122 @@
+module Domains
+using ClimaCore
+using DocStringExtensions
+
+import ClimaCore: Meshes, Spaces, Topologies, Geometry
+
+"""
+    AbstractDomain{FT <:AbstractFloat}
+
+An abstract type for domains.
+"""
+abstract type AbstractDomain{FT <: AbstractFloat} end
+
+"""
+    Column{FT} <: AbstractDomain{FT}
+A struct holding the necessary information 
+to construct a domain, a mesh, a center and face
+space, etc. For use when a finite difference in
+1D is suitable.
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct Column{FT} <: AbstractDomain{FT}
+    "Domain interval limits, (zmin, zmax)"
+    zlim::Tuple{FT, FT}
+    "Number of elements used to discretize the interval"
+    nelements::Int32
+    "Boundary face identifiers"
+    boundary_tags::Tuple{Symbol, Symbol}
+end
+
+Base.ndims(::Column) = 1
+
+Base.length(domain::Column) = domain.zlim[2] - domain.zlim[1]
+
+Base.size(domain::Column) = length(domain)
+
+"""
+    function Column(FT::DataType = Float64; zlim, nelements)
+Outer constructor for the `Column` type.
+The `boundary_tags` field values are used to label the boundary faces 
+at the top and bottom of the domain.
+"""
+function Column(FT::DataType = Float64; zlim, nelements)
+    @assert zlim[1] < zlim[2]
+    boundary_tags = (:bottom, :top)
+    return Column{FT}(zlim, nelements, boundary_tags)
+end
+
+"""
+    make_function_space(domain::Column)
+Returns the center and face space of the column domain.
+"""
+function make_function_space(domain::Column{FT}) where {FT}
+    column = ClimaCore.Domains.IntervalDomain(
+        ClimaCore.Geometry.ZPoint{FT}(domain.zlim[1]),
+        ClimaCore.Geometry.ZPoint{FT}(domain.zlim[2]);
+        boundary_tags = domain.boundary_tags,
+    )
+    mesh = Meshes.IntervalMesh(column; nelems = domain.nelements)
+    center_space = Spaces.CenterFiniteDifferenceSpace(mesh)
+    face_space = Spaces.FaceFiniteDifferenceSpace(center_space)
+
+    return center_space, face_space
+end
+
+"""
+    coordinates(domain::Column{FT}) where {FT}
+        
+Get the center coordinates from the `Column` domain. Face coordinates will be
+added if necessary. Note that this function can only be called one time
+for coordinates derived from ClimaCore.Spaces.
+
+This is a required function for each concrete type of domain.
+    """
+function coordinates(domain::Column{FT}) where {FT}
+    cs, _ = make_function_space(domain)
+    cc = ClimaCore.Fields.coordinate_field(cs)
+    return cc
+end
+
+"""
+    empty_state(coordinates::ClimaCore.Fields.Field)
+
+Returns an empy field with the same underlying space as 
+`coordinates`.
+
+This is a required function for each concrete type of coordinates.
+"""
+function empty_state(coordinates::ClimaCore.Fields.Field)
+    return similar(coordinates.z)
+end
+
+
+"""
+   RootDomain{FT} <: AbstractDomain{FT}
+
+Domain for a single bulk plant with roots of varying depths. The user needs
+to specify the depths of the root tips as wel as the heights of the
+compartments to be modeled within the plant. The compartment heights
+are expected to be sorted in ascending order.
+"""
+struct RootDomain{FT} <: AbstractDomain{FT}
+    root_depths::Vector{FT}
+    compartment_heights::Vector{FT}
+end
+
+function coordinates(domain::RootDomain{FT}) where {FT}
+    return domain.compartment_heights
+end
+
+function empty_state(coordinates::Vector{FT}) where {FT}
+    return similar(coordinates)
+end
+
+
+export AbstractDomain
+export Column, RootDomain
+export coordinates, empty_state
+
+
+end

--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -1,0 +1,42 @@
+module Roots
+using ClimaLSM
+using ClimaCore
+import ClimaCore: Fields
+using ClimaCore.Domains
+import ClimaLSM:
+    AbstractModel,
+    initialize_prognostic,
+    make_update_aux,
+    make_rhs,
+    make_ode_function,
+    prognostic_vars,
+    auxiliary_vars,
+    initialize,
+    initialize_auxiliary
+export RootsModel
+
+"""
+    RootsModel
+
+A standin for a model used to simulate water content in roots.
+"""
+struct RootsModel{FT, ps, d} <: AbstractModel{FT}
+    param_set::ps
+    domain::d
+    model_name::Symbol
+end
+
+function RootsModel{FT}(;
+    param_set = param_set,
+    domain = domain <: AbstractDomain{FT},
+) where {FT}
+    return RootsModel{FT, typeof(param_set), typeof(domain)}(
+        param_set,
+        domain,
+        :roots,
+    )
+end
+
+prognostic_vars(model::RootsModel) = (:rwc,)
+
+end

--- a/src/Soil.jl
+++ b/src/Soil.jl
@@ -1,0 +1,44 @@
+module Soil
+using ClimaLSM
+using ClimaCore
+import ClimaCore: Fields, Operators, Geometry
+using ClimaLSM.Domains
+import ClimaLSM:
+    AbstractModel,
+    initialize,
+    initialize_auxiliary,
+    initialize_prognostic,
+    make_update_aux,
+    make_rhs,
+    make_ode_function,
+    prognostic_vars,
+    auxiliary_vars
+export RichardsModel
+
+"""
+    RichardsModel
+
+A standin for a model used to simulate water flow in soil via Richards equation.
+"""
+struct RichardsModel{FT, ps, d} <: AbstractModel{FT}
+    param_set::ps
+    domain::d
+    model_name::Symbol
+end
+
+function RichardsModel{FT}(;
+    param_set = param_set,
+    domain = domain <: AbstractDomain{FT},
+) where {FT}
+    return RichardsModel{FT, typeof(param_set), typeof(domain)}(
+        param_set,
+        domain,
+        :soil,
+    )
+end
+
+prognostic_vars(model::RichardsModel) = (:ϑ_l,)
+
+auxiliary_vars(model::RichardsModel) = (:z,)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,37 @@
 using Test
 
-@testset "Stand-in test" begin
-    @test 1 == 1
-end
+using ClimaLSM
+using ClimaLSM.Domains: Column, RootDomain
+include(joinpath("../src", "Soil.jl"))
+using .Soil
+include(joinpath("../src", "Roots.jl"))
+using .Roots
+
+FT = Float64
+soil_domain = Column(FT, zlim = (-1.0, 0.0), nelements = 10)
+soil = Soil.RichardsModel{FT}(; param_set = nothing, domain = soil_domain)
+
+root_domain = RootDomain{FT}([-0.5], [0.0, 1.0])
+roots = Roots.RootsModel{FT}(; domain = root_domain, param_set = nothing)
+# In the future, the user would call initialize and get back coordinates and the state
+# structure (empty). They then would initialize Y =Y0 using their IC function(coords)
+# then call simulations(model, Y0). P would not need to be shown to the user, as it
+# can be created and initialized to the correct starting values (consistent with Y0)
+# within Simulations. 
+Ysoil, psoil, csoil = initialize(soil)
+Yroots, proots, croots = initialize(roots)
+
+# vs
+land = LandModel{FT, typeof(soil), typeof(roots)}(soil, roots)
+Yland, pland, cland = initialize(land)
+
+# Same structure
+@test propertynames(pland.soil) == propertynames(psoil.soil)
+@test propertynames(Yland.soil) == propertynames(Ysoil.soil)
+@test propertynames(Yland.roots) == propertynames(Yroots.roots)
+@test propertynames(pland.roots) == propertynames(proots.roots)
+
+# Make sure this runs...
+odef! = make_ode_function(land)
+dY = similar(Yland)
+odef!(dY, Yland, pland, 0.0)


### PR DESCRIPTION
This PR defines the concept of an AbstractModel (consisting of a domain, parameters, prognostic variables, auxiliary variables) and introduces a number of core methods that every concrete type of AbstractModel  must have, including a way to create the state vector structure (assumed to be a ClimaCore FieldVector with a NamedTuple like format) and advance this state vector using the OrdinaryDiffEq package. 

This should allow for an LSM, contructed from many individual AbstractModels and itself a type of AbstractModel, to run using the same interface as each of the components when run in standalone mode.