### PR TITLE
Add root model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,10 @@ version = "0.1.0"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 julia = "1.7"

--- a/src/ComponentExchanges.jl
+++ b/src/ComponentExchanges.jl
@@ -1,0 +1,27 @@
+module ComponentExchanges
+
+export AbstractComponentExchange
+"""
+
+    AbstractComponentExchange{FT <: AbstractFloat}
+
+A general abstract type for any type of exchange between components of the 
+Land Surface Model, either in standalone or integrated modes.
+
+This encompasses true boundary conditions (e.g. Dirichlet or Neumann, 
+at the boundary of the soil domain), source/sink terms (e.g. transpiration 
+of leaves within the canopy airspace), and more general flows (e.g. a prescribed
+soil pressure leading to root extraction of water from soil).
+
+This is to be used both for standalone component runs, in which case exchanges 
+are computed using only the component state and the prescribed quantities driving
+the system, or for Land Surface Models, in which case exchanges are computed using
+the entire land surface state and atmospheric quantities, which drive the system.
+
+The user must define a concrete type for dispatching on
+when computing necessary exchange/flux/flow quantities.
+
+"""
+abstract type AbstractComponentExchange{FT <: AbstractFloat} end
+
+end

--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -1,8 +1,11 @@
 module Roots
 using ClimaLSM
 using ClimaCore
+using UnPack
 import ClimaCore: Fields
-using ClimaCore.Domains
+using ClimaLSM.ComponentExchanges: AbstractComponentExchange
+using ClimaLSM.Domains: AbstractPlantDomain, RootDomain
+
 import ClimaLSM:
     AbstractModel,
     initialize_prognostic,
@@ -13,30 +16,321 @@ import ClimaLSM:
     auxiliary_vars,
     initialize,
     initialize_auxiliary
-export RootsModel
+export RootsModel,
+    compute_flow,
+    theta_to_p,
+    p_to_theta,
+    RootsPrescribedExchange,
+    RootsParameters
+
+"""
+    RootsParameters{FT <: AbstractFloat}
+
+
+A struct for holding parameters of the Root Model. Eventually to be used with ClimaParameters.
+"""
+struct RootsParameters{FT <: AbstractFloat}
+    "controls the shape and steepness of conductance vs. pressure curve, for roots: unitless"
+    a_root::FT
+    "controls the steepness of the relative conductance vs. pressure curve, for roots: inverse MPa"
+    b_root::FT
+    "controls the shape and steepness of relative conductance vs. pressure curve, for stems: unitless"
+    a_stem::FT
+    "controls the steepness of the conductance vs. pressure curve, for stems: inverse MPa"
+    b_stem::FT
+    "the physical size of the stem, in moles"
+    size_reservoir_stem_moles::FT
+    "the physical size of the leaves, in moles"
+    size_reservoir_leaf_moles::FT
+    "water conductance in roots (moles/s/MPa) when pressure is zero, a maximum"
+    K_max_root_moles::FT
+    "water conductance in stems (moles/s/MPa) when pressure is zero, a maximum"
+    K_max_stem_moles::FT
+end
+
 
 """
     RootsModel
 
-A standin for a model used to simulate water content in roots.
+Defines, and constructs instances of, the RootsModel type, which is used
+for simulation flow of water to/from soil, along roots of different depths,
+along a stem, to a leaf, and ultimately being lost from the system by
+transpiration. 
+
+This model can be used in standalone mode by prescribing the transpiration rate
+and soil pressure at the root tips (boundary_exchanges of type `RootsPrescribedExchange`),
+or with a dynamic soil model (boundary exchanges of type TBD).
+
+The RootModel domain must be of type `AbstractPlantDomain`.
 """
-struct RootsModel{FT, ps, d} <: AbstractModel{FT}
-    param_set::ps
-    domain::d
+struct RootsModel{FT, PS, D, B} <: AbstractModel{FT}
+    param_set::PS
+    domain::D
+    boundary_exchanges::B
     model_name::Symbol
 end
 
 function RootsModel{FT}(;
-    param_set = param_set,
-    domain = domain <: AbstractDomain{FT},
+    param_set,
+    domain::AbstractPlantDomain{FT},
+    boundary_exchanges::AbstractComponentExchange{FT},
 ) where {FT}
-    return RootsModel{FT, typeof(param_set), typeof(domain)}(
+    return RootsModel{
+        FT,
+        typeof(param_set),
+        typeof(domain),
+        typeof(boundary_exchanges),
+    }(
         param_set,
         domain,
+        boundary_exchanges,
         :roots,
     )
 end
 
+
+
+
+"""
+    RootsPrescribedExchange{FT} <: AbstractComponentExchange{FT}
+
+The component exchange type to be used for the Root model in standalone mode.
+
+The user provides a function of time returning the transpiration rate (moles/sec),
+ and a function of time returning a 
+vector of soil pressures (MPa). The different elements of
+this vector hold the soil pressure at the root tips, with depths indicated by
+the different elements of the `root_depths` vector of `RootDomain`. 
+"""
+struct RootsPrescribedExchange{FT} <: AbstractComponentExchange{FT}
+    "Time dependent transpiration, given in moles/sec"
+    T::Function
+    "Time dependent soil pressure at root tips, given in MPa"
+    p_soil::Function
+end
+
+
 prognostic_vars(model::RootsModel) = (:rwc,)
+
+"""
+    function compute_flow(
+        z_do::FT,
+        z_up::FT,
+        p_do::FT,
+        p_up::FT,
+        a::FT,
+        b::FT,
+        Kmax::FT,
+    ) where {FT}
+
+Computes the flow of water (moles/sec)  given the height and pressures
+at two points, `do` and `up`. Here, `a`, `b, and `Kmax` are parameters
+which parameterize the hydraulic conductance of the pathway along which
+the flow occurs.
+"""
+function compute_flow(
+    z_do::FT,
+    z_up::FT,
+    p_do::FT,
+    p_up::FT,
+    a::FT,
+    b::FT,
+    Kmax::FT,
+) where {FT}
+    u_do, u_up, A, B, flow_approx =
+        vc_integral_approx(z_do, z_up, p_do, p_up, a, b, Kmax)
+    flow::FT = vc_integral(u_do, u_up, A, B, flow_approx)
+    return flow
+end
+
+"""
+    vc_integral(
+        u_do::FT,
+        u_up::FT,
+        A::FT,
+        B::FT,
+        flow_approx::FT,
+    ) where {FT}
+
+Approximates the vc integral given the height and pressures
+at two points, `do` and `up`. Here, `a`, `b, and `Kmax` are parameters
+which parameterize the hydraulic conductance of the pathway along which
+the flow occurs.
+"""
+function vc_integral_approx(
+    z_do::FT,
+    z_up::FT,
+    p_do::FT,
+    p_up::FT,
+    a::FT,
+    b::FT,
+    Kmax::FT,
+) where {FT}
+    rhog_MPa = FT(0.0098)
+    u_do = a * exp(b * p_do)
+    u_up = a * exp(b * p_up)
+    num_do = log(u_do + FT(10))
+    num_up = log(u_up + FT(10))
+    c = Kmax * (a + FT(10)) / a
+    d = rhog_MPa * (z_up - z_do)
+    flow_approx = -c / b * (num_up - num_do) * (p_up - p_do + d) / (p_up - p_do) # this is NaN if p_up = p_do
+    A = c * d + flow_approx
+    B = -c * flow_approx / (b * A)
+    return u_do, u_up, A, B, flow_approx
+end
+
+"""
+    vc_integral(
+        u_do::FT,
+        u_up::FT,
+        A::FT,
+        B::FT,
+        flow_approx::FT,
+    ) where {FT}
+
+Computes the vc integral given the approximate flow.
+"""
+function vc_integral(
+    u_do::FT,
+    u_up::FT,
+    A::FT,
+    B::FT,
+    flow_approx::FT,
+) where {FT}
+    flow = B * log((u_up * A + flow_approx) / (u_do * A + flow_approx))
+    return flow
+end
+
+"""
+    theta_to_p(theta::FT) where {FT}
+
+Computes the volumetric water content (theta) given pressure (p)
+"""
+function theta_to_p(theta::FT) where {FT}
+    p = (theta - FT(1)) * FT(5)
+    return p
+end
+
+
+"""
+    p_to_theta(p::FT) where {FT}
+
+Computes the pressure (p)  given the volumetric water content (theta).
+"""
+function p_to_theta(p::FT) where {FT}
+    theta = p / FT(5) + FT(1)
+    return theta
+end
+
+
+"""
+    make_rhs(model::RootsModel)
+
+A function which creates the rhs! function for the RootsModel.
+
+The rhs! function must comply with a rhs function of OrdinaryDiffEq.jl.
+"""
+function make_rhs(model::RootsModel)
+    function rhs!(dY, Y, p, t)
+        @unpack a_root,
+        b_root,
+        K_max_root_moles,
+        size_reservoir_stem_moles,
+        a_stem,
+        b_stem,
+        K_max_stem_moles,
+        size_reservoir_leaf_moles = model.param_set
+
+        z_stem, z_leaf = model.domain.compartment_heights
+
+        p_stem = theta_to_p(Y.roots.rwc[1] / size_reservoir_stem_moles)
+        p_leaf = theta_to_p(Y.roots.rwc[2] / size_reservoir_leaf_moles)
+
+        # Flows are in moles/second
+        flow_out_roots =
+            compute_flow_out_roots(model.boundary_exchanges, model, Y, p, t)
+
+        flow_in_stem = sum(flow_out_roots)
+        flow_out_stem = compute_flow(
+            z_stem,
+            z_leaf,
+            p_stem,
+            p_leaf,
+            a_stem,
+            b_stem,
+            K_max_stem_moles,
+        )
+
+        dY.roots.rwc[1] = flow_in_stem - flow_out_stem
+        dY.roots.rwc[2] =
+            flow_out_stem -
+            compute_transpiration(model.boundary_exchanges, Y, p, t)
+    end
+    return rhs!
+end
+
+"""
+    function compute_flow_out_roots(
+        boundary_exchanges::RootsPrescribedExchange{FT},
+        model::RootsModel{FT},
+        Y::ClimaCore.Fields.FieldVector,
+        p::ClimaCore.Fields.FieldVector,
+        t::FT,
+    )::Vector{FT} where {FT}
+
+A method which computes the flow between the soil and the stem, via the roots,
+in the case of a standalone root model with prescribed soil pressure (in MPa)
+at the root tips.
+
+This assumes that the stem compartment is the first element of `Y.roots.rwc`.
+"""
+function compute_flow_out_roots(
+    boundary_exchanges::RootsPrescribedExchange{FT},
+    model::RootsModel{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::ClimaCore.Fields.FieldVector,
+    t::FT,
+)::Vector{FT} where {FT}
+    @unpack a_root, b_root, K_max_root_moles, size_reservoir_stem_moles =
+        model.param_set
+    p_stem = theta_to_p(Y.roots.rwc[1] / size_reservoir_stem_moles)
+
+    flow =
+        compute_flow.(
+            model.domain.root_depths,
+            model.domain.compartment_heights[1],
+            boundary_exchanges.p_soil(t),
+            p_stem,
+            a_root,
+            b_root,
+            K_max_root_moles,
+        )
+    return flow
+end
+
+
+"""
+    compute_transpiration(boundary_exchanges::RootsPrescribedExchange{FT},
+        Y::ClimaCore.Fields.FieldVector,
+        p::ClimaCore.Fields.FieldVector,
+        t::FT)::FT where {FT}
+
+A method which computes the transpiration in moles/sec between the leaf
+and the atmosphere,
+in the case of a standalone root model with prescribed transpiration rate.
+"""
+function compute_transpiration(
+    boundary_exchanges::RootsPrescribedExchange{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::ClimaCore.Fields.FieldVector,
+    t::FT,
+)::FT where {FT}
+    return boundary_exchanges.T(t)
+end
+
+
+
+
+
 
 end

--- a/src/Soil.jl
+++ b/src/Soil.jl
@@ -20,16 +20,13 @@ export RichardsModel
 
 A standin for a model used to simulate water flow in soil via Richards equation.
 """
-struct RichardsModel{FT, ps, d} <: AbstractModel{FT}
-    param_set::ps
-    domain::d
+struct RichardsModel{FT, PS, D} <: AbstractModel{FT}
+    param_set::PS
+    domain::D
     model_name::Symbol
 end
 
-function RichardsModel{FT}(;
-    param_set = param_set,
-    domain = domain <: AbstractDomain{FT},
-) where {FT}
+function RichardsModel{FT}(; param_set, domain::AbstractDomain{FT}) where {FT}
     return RichardsModel{FT, typeof(param_set), typeof(domain)}(
         param_set,
         domain,

--- a/test/initial_structure_test.jl
+++ b/test/initial_structure_test.jl
@@ -1,0 +1,29 @@
+soil_domain = Column(FT, zlim = (-1.0, 0.0), nelements = 10)
+soil = Soil.RichardsModel{FT}(; param_set = nothing, domain = soil_domain)
+
+root_domain = RootDomain{FT}([-0.5], [0.0, 1.0])
+roots = Roots.RootsModel{FT}(;
+    domain = root_domain,
+    param_set = nothing,
+    boundary_exchanges = RootsPrescribedExchange{FT}(
+        () -> nothing,
+        () -> nothing,
+    ),
+)
+# In the future, the user would call initialize and get back coordinates and the state
+# structure (empty). They then would initialize Y =Y0 using their IC function(coords)
+# then call simulations(model, Y0). P would not need to be shown to the user, as it
+# can be created and initialized to the correct starting values (consistent with Y0)
+# within Simulations. 
+Ysoil, psoil, csoil = initialize(soil)
+Yroots, proots, croots = initialize(roots)
+
+# vs
+land = LandModel{FT, typeof(soil), typeof(roots)}(soil, roots)
+Yland, pland, cland = initialize(land)
+
+# Same structure
+@test propertynames(pland.soil) == propertynames(psoil.soil)
+@test propertynames(Yland.soil) == propertynames(Ysoil.soil)
+@test propertynames(Yland.roots) == propertynames(Yroots.roots)
+@test propertynames(pland.roots) == propertynames(proots.roots)

--- a/test/root_test.jl
+++ b/test/root_test.jl
@@ -1,0 +1,167 @@
+const a_root = FT(13192)
+const a_stem = FT(515.5605)
+const b_root = FT(2.1079)
+const b_stem = FT(0.9631)
+const size_reservoir_leaf_moles = FT(16766.2790)
+const size_reservoir_stem_moles = FT(11000.8837)
+const K_max_root_moles = FT(12.9216)
+const K_max_stem_moles = FT(3.4415)
+const z_leaf = FT(12) # height of leaf
+const z_root_depths = [FT(-1.0)] # m, rooting depth
+const z_bottom_stem = FT(0.0)
+
+root_domain = RootDomain{FT}(z_root_depths, [z_bottom_stem, z_leaf])
+param_set = Roots.RootsParameters{FT}(
+    a_root,
+    b_root,
+    a_stem,
+    b_stem,
+    size_reservoir_stem_moles,
+    size_reservoir_leaf_moles,
+    K_max_root_moles,
+    K_max_stem_moles,
+)
+
+function transpiration(t::ft) where {ft}
+    mass_mole_water = ft(0.018)
+    T = ft(0.0)
+    T_0 = ft(0.01 / mass_mole_water)
+    if t < ft(500)
+        T = T_0
+    elseif t < ft(1000)
+        T = ft(10 * (T_0 / 5) * (t - 500) / 500 + T_0)
+    else
+        T = ft(10 * (T_0 / 5) * 500 / 500 + T_0)
+    end
+    return T
+end
+
+const p_soil0 = [FT(-0.02)]
+boundary_exchanges = Roots.RootsPrescribedExchange{FT}(
+    (t::FT) -> transpiration(t),
+    (t::FT) -> p_soil0,
+)
+roots = Roots.RootsModel{FT}(;
+    domain = root_domain,
+    param_set = param_set,
+    boundary_exchanges = boundary_exchanges,
+)
+
+# Set system to equilibrium state by setting LHS of both ODEs to 0
+
+
+function f!(F, Y)
+    T0 = 0.01 / 0.018
+    flow_in_stem = sum(
+        compute_flow.(
+            z_root_depths,
+            z_bottom_stem,
+            p_soil0,
+            Y[1],
+            a_root,
+            b_root,
+            K_max_root_moles,
+        ),
+    )
+    flow_out_stem = compute_flow(
+        z_bottom_stem,
+        z_leaf,
+        Y[1],
+        Y[2],
+        a_stem,
+        b_stem,
+        K_max_stem_moles,
+    )
+    F[1] = flow_in_stem - T0
+    F[2] = flow_out_stem - T0
+end
+
+soln = nlsolve(f!, [-1.0, -0.9])
+p_stem_ini = soln.zero[1]
+p_leaf_ini = soln.zero[2]
+
+theta_stem_0 = p_to_theta(p_stem_ini)
+theta_leaf_0 = p_to_theta(p_leaf_ini)
+y1_0 = FT(theta_stem_0 * size_reservoir_stem_moles)
+y2_0 = FT(theta_leaf_0 * size_reservoir_leaf_moles)
+y0 = [y1_0, y2_0]
+Y, p, coords = initialize(roots)
+Y.roots.rwc .= y0
+
+root_ode! = make_ode_function(roots)
+
+t0 = FT(0);
+tf = FT(60 * 60.0 * 10);
+dt = FT(1);
+
+prob = ODEProblem(root_ode!, Y, (t0, tf), p);
+sol = solve(prob, Euler(), dt = dt);
+
+dY = similar(Y)
+root_ode!(dY, Y, p, 0.0)
+@test sqrt(sum(dY.roots.rwc .^ 2.0)) < 1e-10 # starts in equilibrium
+
+
+y_1 = reduce(hcat, sol.u)[1, :]
+y_2 = reduce(hcat, sol.u)[2, :]
+y_theta_1 = y_1 ./ size_reservoir_stem_moles
+y_theta_2 = y_2 ./ size_reservoir_leaf_moles
+p_stem = theta_to_p.(y_theta_1)
+p_leaf = theta_to_p.(y_theta_2)
+
+function f2!(F, Y)
+    p_soilf = p_soil0
+    Tf = 0.01 / 0.018 .* 3.0
+    flow_in_stem = sum(
+        compute_flow.(
+            z_root_depths,
+            z_bottom_stem,
+            p_soilf,
+            Y[1],
+            a_root,
+            b_root,
+            K_max_root_moles,
+        ),
+    )
+    flow_out_stem = compute_flow(
+        z_bottom_stem,
+        z_leaf,
+        Y[1],
+        Y[2],
+        a_stem,
+        b_stem,
+        K_max_stem_moles,
+    )
+    F[1] = flow_in_stem - Tf
+    F[2] = flow_out_stem - Tf
+end
+
+
+# Check that the final state is in the new equilibrium
+soln = nlsolve(f2!, [-1.0, -0.9])
+p_stem_f = soln.zero[1]
+p_leaf_f = soln.zero[2]
+@test abs(p_stem_f - p_stem[end]) < 1e-10
+@test abs(p_leaf_f - p_leaf[end]) < 1e-10
+
+
+#= Plots for comparison to Anna's script. Can remove when ready to merge.
+using Plots
+times = sol.t .<=60*60.0*2
+plot(sol.t[times], y_1[times], label="stem", xaxis="t [s]", yaxis="water content [mol]", dpi=500)
+plot!(sol.t[times], y_2[times], label="leaf")
+plot!(sol.t[times], y1_0.*ones(sum(times),1),label="W_stem_0",dpi=500)
+plot!(sol.t[times], y2_0.*ones(sum(times),1),label="W_leaf_0",dpi=500)
+savefig("absolute_water_content.png") 
+
+plot(sol.t[times], y_theta_1[times], label="stem", xaxis="t [s]", yaxis="relative water content [m3/m3]",dpi=500)
+plot!(sol.t[times], y_theta_2[times], label="leaf", dpi=500)
+savefig("relative_water_content.png") 
+
+plot(sol.t[times],p_stem[times],linewidth=2,xaxis="time [s]",yaxis="pressure [MPa]",label="stem",dpi=500)
+plot!(sol.t[times],p_leaf[times],linewidth=2,label="leaf",dpi=500)
+plot!(sol.t[times],p_stem_ini.*ones(sum(times),1),label="p_stem_0",dpi=500)
+plot!(sol.t[times],p_leaf_ini.*ones(sum(times),1),label="p_leaf_0",dpi=500)
+savefig("pressure.png") 
+
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,32 +6,12 @@ include(joinpath("../src", "Soil.jl"))
 using .Soil
 include(joinpath("../src", "Roots.jl"))
 using .Roots
+using UnPack
+using NLsolve
+using OrdinaryDiffEq: ODEProblem, solve, Euler
+
 
 FT = Float64
-soil_domain = Column(FT, zlim = (-1.0, 0.0), nelements = 10)
-soil = Soil.RichardsModel{FT}(; param_set = nothing, domain = soil_domain)
 
-root_domain = RootDomain{FT}([-0.5], [0.0, 1.0])
-roots = Roots.RootsModel{FT}(; domain = root_domain, param_set = nothing)
-# In the future, the user would call initialize and get back coordinates and the state
-# structure (empty). They then would initialize Y =Y0 using their IC function(coords)
-# then call simulations(model, Y0). P would not need to be shown to the user, as it
-# can be created and initialized to the correct starting values (consistent with Y0)
-# within Simulations. 
-Ysoil, psoil, csoil = initialize(soil)
-Yroots, proots, croots = initialize(roots)
-
-# vs
-land = LandModel{FT, typeof(soil), typeof(roots)}(soil, roots)
-Yland, pland, cland = initialize(land)
-
-# Same structure
-@test propertynames(pland.soil) == propertynames(psoil.soil)
-@test propertynames(Yland.soil) == propertynames(Ysoil.soil)
-@test propertynames(Yland.roots) == propertynames(Yroots.roots)
-@test propertynames(pland.roots) == propertynames(proots.roots)
-
-# Make sure this runs...
-odef! = make_ode_function(land)
-dY = similar(Yland)
-odef!(dY, Yland, pland, 0.0)
+include("./initial_structure_test.jl")
+include("./root_test.jl")


### PR DESCRIPTION
This PR adds in the standalone root model, based off of the script @gagnelandmanna wrote here: https://github.com/CliMA/LandHydrology.jl/blob/bulk_roots/src/plant_hydraulics.jl .

This model is used to simulate water flow within a bulk plant, with roots of different depths, and stem compartment, and a leaf compartment. A soil pressure at the root tips and a transpiration rate from the leaf are prescribed. 

This model uses the AbstractModel functionality laid out in ClimaLSM.jl.