### PR TITLE
added aux variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,6 @@ version = "0.1.0"
 [deps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
+DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
+NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,23 @@
 using Test
+using Statistics
+using DifferentialEquations
+using UnPack
+using NLsolve
+using OrdinaryDiffEq: ODEProblem, solve, Euler
+using ClimaCore
 
+if !("." in LOAD_PATH) # for ease of include
+    push!(LOAD_PATH, ".")
+end
 using ClimaLSM
 using ClimaLSM.Domains: Column, RootDomain
 using ClimaLSM.Soil
 using ClimaLSM.Roots
-using UnPack
-using NLsolve
-using OrdinaryDiffEq: ODEProblem, solve, Euler
 
 
 FT = Float64
+
+saved_values = SavedValues(FT, ClimaCore.Fields.FieldVector)
 
 include("./initial_structure_test.jl")
 include("./root_test.jl")


### PR DESCRIPTION
Testing adding aux variables to the soil model.

Works well out of the box! using default initialize_auxiliary, just had to define
`aux_variables(model::RichardsModel)` and `make_update_aux(model::RichardsModel)`.

The only hitch is that `solve!` only returns `integrator.sol`, which has only the prognostic state and time. if we use the `integrator` interface, we do have access to `integrator.p` at each step. otherwise we need to use a callback to get aux variables back - that is what this currently does in the test file. 

Note that `p` is updated in place, so what we pass into `prob` originally, after `solve` finishes, is the final `p`.

https://diffeq.sciml.ai/stable/basics/integrator/#Handing-Integrators
https://github.com/SciML/OrdinaryDiffEq.jl/blob/4bf1d8e8a6b99f104e3abc0f51eaae2fae8ce64b/src/solve.jl#L496