### PR TITLE
created different land versions

### DIFF
--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -1,5 +1,4 @@
 module Configurations
-
 export AbstractConfiguration, RootSoilConfiguration
 """
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,0 +1,142 @@
+export AbstractModel,
+    make_rhs,
+    make_ode_function,
+    make_update_aux,
+    initialize_prognostic,
+    initialize_auxiliary,
+    initialize,
+    prognostic_vars,
+    auxiliary_vars
+
+## Default methods for all models - to be in a seperate module at some point.
+
+abstract type AbstractModel{FT <: AbstractFloat} end
+
+
+"""
+   prognostic_vars(m::AbstractModel)
+
+Returns the prognostic variable symbols for the model in the form of a tuple.
+"""
+prognostic_vars(m::AbstractModel) = ()
+
+"""
+   auxiliary_vars(m::AbstractModel)
+
+Returns the auxiliary variable symbols for the model in the form of a tuple.
+"""
+auxiliary_vars(m::AbstractModel) = ()
+
+"""
+    make_rhs(model::AbstractModel)
+
+Return a `rhs!` function that updates state variables.
+
+`rhs!` should be compatible with OrdinaryDiffEq.jl solvers.
+"""
+function make_rhs(model::AbstractModel)
+    function rhs!(dY, Y, p, t) end
+    return rhs!
+end
+
+"""
+    make_update_aux(model::AbstractModel)
+
+Return an `update_aux!` function that updates auxiliary parameters `p`.
+"""
+function make_update_aux(model::AbstractModel)
+    function update_aux!(p, Y, t) end
+    return update_aux!
+end
+
+"""
+    make_ode_function(model::AbstractModel)
+
+Returns an `ode_function` that updates auxiliary variables and
+updates the prognostic state.
+
+`ode_function!` should be compatible with OrdinaryDiffEq.jl solvers.
+"""
+function make_ode_function(model::AbstractModel)
+    rhs! = make_rhs(model)
+    update_aux! = make_update_aux(model)
+    function ode_function!(dY, Y, p, t)
+        update_aux!(p, Y, t)
+        rhs!(dY, Y, p, t)
+    end
+    return ode_function!
+end
+
+"""
+    initialize_prognostic(model::AbstractModel, state::Union{ClimaCore.Fields.Field, Vector{FT}, FT})
+
+Returns a FieldVector of prognostic variables for `model` with the required
+structure, with values equal to `similar(state)`. This assumes that all prognostic
+variables are defined over the entire domain. 
+
+The default is a model with no prognostic variables, in which case 
+the returned FieldVector contains only an empty array.
+
+Adjustments to this - for example because different prognostic variables
+have different dimensions - require defining a new method.
+"""
+function initialize_prognostic(
+    model::AbstractModel{FT},
+    state::Union{ClimaCore.Fields.Field, Vector{FT}, FT},
+) where {FT}
+    keys = prognostic_vars(model)
+    if length(keys) == 0
+        return ClimaCore.Fields.FieldVector(; model.model_name => FT[])
+    else
+        values = map((x) -> similar(state), keys)
+        return ClimaCore.Fields.FieldVector(;
+            model.model_name => (; zip(keys, values)...),
+        )
+    end
+
+end
+
+"""
+    initialize_auxiliary(model::AbstractModel,state::Union{ClimaCore.Fields.Field, Vector{FT}, FT})
+
+Returns a FieldVector of auxiliary variables for `model` with the required
+structure, with values equal to `similar(state)`. This assumes that all auxiliary
+variables are defined over the entire domain. 
+
+The default is a model with no auxiliary variables, in which case 
+the returned FieldVector contains only an empty array.
+
+Adjustments to this - for example because different auxiliary variables
+have different dimensions - require defining a new method.
+"""
+function initialize_auxiliary(
+    model::AbstractModel{FT},
+    state::Union{ClimaCore.Fields.Field, Vector{FT}, FT},
+) where {FT}
+    keys = auxiliary_vars(model)
+    if length(keys) == 0
+        return ClimaCore.Fields.FieldVector(; model.model_name => FT[])
+    else
+        values = map((x) -> similar(state), keys)
+        return ClimaCore.Fields.FieldVector(;
+            model.model_name => (; zip(keys, values)...),
+        )
+    end
+end
+
+"""
+    initialize(model::AbstractModel)
+
+Creates the prognostic and auxiliary states structures, but with unset values
+not set; constructs and returns the coordinates for the `model` domain.
+We may need to consider this default more as we add diverse components and 
+`Simulations`.
+"""
+function initialize(model::AbstractModel)
+    coords = coordinates(model)
+    Y = initialize_prognostic(model, coords)
+    p = initialize_auxiliary(model, coords)
+    return Y, p, coords
+end
+
+Domains.coordinates(model::AbstractModel) = Domains.coordinates(model.domain)

--- a/test/initial_structure_test.jl
+++ b/test/initial_structure_test.jl
@@ -9,10 +9,7 @@ root_domain = RootDomain{FT}([-0.5], [0.0, 1.0])
 roots = Roots.RootsModel{FT}(;
     domain = root_domain,
     param_set = nothing,
-    configuration = RootsConfiguration{FT}(
-        () -> nothing,
-        () -> nothing,
-    ),
+    configuration = RootsConfiguration{FT}(() -> nothing, () -> nothing),
 )
 # In the future, the user would call initialize and get back coordinates and the state
 # structure (empty). They then would initialize Y =Y0 using their IC function(coords)

--- a/test/lsm_test.jl
+++ b/test/lsm_test.jl
@@ -29,7 +29,7 @@ const K_max_stem_moles = FT(3.4415)
 const z_leaf = FT(12) # height of leaf
 # currently hardcoded to match the soil coordinates. this has to
 # be fixed eventually.
-const z_root_depths = - Array(1:1:20.0)./20.0*3.0 .+ 0.15/2.0
+const z_root_depths = -Array(1:1:20.0) ./ 20.0 * 3.0 .+ 0.15 / 2.0
 const z_bottom_stem = FT(0.0)
 roots_domain = RootDomain{FT}(z_root_depths, [z_bottom_stem, z_leaf])
 roots_ps = Roots.RootsParameters{FT}(
@@ -56,9 +56,14 @@ const vg_m = FT(1) - FT(1) / vg_n;
 const θ_r = FT(0);
 soil_ps = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r);
 
-soil_args = (domain= soil_domain, param_set = soil_ps)
+soil_args = (domain = soil_domain, param_set = soil_ps)
 root_args = (domain = roots_domain, param_set = roots_ps)
-land = LandModel{FT}(; soil_args = soil_args, vegetation_args = root_args)
+land = RootSoilModel{FT}(;
+    soil_model_type = Soil.RichardsModel{FT},
+    soil_args = soil_args,
+    vegetation_model_type = Roots.RootsModel{FT},
+    vegetation_args = root_args,
+)
 Y, p, coords = initialize(land)
 # specify ICs
 function init_soil!(Ysoil, z, params)
@@ -81,8 +86,8 @@ init_soil!(Y, coords.soil, land.soil.param_set)
 ## Want ρgΨ_plant = ρg(-3) - ρg z_plant & convert to MPa
 # we should standardize the units! and not ahve to convert every time.
 # convert parameters once up front and then not each RHS
-p_stem_ini = (-3.0 - z_bottom_stem)*9.8*1000.0/1000000.0
-p_leaf_ini = (-3.0 - z_leaf)*9.8*1000.0/1000000.0
+p_stem_ini = (-3.0 - z_bottom_stem) * 9.8 * 1000.0 / 1000000.0
+p_leaf_ini = (-3.0 - z_leaf) * 9.8 * 1000.0 / 1000000.0
 
 theta_stem_0 = p_to_theta(p_stem_ini)
 theta_leaf_0 = p_to_theta(p_leaf_ini)

--- a/test/root_test.jl
+++ b/test/root_test.jl
@@ -138,7 +138,7 @@ end
 
 
 # Check that the final state is in the new equilibrium
-soln = nlsolve(f2!, [-1.0, -0.9];ftol = 1e-10)
+soln = nlsolve(f2!, [-1.0, -0.9]; ftol = 1e-10)
 p_stem_f = soln.zero[1]
 p_leaf_f = soln.zero[2]
 @test abs(p_stem_f - p_stem[end]) < 1e-10

--- a/test/soiltest.jl
+++ b/test/soiltest.jl
@@ -12,7 +12,7 @@ const nelems = 50;
 soil_domain = Column(FT, zlim = (zmin, zmax), nelements = nelems);
 top_flux_bc = FT(0.0);
 bot_flux_bc = FT(0.0);
-boundary_fluxes = FluxBC{FT}(top_flux_bc,bot_flux_bc)
+boundary_fluxes = FluxBC{FT}(top_flux_bc, bot_flux_bc)
 params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r);
 
 soil = Soil.RichardsModel{FT}(;
@@ -46,17 +46,15 @@ soil_ode! = make_ode_function(soil)
 t0 = FT(0);
 tf = FT(60);
 dt = FT(1);
-cb = SavingCallback((u, t, integrator) -> integrator.p, saved_values)
+cb = SavingCallback((u, t, integrator) -> copy(integrator.p), saved_values)
 prob = ODEProblem(soil_ode!, Y, (t0, tf), p);
 sol = solve(prob, Euler(); dt = dt, callback = cb);
 
 @test sum(parent(sol.u[end]) .== parent(Y.soil.ϑ_l)) == nelems
-# Testing that ψ +z is constant - > hydrostatic equilibrium
-@test mean(parent(p.soil.ψ .+ coords)[:] .- (-10.0)) < eps(FT)
-# should be at every layer, at each step too:
+# should be hydrostatic equilibrium at every layer, at each step:
 @test mean(
     sum([
         parent(saved_values.saveval[k].soil.ψ .+ coords)[:] .+ 10.0 for
-        k in 1:1:50
+        k in 2:1:50
     ]),
-) < 1e-14
+) < 1e-10


### PR DESCRIPTION
1. This recognizes that we will have different types of soil, vegetation, etc models, and so it may be helpful to define an `AbstractSoilModel`, `AbstractVegetationModel`, which inherit from `AbstractModel`. (this may be unnecessary, but it adds some organization, especially once we have `RichardsModel`, `SoilEnergyWaterModel` (or whatever), etc)

2. If we think of different Land Surface Models, with different components in them, as different types of `LandModel`, it might also be useful to introduce an `AbstractLandModel` type and make different concrete types. For example, a `LandHydrologyLSM`, `BiopshereLSM`, `LSM`. Then these types would have preset components, and we wouldnt need the `NotIncluded` types. We hadn't done this before because (IIRC) we wanted to have default behavior for `initialize(land::LandModel)`, `make_update_aux(land::LandModel)`, etc. But we can still do that using `land::AbstractLandModel`.

3. Orthogonal to the above changes, this PR makes it so we `map` over the components of the land model, to automate the `make_ode_function`, `make_update_aux`, and `initialize` methods for land. If we keep all components in a single `LandModel` type, and keep the `NotIncluded` type, this should still work fine.

4. For clarity, I also moved all the abstract model functions to a `models.jl` file, in anticipation of this being a separate module or repo at some point.


TBD on how to finesse `Configurations`