### PR TITLE
Config ideas

### DIFF
--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -1,38 +1,28 @@
 module Configurations
-export AbstractConfiguration, RootSoilConfiguration
+
 """
 
-    AbstractComponentExchange{FT <: AbstractFloat}
+    AbstractConfiguration{FT <: AbstractFloat}
 
-A general abstract type for any type of exchange between components of the 
-Land Surface Model, either in standalone or integrated modes.
+An abstract type for land surface and component simulation configurations.
 
-This encompasses true boundary conditions (e.g. Dirichlet or Neumann, 
-at the boundary of the soil domain), source/sink terms (e.g. transpiration 
-of leaves within the canopy airspace), and more general flows (e.g. a prescribed
-soil pressure leading to root extraction of water from soil).
+Configuration types for each component hold the necessary information for
+setting up the right hand side, including boundary conditions, source terms,
+and forcing terms. 
 
-This is to be used both for standalone component runs, in which case exchanges 
-are computed using only the component state and the prescribed quantities driving
-the system, or for Land Surface Models, in which case exchanges are computed using
-the entire land surface state and atmospheric quantities, which drive the system.
+Each component has the freedom to define the attributes
+of the configuration for that component as it makes sense for that 
+component. In general, these attributes will be of a type which can be used
+for multiple dispatch, such that the RHS functions call different methods
+as appropriate.
 
-The user must define a concrete type for dispatching on
-when computing necessary exchange/flux/flow quantities.
+For example, a `apply_boundary_conditions(bc)` function, appearing in
+the right hand side of a discretized PDE, will execute different methods if
+the boundary condition `bc` is of type `Dirichlet` or `Neumann`. A 
+`compute_source(source)` function will execute different methods
+depending on the type of the `source` argument.
 
 """
 abstract type AbstractConfiguration{FT <: AbstractFloat} end
 
-"""
-    RootSoilConfiguration{FT} <: AbstractConfiguration{FT}
-
-Root-soil configuration. 
-"""
-Base.@kwdef struct RootSoilConfiguration{FT} <: AbstractConfiguration{FT}
-    "Time dependent transpiration, given in moles/sec"
-    T::Function = (t) -> FT(0.0)
-    "Time dependent precipitation, given in m/s"
-    P::Function = (t) -> FT(0.0)
-
-end
 end

--- a/src/Soil.jl
+++ b/src/Soil.jl
@@ -4,40 +4,22 @@ using ClimaLSM
 using ClimaCore
 import ClimaCore: Fields, Operators, Geometry
 import ClimaLSM.Domains: coordinates
-using ClimaLSM.Configurations: RootSoilConfiguration, AbstractConfiguration
 import ClimaLSM:
     AbstractModel, make_update_aux, make_rhs, prognostic_vars, auxiliary_vars
 using UnPack
-export AbstractSoilModel, RichardsModel, RichardsParameters, FluxBC
+export RichardsModel,
+    RichardsParameters,
+    FluxBC,
+    RootExtraction,
+    AbstractSoilModel,
+    AbstractSoilSource,
+    source
 
+abstract type AbstractSoilBoundaryConditions{FT <: AbstractFloat} end
+
+abstract type AbstractSoilSource{FT <: AbstractFloat} end
 
 abstract type AbstractSoilModel{FT} <: AbstractModel{FT} end
-"""
-    RichardsModel
-
-A model for simulating the flow of water in a soil column.
-"""
-struct RichardsModel{FT, PS, D, C, B} <: AbstractSoilModel{FT}
-    param_set::PS
-    domain::D
-    coordinates::C
-    configuration::B
-    model_name::Symbol
-end
-
-function RichardsModel{FT}(; param_set, domain, configuration) where {FT}
-    coords = coordinates(domain)
-    args = (param_set, domain, coords, configuration)
-    RichardsModel{FT, typeof.(args)...}(
-        param_set,
-        domain,
-        coords,
-        configuration,
-        :soil,
-    )
-end
-
-coordinates(model::RichardsModel) = model.coordinates
 
 """
     RichardsParameters{FT <: AbstractFloat}
@@ -53,6 +35,33 @@ struct RichardsParameters{FT <: AbstractFloat}
     S_s::FT
     θ_r::FT
 end
+
+"""
+    RichardsModel
+
+A model for simulating the flow of water in a soil column.
+"""
+struct RichardsModel{FT, PS, D, C, BC, S} <: AbstractSoilModel{FT}
+    param_set::PS
+    domain::D
+    coordinates::C
+    boundary_conditions::BC
+    sources::S
+    model_name::Symbol
+end
+
+function RichardsModel{FT}(;
+    param_set::RichardsParameters{FT},
+    domain::D,
+    boundary_conditions::AbstractSoilBoundaryConditions{FT},
+    sources::Tuple,
+) where {FT, D}
+    coords = coordinates(domain)
+    args = (param_set, domain, coords, boundary_conditions, sources)
+    RichardsModel{FT, typeof.(args)...}(args..., :soil)
+end
+
+coordinates(model::RichardsModel) = model.coordinates
 
 function volumetric_liquid_fraction(ϑ_l::FT, ν_eff::FT) where {FT}
     if ϑ_l < ν_eff
@@ -101,37 +110,10 @@ function hydraulic_conductivity(Ksat::FT, m::FT, S::FT) where {FT}
     return K * Ksat
 end
 
-abstract type AbstractSoilConfiguration{FT} <: AbstractConfiguration{FT} end
-# Eventually would support other types of BC
-struct FluxBC{FT} <: AbstractSoilConfiguration{FT}
-    top_flux_bc::FT
-    bot_flux_bc::FT
-end
-
-function compute_boundary_fluxes(be::FluxBC, _...)
-    return be.top_flux_bc, be.bot_flux_bc
-end
-
-function compute_boundary_fluxes(be::RootSoilConfiguration{FT}, t) where {FT}
-    return be.P(t), FT(0.0)
-end
-
-function compute_source(be::FluxBC{FT}, _...) where {FT}
-    return FT(0.0)
-end
-
-function compute_source(be::RootSoilConfiguration{FT}, Y, p) where {FT}
-    V_layer = FT(1.0 * 0.15) # hardcoded
-    ρm = FT(1e6 / 18) # moles/m^3
-    return p.root_extraction ./ ρm ./ V_layer # Field
-end
-
-
 function make_rhs(model::RichardsModel)
     function rhs!(dY, Y, p, t)
         @unpack ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r = model.param_set
-        top_flux_bc, bot_flux_bc =
-            compute_boundary_fluxes(model.configuration, t)
+        top_flux_bc, bot_flux_bc = boundary_fluxes(model.boundary_conditions, t)
         z = model.coordinates
         interpc2f = Operators.InterpolateC2F()
         gradc2f_water = Operators.GradientC2F()
@@ -141,7 +123,10 @@ function make_rhs(model::RichardsModel)
         )
         @. dY.soil.ϑ_l =
             -(divf2c_water(-interpc2f(p.soil.K) * gradc2f_water(p.soil.ψ + z)))
-        dY.soil.ϑ_l .= compute_source(model.configuration, Y, p)
+        for src in model.sources
+            dY.soil.ϑ_l .+= source(src, Y, p)
+        end
+
     end
     return rhs!
 end
@@ -158,8 +143,23 @@ function make_update_aux(model::RichardsModel)
             effective_saturation(ν, Y.soil.ϑ_l, θ_r),
         )
         @. p.soil.ψ = pressure_head(vg_α, vg_n, vg_m, θ_r, Y.soil.ϑ_l, ν, S_s)
-        return update_aux!
     end
+    return update_aux!
 end
+
+# eventually, FreezeThaw{FT} will be a soil source type.
+
+# Eventually would support other types of BC
+struct FluxBC{FT} <: AbstractSoilBoundaryConditions{FT}
+    top_flux_bc::FT
+    bot_flux_bc::FT
+end
+
+function boundary_fluxes(bc::FluxBC, _...)
+    return bc.top_flux_bc, bc.bot_flux_bc
+end
+
+
+function source(src::AbstractSoilSource, _...) end
 
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -8,6 +8,7 @@ export AbstractModel,
     prognostic_vars,
     auxiliary_vars
 
+import .Domains: coordinates
 ## Default methods for all models - to be in a seperate module at some point.
 
 abstract type AbstractModel{FT <: AbstractFloat} end

--- a/test/root_test.jl
+++ b/test/root_test.jl
@@ -22,7 +22,7 @@ param_set = Roots.RootsParameters{FT}(
     K_max_stem_moles,
 )
 
-function transpiration(t::ft) where {ft}
+function leaf_transpiration(t::ft) where {ft}
     mass_mole_water = ft(0.018)
     T = ft(0.0)
     T_0 = ft(0.01 / mass_mole_water)
@@ -37,14 +37,13 @@ function transpiration(t::ft) where {ft}
 end
 
 const p_soil0 = [FT(-0.02)]
-configuration = Roots.RootsConfiguration{FT}(
-    (t::FT) -> transpiration(t),
-    (t::FT) -> p_soil0,
-)
+transpiration = PrescribedTranspiration{FT}((t::FT) -> leaf_transpiration(t))
+root_extraction = PrescribedSoilPressure{FT}((t::FT) -> p_soil0)
 roots = Roots.RootsModel{FT}(;
     domain = root_domain,
     param_set = param_set,
-    configuration = configuration,
+    root_extraction = root_extraction,
+    transpiration = transpiration,
 )
 
 # Set system to equilibrium state by setting LHS of both ODEs to 0
@@ -53,7 +52,7 @@ roots = Roots.RootsModel{FT}(;
 function f!(F, Y)
     T0 = 0.01 / 0.018
     flow_in_stem = sum(
-        compute_flow.(
+        flow.(
             z_root_depths,
             z_bottom_stem,
             p_soil0,
@@ -63,7 +62,7 @@ function f!(F, Y)
             K_max_root_moles,
         ),
     )
-    flow_out_stem = compute_flow(
+    flow_out_stem = flow(
         z_bottom_stem,
         z_leaf,
         Y[1],
@@ -113,7 +112,7 @@ function f2!(F, Y)
     p_soilf = p_soil0
     Tf = 0.01 / 0.018 .* 3.0
     flow_in_stem = sum(
-        compute_flow.(
+        flow.(
             z_root_depths,
             z_bottom_stem,
             p_soilf,
@@ -123,7 +122,7 @@ function f2!(F, Y)
             K_max_root_moles,
         ),
     )
-    flow_out_stem = compute_flow(
+    flow_out_stem = flow(
         z_bottom_stem,
         z_leaf,
         Y[1],

--- a/test/soiltest.jl
+++ b/test/soiltest.jl
@@ -12,13 +12,15 @@ const nelems = 50;
 soil_domain = Column(FT, zlim = (zmin, zmax), nelements = nelems);
 top_flux_bc = FT(0.0);
 bot_flux_bc = FT(0.0);
+sources = ()
 boundary_fluxes = FluxBC{FT}(top_flux_bc, bot_flux_bc)
 params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r);
 
 soil = Soil.RichardsModel{FT}(;
     param_set = params,
     domain = soil_domain,
-    configuration = boundary_fluxes,
+    boundary_conditions = boundary_fluxes,
+    sources = sources,
 )
 
 Y, p, coords = initialize(soil)


### PR DESCRIPTION
This removes the Configuration concept. Instead of using a single keyword type `Configuration` and dispatching on the type of this for boundary conditions, source terms, boundary flows for the roots, etc, we are making things more explicit, and creating `boundary_conditions`, `source`, `transpiration` attributes that live inside `Soil` and `Roots` model, as makes sense for that model.  Then, for example, on the soil RHS, we could call `compute_source(source)`, rather than `compute_source(config)`. 

Our main motivation for this change is that it was unclear what "Configurations" was buying us, and it had the potential to be confusing, as it lumped a lot of related concepts together. 

Our goal is that the LSM constructor can than make the necessary source, boundary conditions, transpiration, and root extraction structs when it makes the soil model and root model. This could be using info the user passes in as needed.

In a way, this emphasizing a design based on standalone models - the LSM just constructs a version of the standalone model that is appropriate for running in LSM mode, and then runs many of these (snow, rivers, soil, etc) all together (and defines the appropriate methods, etc, to capture interaction exchanges). The alternative - based on Configurations - emphasizes the LSM mode (and a few "configurations" that are relevant for that). We can go back to that, as needed.