### PR TITLE
Add in LSM Domain constructors

### DIFF
--- a/test/domains.jl
+++ b/test/domains.jl
@@ -55,3 +55,24 @@ end
     @test point.z_sfc == zlim[1]
     @test coordinates(point) == [zlim[1]]
 end
+
+
+@testset "SingleColumnLSM Domain" begin
+    domain = SingleColumnLSM(FT, zlim = zlim, nelements = nelements[3])
+
+    point = domain.surface
+    column = domain.subsurface
+
+    @test typeof(column) == Column{FT}
+    @test typeof(point) == Point{FT}
+    @test point.z_sfc == zlim[2]
+    @test coordinates(point) == [zlim[2]]
+    @test coordinates(point) == coordinates(domain).surface
+
+    column_coords = coordinates(column)
+    @test column.zlim == FT.(zlim)
+    @test column.nelements == nelements[3]
+    @test eltype(column_coords) == ClimaCore.Geometry.ZPoint{FT}
+    @test typeof(column_coords) <: ClimaCore.Fields.Field
+    @test parent(coordinates(domain).subsurface) == parent(column_coords)
+end

--- a/test/pond_soil_lsm.jl
+++ b/test/pond_soil_lsm.jl
@@ -17,16 +17,18 @@ zmax = FT(0);
 zmin = FT(-1);
 nelems = 20;
 
-soil_domain = Column(FT, zlim = (zmin, zmax), nelements = nelems);
-soil_ps = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r);
-soil_args = (domain = soil_domain, param_set = soil_ps)
+lsm_domain = SingleColumnLSM(FT, zlim = (zmin, zmax), nelements = nelems)
 land_args = (precip = precipitation,)
 
+soil_ps = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r);
+soil_args = (param_set = soil_ps, domain = lsm_domain.subsurface)
+surface_water_args = (domain = lsm_domain.surface,)
 land = LandHydrology{FT}(;
     land_args = land_args,
     soil_model_type = Soil.RichardsModel{FT},
     soil_args = soil_args,
     surface_water_model_type = Pond.PondModel{FT},
+    surface_water_args = surface_water_args,
 )
 Y, p, coords = initialize(land)
 function init_soil!(Ysoil, coords, params)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,8 @@ if !("." in LOAD_PATH) # for ease of include
     push!(LOAD_PATH, ".")
 end
 using ClimaLSM
-using ClimaLSM.Domains: Column, RootDomain, HybridBox, Plane, Point
+using ClimaLSM.Domains:
+    Column, RootDomain, HybridBox, Plane, Point, SingleColumnLSM
 using ClimaLSM.Soil
 using ClimaLSM.Roots
 using ClimaLSM.Pond


### PR DESCRIPTION
We are planning LSM domains of the following type:
 - SingleColumnLSM <: AbstractDomain = Column (with FD space, for soil) + surface Point
 - MultiColumnLSM <: AbstractDomain = HybridBox (soil) + HybridBox with one element (surface 2d space)

We construct them at the same time because we think the 2d spaces need to be the same instance in the MultiColumn case. It is also neat for the user to be able to specify everything they need for an LSM run in a single constructor.

The LSM Models can either take in the `LSM` Domains as arguments, and create the sub-component domains, in order to create the subcomponent models, or the user can make the domain and pass in lsm_domain.surface as the domain for the surface models or lsm_domain.subsurface for the soil model.

