### PR TITLE
LSM Multi-column domain and pond/soil test

### DIFF
--- a/src/SharedUtilities/Domains.jl
+++ b/src/SharedUtilities/Domains.jl
@@ -298,8 +298,41 @@ function coordinates(
     return cc
 end
 
+
+struct LSMMultiColumnDomain{FT, SS, SF} <: AbstractDomain{FT}
+    subsurface::SS
+    surface::SF
+end
+
+function LSMMultiColumnDomain(;
+    xlim::Tuple{FT,FT},
+    ylim::Tuple{FT,FT},
+    zlim::Tuple{FT,FT},
+    nelements::Tuple{Int,Int,Int},
+    npolynomial::Int,
+    periodic = (true, true),
+) where {FT}
+    @assert xlim[1] < xlim[2]
+    @assert ylim[1] < ylim[2]
+    @assert zlim[1] < zlim[2]
+    @assert periodic == (true, true)
+    subsurface_domain =  HybridBox{FT}(xlim, ylim, zlim, nelements, npolynomial, periodic)
+    surface_domain = Plane{FT}(xlim, ylim, nelements[1:2], periodic, npolynomial)
+    return LSMMultiColumnDomain{FT, typeof.([subsurface_domain, surface_domain])...}(subsurface_domain, surface_domain)
+end
+
+function coordinates(domain::LSMMultiColumnDomain{FT}) where {FT}
+    return (
+        # Opting for making two distinct instances of the horizontal space
+        # can return to later as needed
+        subsurface = coordinates(domain.subsurface),
+        surface = coordinates(domain.surface),
+    )
+end
+
 export AbstractDomain, AbstractVegetationDomain
 export Column, Plane, HybridBox, RootDomain, Point
+export LSMMultiColumnDomain
 export coordinates
 
 end

--- a/src/SurfaceWater/Pond.jl
+++ b/src/SurfaceWater/Pond.jl
@@ -6,8 +6,7 @@ using DocStringExtensions
 import ClimaCore: Fields
 
 import ClimaLSM: AbstractModel, make_rhs, prognostic_vars, name
-using ClimaLSM.Domains
-import ClimaLSM.Domains: coordinates
+using ClimaLSM.Domains: AbstractDomain
 export PondModel, PrescribedRunoff, surface_runoff
 
 abstract type AbstractSurfaceWaterModel{FT} <: AbstractModel{FT} end
@@ -24,12 +23,13 @@ In integrated LSM mode, the infiltration into the soil will be computed
 via a different method, and also be applied as a flux boundary condition
 for the soil model. 
 """
-struct PondModel{FT, R} <: AbstractSurfaceWaterModel{FT}
+struct PondModel{FT, D, R} <: AbstractSurfaceWaterModel{FT}
+    domain::D
     runoff::R
 end
 
-function PondModel{FT}(; runoff::AbstractSurfaceRunoff{FT}) where {FT}
-    return PondModel{FT, typeof(runoff)}(runoff)
+function PondModel{FT}(; domain::AbstractDomain{FT}, runoff::AbstractSurfaceRunoff{FT}) where {FT}
+    return PondModel{FT, typeof(domain), typeof(runoff)}(domain, runoff)
 end
 
 
@@ -49,7 +49,6 @@ end
 
 ClimaLSM.prognostic_vars(model::PondModel) = (:η,)
 ClimaLSM.name(::AbstractSurfaceWaterModel) = :surface_water
-ClimaLSM.Domains.coordinates(model::PondModel{FT}) where {FT} = FT.([0.0])
 
 function ClimaLSM.make_rhs(model::PondModel)
     function rhs!(dY, Y, p, t)

--- a/test/LSM/pond_soil_multi_column.jl
+++ b/test/LSM/pond_soil_multi_column.jl
@@ -1,0 +1,93 @@
+using Test
+using UnPack
+using DifferentialEquations
+using OrdinaryDiffEq: ODEProblem, solve, Euler
+using ClimaCore
+
+if !("." in LOAD_PATH)
+    push!(LOAD_PATH, ".")
+end
+using ClimaLSM
+using ClimaLSM.Domains: LSMMultiColumnDomain
+using ClimaLSM.Soil
+using ClimaLSM.Pond
+
+FT = Float64
+#@testset "Pond soil LSM integretation test" begin
+
+    function precipitation(t::ft) where {ft}
+        if t < ft(20)
+            precip = -ft(1e-8)
+        else
+            precip = t < ft(100) ? -ft(5e-5) : ft(0.0)
+        end
+        return precip
+    end
+    ν = FT(0.495)
+    Ksat = FT(0.0443 / 3600 / 100) # m/s
+    S_s = FT(1e-3) #inverse meters
+    vg_n = FT(2.0)
+    vg_α = FT(2.6) # inverse meters
+    vg_m = FT(1) - FT(1) / vg_n
+    θ_r = FT(0)
+    xmax = FT(10)
+    xmin = FT(0)
+    ymax = FT(10)
+    ymin = FT(0)
+    zmax = FT(0)
+    zmin = FT(-1)
+    nelems = (2,2,20)
+    npoly = 1
+    lsm_domain = LSMMultiColumnDomain(;xlim = (xmin, xmax), ylim = (ymin, ymax), zlim = (zmin, zmax), nelements = nelems, npolynomial = npoly)
+
+    soil_domain = lsm_domain.subsurface
+    soil_ps = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r)
+    soil_args = (domain = soil_domain, param_set = soil_ps)
+    surface_water_args = (domain = lsm_domain.surface,)
+
+    land_args = (precip = precipitation,)
+
+    land = LandHydrology{FT}(;
+        land_args = land_args,
+        soil_model_type = Soil.RichardsModel{FT},
+        soil_args = soil_args,
+        surface_water_model_type = Pond.PondModel{FT},
+        surface_water_args = surface_water_args,
+    )
+    Y, p, coords = initialize(land)
+    function init_soil!(Ysoil, coords, params)
+        function hydrostatic_profile(
+            z::FT,
+            params::RichardsParameters{FT},
+        ) where {FT}
+            @unpack ν, vg_α, vg_n, vg_m, θ_r = params
+            #unsaturated zone only, assumes water table starts at z_∇
+            z_∇ = FT(-3)# matches zmin
+            S = FT((FT(1) + (vg_α * (z - z_∇))^vg_n)^(-vg_m))
+            ϑ_l = S * (ν - θ_r) + θ_r
+            return FT(ϑ_l)
+        end
+        Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z, Ref(params))
+    end
+    init_soil!(Y, coords.soil, land.soil.param_set)
+    # initialize the pond height to zero
+    Y.surface_water.η .= 0.0
+
+    saved_values = SavedValues(FT, ClimaCore.Fields.FieldVector)
+    ode! = make_ode_function(land)
+    t0 = FT(0)
+    tf = FT(200)
+    dt = FT(1)
+    cb = SavingCallback((u, t, integrator) -> integrator.p, saved_values)
+    prob = ODEProblem(ode!, Y, (t0, tf), p)
+    sol = solve(prob, Euler(), dt = dt, callback = cb)
+    # it running is the test
+
+    # Infiltration at point test
+
+    η = [0.0, 0.0, 0.0, 0.0, 1.0, 1.0]
+    i_c = [2.0, 2.0, -2.0, -2.0, 2.0, 2.0]
+    P = [3.0, -1.0, 3.0, -3.0, 1.0, 3.0]
+    iap = [2.0, -1.0, -2.0, -3.0, 2.0, 2.0]
+    @test infiltration_at_point.(η, i_c, P) ≈ iap
+#end

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -4,7 +4,7 @@ if !("." in LOAD_PATH)
     push!(LOAD_PATH, ".")
 end
 using ClimaLSM
-using ClimaLSM.Domains: Column, RootDomain, HybridBox, Plane, Point
+using ClimaLSM.Domains: Column, RootDomain, HybridBox, Plane, Point, LSMMultiColumnDomain
 using ClimaLSM.Domains: coordinates
 
 FT = Float64
@@ -60,4 +60,16 @@ end
     point = Point(zlim[1])
     @test point.z_sfc == zlim[1]
     @test coordinates(point) == [zlim[1]]
+end
+
+@testset "LSMMultiColumnDomain" begin
+    domain = LSMMultiColumnDomain(;xlim = xlim, ylim = ylim, zlim = zlim,   
+    nelements = nelements, npolynomial = 2)
+    plane = domain.surface
+    box = domain.subsurface
+
+    @test typeof(box) == HybridBox{FT}
+    @test typeof(plane) == Plane{FT}
+    @test parent(coordinates(plane)) == parent(coordinates(domain).surface)
+    @test parent(coordinates(box)) == parent(coordinates(domain).subsurface)
 end


### PR DESCRIPTION
Goals for this PR:
- define an LSM MultiColumnDomain - Hybrid box + plane or hybrid box + hybrid box with one element
- redefine interaction methods for soil/pond to broadcast correctly between the field of surface variables and the field of the top soil layer, for both single column and multi column domains.
- check that the output for a simulation with no variation in the horizontal leads to the same output in each column, and matches what we expect based on a single column run, or that the RHS eval gives the same result (unit test)
- add unit tests for the new domain type.
- we could even design the RHS for the LSM as looping over columns and computing horizontal terms afterwards; saving this for a later PR is fine!