### PR TITLE
add clima params to models that need them

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Clima Land Team"]
 version = "0.1.0"
 
 [deps]
+CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"

--- a/docs/src/APIs/Soil.md
+++ b/docs/src/APIs/Soil.md
@@ -8,7 +8,7 @@ CurrentModule = ClimaLSM.Soil
 ```@docs
 ClimaLSM.Soil.AbstractSoilModel
 ClimaLSM.Soil.RichardsModel
-ClimaLSM.Soil.SoilEnergyHydrology
+ClimaLSM.Soil.EnergyHydrology
 ```
 
 ## Soil Diagnostic Variables
@@ -24,7 +24,7 @@ ClimaLSM.Soil.temperature_from_ρe_int
 
 ```@docs
 ClimaLSM.Soil.RichardsParameters
-ClimaLSM.Soil.HeatParameters
+ClimaLSM.Soil.EnergyHydrologyParameters
 ```
 
 ## Soil Methods and Types

--- a/docs/tutorials/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/LSM_single_column_tutorial.jl
@@ -98,7 +98,7 @@ boundary_fluxes = FluxBC{FT}(top_flux_bc, bot_flux_bc);
 
 # With this information, we can make our model:
 soil = Soil.RichardsModel{FT}(;
-    param_set = soil_ps,
+    parameters = soil_ps,
     domain = soil_domain,
     boundary_conditions = boundary_fluxes,
     sources = sources,
@@ -254,7 +254,7 @@ lsm_domain.subsurface
 # Let's now collect the needed arguments for the soil and pond
 # models:
 
-soil_args = (param_set = soil_ps, domain = lsm_domain.subsurface, sources = ());
+soil_args = (parameters = soil_ps, domain = lsm_domain.subsurface, sources = ());
 surface_water_args = (domain = lsm_domain.surface,);
 # Atmospheric drivers don't "belong" to either component alone:
 land_args = (precip = precipitation,);

--- a/src/Soil/Soil.jl
+++ b/src/Soil/Soil.jl
@@ -61,6 +61,7 @@ using UnPack
 using DocStringExtensions
 using ClimaCore
 import ClimaCore: Fields, Operators, Geometry, Spaces
+using CLIMAParameters: AbstractEarthParameterSet
 
 import ClimaLSM.Domains: coordinates, Column, HybridBox
 import ClimaLSM:
@@ -74,6 +75,8 @@ import ClimaLSM:
     auxiliary_types
 export RichardsModel,
     RichardsParameters,
+    EnergyHydrologyModel,
+    EnergyHydrologyParameters,
     boundary_fluxes,
     FluxBC,
     RootExtraction,

--- a/src/Soil/rre.jl
+++ b/src/Soil/rre.jl
@@ -31,7 +31,7 @@ $(DocStringExtensions.FIELDS)
 """
 struct RichardsModel{FT, PS, D, C, BC, S} <: AbstractSoilModel{FT}
     "the parameter set"
-    param_set::PS
+    parameters::PS
     "the soil domain, using ClimaCore.Domains"
     domain::D
     "the domain coordinates"
@@ -44,7 +44,7 @@ end
 
 """
     RichardsModel{FT}(;
-        param_set::RichardsParameters{FT},
+        parameters::RichardsParameters{FT},
         domain::D,
         boundary_conditions::AbstractSoilBoundaryConditions{FT},
         sources::Tuple,
@@ -53,13 +53,13 @@ end
 A constructor for a `RichardsModel`.
 """
 function RichardsModel{FT}(;
-    param_set::RichardsParameters{FT},
+    parameters::RichardsParameters{FT},
     domain::D,
     boundary_conditions::AbstractSoilBoundaryConditions{FT},
     sources::Tuple,
 ) where {FT, D}
     coords = coordinates(domain)
-    args = (param_set, domain, coords, boundary_conditions, sources)
+    args = (parameters, domain, coords, boundary_conditions, sources)
     RichardsModel{FT, typeof.(args)...}(args...)
 end
 
@@ -78,7 +78,7 @@ This has been written so as to work with Differential Equations.jl.
 """
 function ClimaLSM.make_rhs(model::RichardsModel)
     function rhs!(dY, Y, p, t)
-        @unpack ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r = model.param_set
+        @unpack ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r = model.parameters
         top_flux_bc, bot_flux_bc =
             boundary_fluxes(model.boundary_conditions, p, t)
         z = model.coordinates.z
@@ -161,7 +161,7 @@ This has been written so as to work with Differential Equations.jl.
 """
 function ClimaLSM.make_update_aux(model::RichardsModel)
     function update_aux!(p, Y, t)
-        @unpack ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r = model.param_set
+        @unpack ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r = model.parameters
         @. p.soil.K = hydraulic_conductivity(
             Ksat,
             vg_m,

--- a/test/LSM/pond_soil_lsm.jl
+++ b/test/LSM/pond_soil_lsm.jl
@@ -38,7 +38,7 @@ FT = Float64
 
     soil_domain = lsm_domain.subsurface
     soil_ps = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, Ksat, S_s, θ_r)
-    soil_args = (domain = soil_domain, param_set = soil_ps)
+    soil_args = (domain = soil_domain, parameters = soil_ps)
     surface_water_args = (domain = lsm_domain.surface,)
 
     land_args = (precip = precipitation,)
@@ -65,7 +65,7 @@ FT = Float64
         end
         Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z, Ref(params))
     end
-    init_soil!(Y, coords.soil, land.soil.param_set)
+    init_soil!(Y, coords.soil, land.soil.parameters)
     # initialize the pond height to zero
     Y.surface_water.η .= 0.0
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"

--- a/test/Vegetation/root_test.jl
+++ b/test/Vegetation/root_test.jl
@@ -3,6 +3,7 @@ using Statistics
 using NLsolve
 using OrdinaryDiffEq: ODEProblem, solve, Euler
 using ClimaCore
+using CLIMAParameters: AbstractEarthParameterSet
 
 if !("." in LOAD_PATH)
     push!(LOAD_PATH, ".")
@@ -25,9 +26,10 @@ FT = Float64
     z_leaf = FT(12) # height of leaf
     z_root_depths = [FT(-1.0)] # m, rooting depth
     z_bottom_stem = FT(0.0)
-
+    struct EarthParameterSet <: AbstractEarthParameterSet end
+    earth_param_set = EarthParameterSet()
     root_domain = RootDomain{FT}(z_root_depths, [z_bottom_stem, z_leaf])
-    param_set = Roots.RootsParameters{FT}(
+    param_set = Roots.RootsParameters{FT, typeof(earth_param_set)}(
         a_root,
         b_root,
         a_stem,
@@ -36,6 +38,7 @@ FT = Float64
         size_reservoir_leaf_moles,
         K_max_root_moles,
         K_max_stem_moles,
+        earth_param_set,
     )
 
     function leaf_transpiration(t::ft) where {ft}
@@ -58,7 +61,7 @@ FT = Float64
     root_extraction = PrescribedSoilPressure{FT}((t::FT) -> p_soil0)
     roots = Roots.RootsModel{FT}(;
         domain = root_domain,
-        param_set = param_set,
+        parameters = param_set,
         root_extraction = root_extraction,
         transpiration = transpiration,
     )


### PR DESCRIPTION
Add in the clima parameter set (physical constants and shared clima-wide parameters).

Currently, I am only adding it to the models that need them (Roots, SoilEnergyHydrology), and not to RichardsModel or Pond. though the Root/Richards model does need them, we can access them via Roots.earth_param_set.