### PR TITLE
Update Point Domain to ClimaCore and add interactions support

### DIFF
--- a/docs/src/APIs/ClimaLSM.md
+++ b/docs/src/APIs/ClimaLSM.md
@@ -11,6 +11,9 @@ ClimaLSM.LandHydrology
 ClimaLSM.make_interactions_update_aux
 ClimaLSM.initialize_interactions
 ClimaLSM.land_components
+ClimaLSM.interaction_vars
+ClimaLSM.interaction_types
+ClimaLSM.interaction_domains
 ```
 
 ## Land Hydrology

--- a/src/SharedUtilities/Domains.jl
+++ b/src/SharedUtilities/Domains.jl
@@ -16,14 +16,17 @@ An abstract type for domains.
 """
 abstract type AbstractDomain{FT <: AbstractFloat} end
 Base.eltype(::AbstractDomain{FT}) where {FT} = FT
+
 """
     coordinates(domain::AbstractDomain)
 
-Method which returns the coordinates appropriate for a given domain.
-
-The coordinates can be Fields or Vectors.
+Returns the coordinate field for the domain.
 """
-function coordinates(domain::AbstractDomain) end
+function coordinates(domain::AbstractDomain)
+    cs, _ = make_function_space(domain)
+    cc = ClimaCore.Fields.coordinate_field(cs)
+    return cc
+end
 
 """
     Point{FT} <: AbstractDomain{FT}
@@ -49,8 +52,11 @@ function Point(; z_sfc::FT) where {FT}
     return Point{FT}(z_sfc)
 end
 
-
-coordinates(domain::Point) = [domain.z_sfc]
+function make_function_space(domain::Point{FT}) where {FT}
+    coord = ClimaCore.Geometry.ZPoint(domain.z_sfc)
+    space = ClimaCore.Spaces.PointSpace(coord)
+    return space, nothing
+end
 
 """
     Column{FT} <: AbstractDomain{FT}
@@ -382,18 +388,6 @@ function make_function_space(domain::SphericalShell{FT}) where {FT}
 
     return hv_center_space, hv_face_space
 end
-
-"""
-   coordinates(domain::Union{Column{FT}, Plane{FT}, HybridBox{FT}, SphericalShell{FT}}) where {FT}
-
-Returns the coordinate field for the domain.
-"""
-function coordinates(domain::AbstractDomain)
-    cs, _ = make_function_space(domain)
-    cc = ClimaCore.Fields.coordinate_field(cs)
-    return cc
-end
-
 
 ### Example of component specific domain
 """

--- a/src/Soil/rre.jl
+++ b/src/Soil/rre.jl
@@ -110,8 +110,8 @@ function ClimaLSM.make_rhs(model::RichardsModel)
         # the bc is WVector(F) or Covariant3Vector(F*Δr) or Contravariant3Vector(F/Δr)
 
         divf2c_water = Operators.DivergenceF2C(
-            top = Operators.SetValue(Geometry.WVector(top_flux_bc)),
-            bottom = Operators.SetValue(Geometry.WVector(bot_flux_bc)),
+            top = Operators.SetValue(Geometry.WVector.(top_flux_bc)),
+            bottom = Operators.SetValue(Geometry.WVector.(bot_flux_bc)),
         )
 
         # GradC2F returns a Covariant3Vector, so no need to convert.

--- a/src/SurfaceWater/Pond.jl
+++ b/src/SurfaceWater/Pond.jl
@@ -33,8 +33,8 @@ struct PondModel{FT, D, R} <: AbstractSurfaceWaterModel{FT}
 end
 
 function PondModel{FT}(;
-    domain::ClimaLSM.Domains.AbstractDomain{FT} = ClimaLSM.Domains.Point{FT}(
-        0.0,
+    domain::ClimaLSM.Domains.AbstractDomain{FT} = ClimaLSM.Domains.Point(
+        z_sfc = 0.0,
     ),
     runoff::AbstractSurfaceRunoff{FT},
 ) where {FT}

--- a/src/pond_soil_model.jl
+++ b/src/pond_soil_model.jl
@@ -75,20 +75,11 @@ function LandHydrology{FT}(;
     return LandHydrology{FT, typeof.(args)...}(args...)
 end
 
-"""
-    function initialize_interactions(
-        land::LandHydrology{FT, SM, SW},
-    ) where {FT, SM <: Soil.RichardsModel{FT}, SW <: Pond.PondModel{FT}}
+interaction_vars(m::LandHydrology) = (:soil_infiltration,)
 
-Initializes the interaction auxiliary variable `p.soil_infiltration`.
-"""
-function initialize_interactions(
-    land::LandHydrology{FT, SM, SW},
-) where {FT, SM <: Soil.RichardsModel{FT}, SW <: Pond.PondModel{FT}}
+interaction_types(m::LandHydrology{FT}) where {FT} = (FT,)
 
-    surface_coords = coordinates(land.surface_water)#In non-column case, would this be level(soil_coords)?
-    return (soil_infiltration = similar(surface_coords),)
-end
+interaction_domains(m::LandHydrology) = (:surface_water,)
 
 #=
 If there is a pond present, flux BC should be -i_c
@@ -242,5 +233,5 @@ function Soil.boundary_fluxes(
     p::ClimaCore.Fields.FieldVector,
     t::FT,
 ) where {FT}
-    return p.soil_infiltration[1], FT(0.0)
+    return p.soil_infiltration, FT(0.0)
 end

--- a/src/root_soil_model.jl
+++ b/src/root_soil_model.jl
@@ -76,21 +76,11 @@ function RootSoilModel{FT}(;
     return RootSoilModel{FT, typeof.(args)...}(args...)
 end
 
+interaction_vars(m::RootSoilModel) = (:root_extraction,)
 
-"""
-    initialize_interactions(
-        land::RootSoilModel{FT, SM, RM},
-    ) where {FT, SM <: Soil.RichardsModel{FT}, RM <: Roots.RootsModel{FT}}
+interaction_types(m::RootSoilModel{FT}) where {FT} = (FT,)
 
-Initializes the interaction auxiliary variable `p.root_extraction`.
-"""
-function initialize_interactions(#Do we want defaults, for land::AbstractLandModel?
-    land::RootSoilModel{FT, SM, RM},
-) where {FT, SM <: Soil.RichardsModel{FT}, RM <: Roots.RootsModel{FT}}
-
-    zero_state = map(_ -> zero(FT), land.soil.coordinates)
-    return (root_extraction = similar(zero_state),)
-end
+interaction_domains(m::RootSoilModel) = (:soil,)
 
 """
     make_interactions_update_aux(

--- a/test/LSM/pond_soil_lsm.jl
+++ b/test/LSM/pond_soil_lsm.jl
@@ -15,11 +15,11 @@ using ClimaLSM.Pond
 FT = Float64
 @testset "Pond soil LSM integration test" begin
 
-    function precipitation(t::ft) where {ft}
-        if t < ft(20)
-            precip = -ft(1e-8)
+    function precipitation(t::FT) where {FT}
+        if t < FT(20)
+            precip = -FT(1e-8)
         else
-            precip = t < ft(100) ? -ft(5e-5) : ft(0.0)
+            precip = t < FT(100) ? -FT(5e-5) : FT(0.0)
         end
         return precip
     end
@@ -86,4 +86,27 @@ FT = Float64
     P = [3.0, -1.0, 3.0, -3.0, 1.0, 3.0]
     iap = [2.0, -1.0, -2.0, -3.0, 2.0, 2.0]
     @test infiltration_at_point.(η, i_c, P) ≈ iap
+
+    land_prognostic_vars = prognostic_vars(land)
+    land_prognostic_types = prognostic_types(land)
+    land_auxiliary_vars = auxiliary_vars(land)
+    land_auxiliary_types = auxiliary_types(land)
+    # prognostic vars
+    @test land_prognostic_vars.soil == prognostic_vars(land.soil)
+    @test land_prognostic_vars.surface_water ==
+          prognostic_vars(land.surface_water)
+    # auxiliary vars
+    @test land_auxiliary_vars.soil == auxiliary_vars(land.soil)
+    @test land_auxiliary_vars.surface_water ==
+          auxiliary_vars(land.surface_water)
+    @test land_auxiliary_vars.interactions == ClimaLSM.interaction_vars(land)
+    # prognostic types
+    @test land_prognostic_types.soil == prognostic_types(land.soil)
+    @test land_prognostic_types.surface_water ==
+          prognostic_types(land.surface_water)
+    # auxiliary types
+    @test land_auxiliary_types.soil == auxiliary_types(land.soil)
+    @test land_auxiliary_types.surface_water ==
+          auxiliary_types(land.surface_water)
+    @test land_auxiliary_types.interactions == ClimaLSM.interaction_types(land)
 end

--- a/test/SurfaceWater/pond_test.jl
+++ b/test/SurfaceWater/pond_test.jl
@@ -35,7 +35,7 @@ FT = Float64
     sol = solve(prob, Euler(), dt = dt)
 
 
-    η = [sol.u[k].surface_water.η[1] for k in 1:1:length(sol.t)]
+    η = [sol.u[k].surface_water.η[] for k in 1:1:length(sol.t)]
     t = sol.t[1:end]
 
     function expected_pond_height(t)

--- a/test/variable_types.jl
+++ b/test/variable_types.jl
@@ -46,8 +46,8 @@ end
     point = Point(; z_sfc = zlim[1])
     m = Model{FT, typeof(point)}(point)
     Y, p, coords = initialize(m)
-    @test Y.foo.a == [0.0]
-    @test Y.foo.b == [zero(SVector{2, FT})]
-    @test p.foo.d == [0.0]
-    @test p.foo.e == [zero(SVector{2, FT})]
+    @test Y.foo.a[] == 0.0
+    @test Y.foo.b[] == zero(SVector{2, FT})
+    @test p.foo.d[] == 0.0
+    @test p.foo.e[] == zero(SVector{2, FT})
 end


### PR DESCRIPTION
Makes the `Point` domain consistent with the other domains in that is backed by ClimaCore spaces (`ClimaCore.Spaces.PointSpace`). This allows for `PointFields` to be defined for surface column models.

Minimal changes were needed to update the standalone Pond model. The pond-soil LSM model needs debugging around space instances. Roots model will be updated in a following PR.

Additionally, this PR changes the way that `interactions` auxiliary variables are defined, making them more consistent with other model variables through the definition of `interactions_vars`, `interactions_types`, and `interactions_spaces` methods (see comment below).