### PR TITLE
Added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+A clear and concise description of what the bug is. Include any relevant information, e.g.
+- descriptions of expected behavior
+- plots/screenshots
+
+## To Reproduce
+Ideally a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example):
+
+```julia
+# some code here
+```
+
+Or even better, add it as a unit test, and open pull request.
+
+<details><summary>Project</summary>
+<p>
+If not using the `examples` project:
+```
+paste your Project.toml here.
+```
+```
+paste your Manifest.toml here.
+```
+
+</p>
+</details>
+
+## System details
+
+Any relevant system information:
+- Julia version
+- operating system
+- modules loaded on cluster (`module list`)
+
+## Related issues / PRs
+
+Please add any relevant links.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+Please link to any related issues/PRs.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/software_development_issue.md
+++ b/.github/ISSUE_TEMPLATE/software_development_issue.md
@@ -1,0 +1,37 @@
+---
+name: Software Development Issue
+about: Proposals for major changes
+title: Product title
+labels: SDI
+assignees: ''
+
+---
+
+## Purpose
+The purpose of the Proposal and how it accomplishes a team/CliMA objective.
+
+Link to any relevant PRs/issues.
+
+## Cost/benefits/risks
+An analysis of the cost/benefits/risks associated with the proposal.
+
+## Producers
+A list of the resources and named personnel required to implement the Proposal.
+
+## Components
+A description of the main components of the software solution.
+
+## Inputs
+A description of the inputs to the solution (designs, references, equations, closures, discussions etc).
+
+## Results and deliverables
+A description of the key results, deliverables, quality expectations, and performance metrics.
+
+## Task breakdown
+A preliminary list of PRs and a preliminary timeline of PRs, milestones, and key results.
+- [ ] Task 1
+- [ ] Task 2
+...
+
+## Reviewers
+The names of CliMA personnel who will review the Proposal and subsequent PRs.


### PR DESCRIPTION
Following https://github.com/CliMA/ClimaCore.jl/pull/677, add templates for issues. The expectation is that issues are opened prior to most PRs, which are closed by those PRs.