### PR TITLE
Add variable initialize methods for LSM.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,8 @@ ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+SurfaceFluxes = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
+Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]

--- a/docs/src/APIs/ClimaLSM.md
+++ b/docs/src/APIs/ClimaLSM.md
@@ -31,3 +31,13 @@ ClimaLSM.RunoffBC
 ClimaLSM.PrognosticSoilPressure
 ClimaLSM.RootExtraction
 ```
+
+## BucketModel
+
+```@docs
+ClimaLSM.BucketModelParameters
+ClimaLSM.PrescribedAtmosphere
+ClimaLSM.PrescribedRadiation
+ClimaLSM.CoupledAtmosphere
+ClimaLSM.CoupledRadiation
+ClimaLSM.BucketModel

--- a/src/Bucket/Bucket.jl
+++ b/src/Bucket/Bucket.jl
@@ -1,0 +1,433 @@
+module Bucket
+# (1) Add snow - is there a better way to handle timesteps where only
+# some of the surface energy is used to melt all of the snow?
+# (2) Make atmos functions a function of space (lat lon? x y? coords?)
+# (3) Look at allocations & performance...
+using UnPack
+using DocStringExtensions
+using CLIMAParameters: AbstractEarthParameterSet
+using CLIMAParameters: Stefan
+using CLIMAParameters.Planet:
+    LH_v0, LH_s0, LH_f0, ρ_cloud_liq, T_freeze, T_0, R_d, cp_d, grav, cp_v
+using SurfaceFluxes
+using SurfaceFluxes.UniversalFunctions
+using Thermodynamics
+using StaticArrays
+
+using ClimaLSM
+import ClimaLSM.Domains: coordinates, Plane
+import ClimaLSM:
+    AbstractModel,
+    make_update_aux,
+    make_rhs,
+    prognostic_vars,
+    auxiliary_vars,
+    name,
+    prognostic_types,
+    auxiliary_types
+export BucketModelParameters,
+    PrescribedAtmosphere,
+    PrescribedRadiation,
+    BucketModel,
+    CoupledRadiation,
+    CoupledAtmosphere,
+    surface_fluxes
+include("./bucket_parameterizations.jl")
+
+abstract type AbstractBucketModel{FT} <: AbstractModel{FT} end
+abstract type AbstractAtmosphericDrivers{FT <: AbstractFloat} end
+abstract type AbstractRadiativeDrivers{FT <: AbstractFloat} end
+
+ClimaLSM.name(::AbstractBucketModel) = :bucket
+
+"""
+    struct BucketModelParameters{
+        FT <: AbstractFloat,
+        PSE <: AbstractEarthParameterSet,
+    }
+
+Container for holding the parameters of the bucket model.
+
+$(DocStringExtensions.FIELDS)
+"""
+struct BucketModelParameters{
+    FT <: AbstractFloat,
+    PSE <: AbstractEarthParameterSet,
+}
+    "Depth of the soil column (m) used in heat equation"
+    d_soil::FT
+    "Temperature at the bottom of the soil column (K); constant"
+    T0::FT
+    "Conductivity of the soil (W/K/m); constant"
+    κ_soil::FT
+    "Volumetric heat capacity of the soil (J/m^3/K); constant"
+    ρc_soil::FT
+    "Shortwave soil albedo; constant"
+    α_soil::FT
+    "Shortwave snow albedo; constant"
+    α_snow::FT
+    "Critical SWE amount (m) where surface transitions from soil to snow"
+    S_c::FT
+    "Capacity of the land bucket (m)"
+    W_f::FT
+    "Roughness length for momentum (m)"
+    z_0m::FT
+    "Roughness length for scalars (m)"
+    z_0b::FT
+    "Earth Parameter set; physical constants, etc"
+    earth_param_set::PSE
+end
+
+BucketModelParameters(
+    d_soil::FT,
+    T0::FT,
+    κ_soil::FT,
+    ρc_soil::FT,
+    α_soil::FT,
+    α_snow::FT,
+    S_c::FT,
+    W_f::FT,
+    z_0m::FT,
+    z_0b::FT,
+    earth_param_set::PSE,
+) where {FT, PSE} = BucketModelParameters{FT, PSE}(
+    d_soil,
+    T0,
+    κ_soil,
+    ρc_soil,
+    α_soil,
+    α_snow,
+    S_c,
+    W_f,
+    z_0m,
+    z_0b,
+    earth_param_set,
+)
+
+"""
+    PrescribedAtmosphere{FT, LP, TA, UA, QA, RA} <: AbstractAtmosphericDrivers{FT}
+
+Container for holding prescribed atmospheric drivers and other
+information needed for computing turbulent surface fluxes when
+driving the bucket model in standalone mode.
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedAtmosphere{FT, LP, TA, UA, QA, RA} <:
+       AbstractAtmosphericDrivers{FT}
+    "Precipitation (m/s) function of time: positive by definition"
+    liquid_precip::LP
+    "Prescribed atmospheric temperature (function of time)  at the reference height (K)"
+    T_atmos::TA
+    "Prescribed wind speed (function of time)  at the reference height (m/s)"
+    u_atmos::UA
+    "Prescribed specific humidity (function of time)  at the reference height (_)"
+    q_atmos::QA
+    "Prescribed air density (function of time)  at the reference height (kg/m^3)"
+    ρ_atmos::RA
+    "Reference height, relative to surface elevation(m)"
+    h_atmos::FT
+    "Surface air density (kg/m^3). Note that convergence errors result if ρ_sfc = ρ_atmos."
+    ρ_sfc::FT # Eventually, computed from mean surface pressure (from Atmos) + land T_sfc
+end
+
+function PrescribedAtmosphere(
+    precipitation,
+    T_atmos,
+    u_atmos,
+    q_atmos,
+    ρ_atmos,
+    h_atmos,
+    ρ_sfc,
+)
+    args = (precipitation, T_atmos, u_atmos, q_atmos, ρ_atmos)
+    PrescribedAtmosphere{typeof(h_atmos), typeof.(args)...}(
+        args...,
+        h_atmos,
+        ρ_sfc,
+    )
+end
+
+
+"""
+    CoupledAtmosphere{FT} <: AbstractAtmosphericDrivers{FT}
+
+To be used when coupling to an atmosphere model; internally, used for
+multiple dispatch on `surface_fluxes`.
+"""
+struct CoupledAtmosphere{FT} <: AbstractAtmosphericDrivers{FT} end
+
+
+"""
+    PrescribedRadiativeFluxes{FT, SW, LW} <: AbstractRadiativeDrivers{FT}
+
+Container for the prescribed radiation functions needed to drive the
+bucket model in standalone mode.
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedRadiativeFluxes{FT, SW, LW} <: AbstractRadiativeDrivers{FT}
+    "Downward shortwave radiation function of time (W/m^2): positive indicates towards surface"
+    SW_d::SW
+    "Downward longwave radiation function of time (W/m^2): positive indicates towards surface"
+    LW_d::LW
+end
+
+PrescribedRadiativeFluxes(FT, SW_d, LW_d) =
+    PrescribedRadiativeFluxes{FT, typeof(SW_d), typeof(LW_d)}(SW_d, LW_d)
+
+"""
+    CoupledRadiativeFluxes{FT} <: AbstractRadiativeDrivers{FT}
+
+To be used when coupling to an atmosphere model; internally, used for
+multiple dispatch on `surface_fluxes`.
+"""
+struct CoupledRadiativeFluxes{FT} <: AbstractRadiativeDrivers{FT} end
+
+"""
+
+    struct BucketModel{
+         FT,
+         PS <: BucketModelParameters{FT},
+         ATM <: AbstractAtmosphericDrivers{FT},
+         RAD <: AbstractRadiativeDrivers{FT},
+         D,
+     } <: AbstractBucketModel{FT}
+
+Concrete type for the BucketModel, which store the model
+domain and parameters, as well as the necessary atmosphere
+and radiation fields for driving the model.
+$(DocStringExtensions.FIELDS)
+"""
+struct BucketModel{
+    FT,
+    PS <: BucketModelParameters{FT},
+    ATM <: AbstractAtmosphericDrivers{FT},
+    RAD <: AbstractRadiativeDrivers{FT},
+    D,
+} <: AbstractBucketModel{FT}
+    "Parameters required by the bucket model"
+    parameters::PS
+    "The atmospheric drivers: Prescribed or Coupled"
+    atmos::ATM
+    "The radiation drivers: Prescribed or Coupled"
+    radiation::RAD
+    "The domain of the model"
+    domain::D
+end
+
+function BucketModel(;
+    parameters::BucketModelParameters{FT, PSE},
+    domain::ClimaLSM.Domains.AbstractDomain,
+    atmosphere::ATM,
+    radiation::RAD,
+) where {FT, PSE, ATM, RAD}
+    args = (parameters, atmosphere, radiation, domain)
+    BucketModel{FT, typeof.(args)...}(args...)
+end
+
+prognostic_types(::BucketModel{FT}) where {FT} = (FT, FT, FT, FT)
+prognostic_vars(::BucketModel) = (:W, :T_sfc, :Ws, :S)
+auxiliary_types(::BucketModel{FT}) where {FT} = (FT, FT, FT, FT, FT)
+auxiliary_vars(::BucketModel) = (:q_sfc, :E, :LHF, :SHF, :R_n)
+
+"""
+    surface_fluxes( T_sfc::FT,
+                    q_sfc::FT,
+                    S::FT
+                    t::FT,
+                    parameters::P,
+                    atmos::PA,
+                    radiation::PR,
+                    ) where {FT <: AbstractFloat, P <: BucketModelParameters{FT},  PA <: PrescribedAtmosphere{FT}, PR <: PrescribedRadiativeFluxes{FT}}
+
+Computes the surface flux terms at the ground for a standalone simulation:
+net radiation,  SHF,  LHF,
+as well as the water vapor flux (in units of m^3/m^2/s of water).
+Positive fluxes indicate flow from the ground to the atmosphere.
+
+It solves for these given atmospheric conditions, stored in `atmos`,
+ downwelling shortwave and longwave radiation (in `radiation`),
+model parameters, and the surface temperature and surface specific
+humidity.
+
+Currently, we only support soil covered surfaces.
+"""
+function surface_fluxes(
+    T_sfc::FT,
+    q_sfc::FT,
+    S::FT,
+    t::FT,
+    parameters::P,
+    atmos::PA,
+    radiation::PR,
+) where {
+    FT <: AbstractFloat,
+    P <: BucketModelParameters{FT},
+    PA <: PrescribedAtmosphere{FT},
+    PR <: PrescribedRadiativeFluxes{FT},
+}
+    @unpack ρ_atmos, T_atmos, u_atmos, q_atmos, h_atmos, ρ_sfc = atmos
+    @unpack α_soil, α_snow, z_0m, z_0b, S_c, earth_param_set = parameters
+    @unpack LW_d, SW_d = radiation
+    _σ = Stefan()
+    _ρ_liq = ρ_cloud_liq(earth_param_set)
+
+    # call surface fluxes for E, SHF, LHF
+    ts_sfc = Thermodynamics.PhaseEquil_ρTq(earth_param_set, ρ_sfc, T_sfc, q_sfc)
+    ts_in = Thermodynamics.PhaseEquil_ρTq(
+        earth_param_set,
+        ρ_atmos(t),
+        T_atmos(t),
+        q_atmos(t),
+    )
+
+    # h_atmos is relative to surface height, so we can set surface height to zero.
+    state_sfc = SurfaceFluxes.SurfaceValues(FT(0), SVector{2, FT}(0, 0), ts_sfc)
+    state_in = SurfaceFluxes.InteriorValues(
+        h_atmos,
+        SVector{2, FT}(u_atmos(t), 0),
+        ts_in,
+    )
+
+    # State containers
+    sc = SurfaceFluxes.ValuesOnly{FT}(;
+        state_in,
+        state_sfc,
+        z0m = z_0m,
+        z0b = z_0b,
+    )
+
+    conditions = SurfaceFluxes.surface_conditions(
+        earth_param_set,
+        sc,
+        SurfaceFluxes.UniversalFunctions.Businger(),
+    )
+
+    α = surface_albedo(α_soil, α_snow, S, S_c)
+    # Recall that the user passed the LW and SW downwelling radiation,
+    # where positive values indicate toward surface, so we need a negative sign out front
+    # in order to inidicate positive R_n  = towards atmos.
+    R_n = -((FT(1) - α) * SW_d(t) + LW_d(t) - _σ * T_sfc^FT(4.0))
+    # Land needs a volume flux of water, not mass flux
+    E = SurfaceFluxes.evaporation(sc, earth_param_set, conditions.Ch) / _ρ_liq
+    return (R_n = R_n, LHF = conditions.lhf, SHF = conditions.shf, E = E)
+end
+
+
+"""
+    surface_fluxes( T_sfc::FT,
+                    q_sfc::FT,
+                    S::FT
+                    t::FT,
+                    parameters::P,
+                    atmos::PA,
+                    radiation::PR,
+                    ) where {FT <: AbstractFloat, P <: BucketModelParameters{FT},  PA <: CoupledAtmosphere{FT}, PR <: CoupledRadiativeFluxes{FT}}
+
+Computes the surface flux terms at the ground for a coupled simulation:
+net radiation,  SHF,  LHF,
+as well as the water vapor flux (in units of m^3/m^2/s of water).
+Positive fluxes indicate flow from the ground to the atmosphere.
+
+Currently, we only support soil covered surfaces.
+"""
+function surface_fluxes(
+    T_sfc::FT,
+    q_sfc::FT,
+    S::FT,
+    t::FT,
+    parameters::P,
+    atmos::PA,
+    radiation::PR,
+) where {
+    FT <: AbstractFloat,
+    P <: BucketModelParameters{FT},
+    PA <: CoupledAtmosphere{FT},
+    PR <: CoupledRadiativeFluxes{FT},
+}
+    # coupler does its thing here
+    return (R_n = FT(0.0), LHF = FT(0.0), SHF = FT(0.0), E = FT(0.0))
+end
+
+
+
+"""
+    make_rhs(model::BucketModel{FT}) where {FT}
+
+Creates the rhs! function for the bucket model.
+"""
+function make_rhs(model::BucketModel{FT}) where {FT}
+    function rhs!(dY, Y, p, t)
+        @unpack d_soil, T0, κ_soil, ρc_soil, S_c, W_f = model.parameters
+        # Always positive
+        liquid_precip = model.atmos.liquid_precip(t)
+        @unpack SHF, LHF, R_n, E = p.bucket
+
+        F_surf_soil = @. (R_n + LHF + SHF) # Eqn 16. TODO: modify for snow
+
+        F_bot_soil = @. -κ_soil / (d_soil) * (Y.bucket.T_sfc - T0) # Equation (16)
+
+        E_surf_soil = @. (1.0 - heaviside(Y.bucket.S)) * E # Equation (11) assuming E is volume flux
+        space = axes(Y.bucket.S)
+
+        # Always positive
+        snow_melt = zeros(axes(Y.bucket.S)) .* (1.0 .- heaviside.(Y.bucket.S)) # Equation (8)
+
+        infiltration =
+            infiltration_at_point.(
+                Y.bucket.W,
+                snow_melt,
+                liquid_precip,
+                E_surf_soil,
+                W_f,
+            )
+        # Positive infiltration -> net (negative) flux into soil
+        dY.bucket.W .= infiltration # Equation (4a) of the text. 
+        dY.bucket.Ws .=
+            (liquid_precip .+ snow_melt .- E_surf_soil) .- infiltration # Equation (5) of the text
+        dY.bucket.S .= zeros(space) # To be equation (6)
+
+        @. dY.bucket.T_sfc =
+            -FT(1.0) / ρc_soil / d_soil * (F_surf_soil - F_bot_soil) # Eq 16
+    end
+    return rhs!
+end
+
+"""
+    make_update_aux(model::BucketModel{FT}) where {FT}
+
+Creates the update_aux! function for the BucketModel.
+"""
+function make_update_aux(model::BucketModel{FT}) where {FT}
+    function update_aux!(p, Y, t)
+        p.bucket.q_sfc .=
+            β.(Y.bucket.W, model.parameters.W_f) .*
+            q_sat.(
+                Y.bucket.T_sfc,
+                Y.bucket.S,
+                model.atmos.ρ_sfc,
+                Ref(model.parameters),
+            )
+
+
+        fluxes =
+            surface_fluxes.(
+                Y.bucket.T_sfc,
+                p.bucket.q_sfc,
+                Y.bucket.S,
+                t,
+                Ref(model.parameters),
+                Ref(model.atmos),
+                Ref(model.radiation),
+            )
+
+        @. p.bucket.SHF = fluxes.SHF
+        @. p.bucket.LHF = fluxes.LHF
+        @. p.bucket.R_n = fluxes.R_n
+        @. p.bucket.E = fluxes.E
+
+    end
+    return update_aux!
+end
+
+
+end

--- a/src/Bucket/bucket_parameterizations.jl
+++ b/src/Bucket/bucket_parameterizations.jl
@@ -1,0 +1,97 @@
+"""
+     heaviside(x::FT)::FT where {FT}
+
+Computes the heaviside function.
+"""
+function heaviside(x::FT)::FT where {FT}
+    if x > eps(FT)
+        return FT(1.0)
+    else
+        return FT(0.0)
+    end
+end
+
+"""
+    surface_albedo(α_soil::FT, α_snow::FT, S::FT, S_c::FT)::FT where {FT <: AbstractFloat}
+
+Returns the surface albedo, linearly interpolating between the albedo
+of snow and of soil, based on the snow water equivalent S relative to
+the parameter S_c.
+
+This is taken from Lague et al 2019.
+"""
+function surface_albedo(
+    α_soil::FT,
+    α_snow::FT,
+    S::FT,
+    S_c::FT,
+)::FT where {FT <: AbstractFloat}
+    safe_S::FT = max(S, eps(FT))
+    return (FT(1.0) - S / (S + S_c)) * α_soil + S / (S + S_c) * α_snow
+end
+
+"""
+    infiltration_at_point(W::FT, M::FT, P::FT, E::FT, W_f::FT)::FT where {FT <: AbstractFloat}
+
+Returns the soil infiltration given the current water content of the bucket W, 
+the snow melt volume flux M, the precipitation volume flux P, the liquid evaporative volume
+flux E, and the bucket capacity W_f. Positive values indicate increasing
+soil moisture; the soil infiltration is the magnitude of the water
+flux into the soil.
+
+Extra inflow when the bucket is at capacity runs off.
+Note that P and M are positive by definition, while E can be 
+positive (evaporation) or negative (condensation).
+"""
+function infiltration_at_point(
+    W::FT,
+    M::FT,
+    P::FT,
+    E::FT,
+    W_f::FT,
+)::FT where {FT <: AbstractFloat}
+    if (W > W_f) & (P + M - E > 0) # Equation (4b) of text
+        return FT(0)
+    else
+        return FT(P + M - E)
+    end
+end
+
+"""
+    β(W::FT, W_f::FT) where {FT}
+
+Returns the coefficient which scales the saturated
+specific humidity at the surface based on the bucket water
+levels, which is then used
+ to obtain the
+true specific humidity of the soil surface <= q_sat.
+"""
+function β(W::FT, W_f::FT) where {FT}
+    safe_W = max(FT(0.0), W)
+    if safe_W < FT(0.75) * W_f
+        safe_W / (FT(0.75) * W_f)
+    else
+        FT(1.0)
+    end
+end
+
+"""
+    q_sat(T::FT, S::FT, ρ_sfc::FT, parameters::PE)::FT where {FT, PE}
+
+Computes the saturation specific humidity for the land surface, over ice
+if snow is present (S>0), and over water for a snow-free surface.
+"""
+function q_sat(T::FT, S::FT, ρ_sfc::FT, parameters::PE)::FT where {FT, PE}
+    return (FT(1.0) - heaviside(S)) * Thermodynamics.q_vap_saturation_generic(
+        parameters.earth_param_set,
+        T,
+        ρ_sfc,
+        Thermodynamics.Liquid(),
+    )
+    +heaviside(S) * Thermodynamics.q_vap_saturation_generic(
+        parameters.earth_param_set,
+        T,
+        ρ_sfc,
+        Thermodynamics.Ice(),
+    )
+end

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -6,7 +6,7 @@ import ClimaCore: Fields
 include("SharedUtilities/Domains.jl")
 using .Domains
 include("SharedUtilities/models.jl")
-
+include("Bucket/Bucket.jl")
 
 """
      AbstractLandModel{FT} <: AbstractModel{FT} 
@@ -32,39 +32,44 @@ abstract type AbstractLandModel{FT} <: AbstractModel{FT} end
 
 ClimaLSM.name(::AbstractLandModel) = :land
 
-function initialize(land::AbstractLandModel{FT}) where {FT}
-    components = land_components(land)
+function Domains.coordinates(model::AbstractLandModel)
+    components = land_components(model)
     coords_list = map(components) do (component)
-        Domains.coordinates(getproperty(land, component))
+        Domains.coordinates(getproperty(model, component))
     end
-    Y_state_list = map(zip(components, coords_list)) do (component, coords)
-        zero_state = map(_ -> zero(FT), coords)
-        getproperty(
-            initialize_prognostic(getproperty(land, component), zero_state),
-            component,
-        )
-    end
-    p_state_list = map(zip(components, coords_list)) do (component, coords)
-        zero_state = map(_ -> zero(FT), coords)
-        getproperty(
-            initialize_auxiliary(getproperty(land, component), zero_state),
-            component,
-        )
-    end
-    p_interactions =
-        initialize_interactions(land, NamedTuple{components}(coords_list))
+    coords =
+        ClimaCore.Fields.FieldVector(; NamedTuple{components}(coords_list)...)
+    return coords
+end
 
-    Y = ClimaCore.Fields.FieldVector(;
-        NamedTuple(zip(components, Y_state_list))...,
-    )
+function initialize_prognostic(model::AbstractLandModel{FT}, coords) where {FT}
+    components = propertynames(coords)
+    Y_state_list = map(components) do (component)
+        zero_state = map(_ -> zero(FT), getproperty(coords, component))
+        getproperty(
+            initialize_prognostic(getproperty(model, component), zero_state),
+            component,
+        )
+    end
+    Y = ClimaCore.Fields.FieldVector(; NamedTuple{components}(Y_state_list)...)
+    return Y
+end
+
+function initialize_auxiliary(model::AbstractLandModel{FT}, coords) where {FT}
+    components = propertynames(coords)
+    p_state_list = map(components) do (component)
+        zero_state = map(_ -> zero(FT), getproperty(coords, component))
+        getproperty(
+            initialize_auxiliary(getproperty(model, component), zero_state),
+            component,
+        )
+    end
+    p_interactions = initialize_interactions(model, coords)
     p = ClimaCore.Fields.FieldVector(;
         p_interactions...,
-        NamedTuple(zip(components, p_state_list))...,
+        NamedTuple{components}(p_state_list)...,
     )
-    coords = ClimaCore.Fields.FieldVector(;
-        NamedTuple(zip(components, coords_list))...,
-    )
-    return Y, p, coords
+    return p
 end
 
 function make_update_aux(land::AbstractLandModel)
@@ -147,7 +152,7 @@ end
 
 Returns the interaction variable symbols for the model in the form of a tuple.
 """
-interactios_vars(m::AbstractLandModel) = ()
+interaction_vars(m::AbstractLandModel) = ()
 
 """
    interaction_types(m::AbstractModel)
@@ -176,7 +181,7 @@ Initializes interaction variables, which are a type of auxiliary
 variable, to empty objects of the correct type for the model. 
 
 Interaction variables are specified by `interaction_vars`, their types
-by `interaction_types`, and their spaces by `interaction_spaces`. 
+by `interaction_types`, and their domains by `interaction_domains`. 
 This function should be called during `initialize_auxiliary` step.
 """
 function initialize_interactions(land::AbstractLandModel, land_coords)

--- a/src/SharedUtilities/Domains.jl
+++ b/src/SharedUtilities/Domains.jl
@@ -16,7 +16,6 @@ An abstract type for domains.
 """
 abstract type AbstractDomain{FT <: AbstractFloat} end
 Base.eltype(::AbstractDomain{FT}) where {FT} = FT
-
 """
     coordinates(domain::AbstractDomain)
 

--- a/test/Bucket/bucket_test.jl
+++ b/test/Bucket/bucket_test.jl
@@ -1,0 +1,312 @@
+using Test
+
+using OrdinaryDiffEq: ODEProblem, solve, RK4, Euler
+using DifferentialEquations
+using ClimaCore
+using CLIMAParameters: AbstractEarthParameterSet
+
+if !("." in LOAD_PATH)
+    push!(LOAD_PATH, ".")
+end
+using ClimaLSM.Bucket:
+    BucketModel,
+    BucketModelParameters,
+    PrescribedAtmosphere,
+    PrescribedRadiativeFluxes
+using ClimaLSM.Domains: coordinates, Plane
+using ClimaLSM: initialize, make_update_aux, make_ode_function
+
+
+FT = Float64
+
+# Bucket model parameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const earth_param_set = EarthParameterSet()
+α_soil = FT(0.2) # soil albedo
+α_snow = FT(0.8) # snow albedo
+S_c = FT(0.2)
+W_f = FT(0.15)
+d_soil = FT(100.0) # soil depth
+T0 = FT(280.0)
+z_0m = FT(1e-2)
+z_0b = FT(1e-3)
+κ_soil = FT(1.5)
+ρc_soil = FT(2e6)
+bucket_parameters = BucketModelParameters(
+    d_soil,
+    T0,
+    κ_soil,
+    ρc_soil,
+    α_soil,
+    α_snow,
+    S_c,
+    W_f,
+    z_0m,
+    z_0b,
+    earth_param_set,
+)
+
+# Model domain
+domain = Plane(;
+    xlim = (0.0, 1.0),
+    ylim = (0.0, 1.0),
+    nelements = (1, 1),
+    periodic = (true, true),
+    npolynomial = 1,
+)
+
+@testset "Zero flux RHS" begin
+    "Radiation"
+    SW_d = (t) -> eltype(t)(0.0)
+    LW_d = (t) -> eltype(t)(5.67e-8 * 280.0^4.0)
+    bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d)
+    "Atmos"
+    precip = (t) -> eltype(t)(0) # no precipitation
+    T_atmos = (t) -> eltype(t)(280.0)
+    u_atmos = (t) -> eltype(t)(1.0)
+    q_atmos = (t) -> eltype(t)(0.0) # no atmos water
+    h_atmos = FT(30)
+    ρ_atmos = (t) -> eltype(t)(1.13)
+    ρ_sfc = FT(1.15)
+    bucket_atmos = PrescribedAtmosphere(
+        precip,
+        T_atmos,
+        u_atmos,
+        q_atmos,
+        ρ_atmos,
+        h_atmos,
+        ρ_sfc,
+    )
+
+    model = BucketModel(
+        parameters = bucket_parameters,
+        domain = domain,
+        atmosphere = bucket_atmos,
+        radiation = bucket_rad,
+    )
+    # Initial conditions with no moisture
+    Y, p, coords = initialize(model)
+    Y.bucket.T_sfc .= 280.0
+    Y.bucket.W .= 0.0 # no moisture
+    Y.bucket.Ws .= 0.0 # no runoff
+    Y.bucket.S .= 0.0
+
+    ode_function! = make_ode_function(model)
+    dY = similar(Y)
+    # init to nonzero numbers
+    dY.bucket.T_sfc .= 1.0
+    dY.bucket.W .= 1.0
+    dY.bucket.Ws .= 1.0
+    ode_function!(dY, Y, p, 0.0)
+    @test sum(parent(dY.bucket.T_sfc)) < eps(FT)
+    @test sum(parent(dY.bucket.W)) < eps(FT)
+    @test sum(parent(dY.bucket.Ws)) < eps(FT)
+end
+
+@testset "Energy Only Equilibrium" begin
+    # Energy: P = E = W = 0 (no moisture)
+    # Set u_atmos = 0.0 so there are no turbulent fluxes
+    # Set downward radiation = 300 W / m2
+    # RHS of heat equation is -1/d(R↓-σT^4 +κ/d *(T-T_0))
+    # can solve for fixed point = 255.69458073555182
+    "Radiation"
+    SW_d = (t) -> eltype(t)(290.0)
+    LW_d = (t) -> eltype(t)(10.0)
+    bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d)
+    # Atmosphere with no precipitation
+    precip = (t) -> eltype(t)(0) # no precipitation
+    T_atmos = (t) -> eltype(t)(298.0)
+    u_atmos = (t) -> eltype(t)(0.0) # no turbulent fluxes
+    q_atmos = (t) -> eltype(t)(0.0) # no atmos water
+    h_atmos = FT(30)
+    ρ_atmos = (t) -> eltype(t)(1.13)
+    ρ_sfc = FT(1.15)
+    bucket_atmos = PrescribedAtmosphere(
+        precip,
+        T_atmos,
+        u_atmos,
+        q_atmos,
+        ρ_atmos,
+        h_atmos,
+        ρ_sfc,
+    )
+
+    model = BucketModel(
+        parameters = bucket_parameters,
+        domain = domain,
+        atmosphere = bucket_atmos,
+        radiation = bucket_rad,
+    )
+
+    # Initial conditions with no moisture
+    Y, p, coords = initialize(model)
+    Y.bucket.T_sfc .= 255.69458073555182
+    Y.bucket.W .= 0.0 # no moisture
+    Y.bucket.Ws .= 0.0 # no runoff
+    Y.bucket.S .= 0.0
+    ode_function! = make_ode_function(model)
+    dY = similar(Y)
+    ode_function!(dY, Y, p, 0.0)
+    @test sum(parent(dY.bucket.T_sfc)) < eps(FT)
+    @test sum(parent(dY.bucket.W)) < eps(FT)
+    @test sum(parent(dY.bucket.Ws)) < eps(FT)
+    @test sum(
+        parent(
+            p.bucket.R_n .-
+            -(290.0 * 0.8 + 10.0 - 5.67e-8 * 255.69458073555182^4.0),
+        ),
+    ) < eps(FT)
+
+
+end
+
+@testset "Moisture Conservation" begin
+    # Ensure no heat fluxes (no evaporation too, so no LHF)
+    # and check that runoff+soil water balance precip.
+    "Radiation"
+    SW_d = (t) -> eltype(t)(0.0)
+    LW_d = (t) -> eltype(t)(280.0^4.0 * 5.67e-8) # zeros out LW radiation
+    bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d)
+    # Atmosphere with no precipitation
+    precip = (t) -> eltype(t)(1e-2)
+    T_atmos = (t) -> eltype(t)(298.0)
+    u_atmos = (t) -> eltype(t)(0.0) # no turbulent fluxes
+    q_atmos = (t) -> eltype(t)(0.0) # no atmos water
+    h_atmos = FT(30)
+    ρ_atmos = (t) -> eltype(t)(1.13)
+    ρ_sfc = FT(1.15)
+    bucket_atmos = PrescribedAtmosphere(
+        precip,
+        T_atmos,
+        u_atmos,
+        q_atmos,
+        ρ_atmos,
+        h_atmos,
+        ρ_sfc,
+    )
+
+    model = BucketModel(
+        parameters = bucket_parameters,
+        domain = domain,
+        atmosphere = bucket_atmos,
+        radiation = bucket_rad,
+    )
+
+    # Initial conditions with no moisture
+    Y, p, coords = initialize(model)
+    Y.bucket.T_sfc .= 280.0
+    Y.bucket.W .= 0.14 # no moisture
+    Y.bucket.Ws .= 0.0 # no runoff
+    Y.bucket.S .= 0.0
+    ode_function! = make_ode_function(model)
+
+    t0 = 0.0
+    tf = 10.0
+    prob = ODEProblem(ode_function!, Y, (t0, tf), p)
+    Δt = 1.0
+    integrator = init(prob, RK4(); dt = Δt, saveat = 0:Δt:tf)
+    for step in 1:10
+        step!(integrator, Δt, true)
+    end
+
+    # net soil water
+    land_water = unique(
+        parent(
+            integrator.sol.u[end].bucket.W .+ integrator.sol.u[end].bucket.Ws,
+        ),
+    )[1]
+    dland_water = land_water - 0.14 # 0.14 is initial water
+    datmos_water = 1e-2 * integrator.sol.t[end]
+    @test datmos_water ≈ dland_water
+end
+
+@testset "Energy + Moisture Conservation" begin
+    "Radiation"
+    SW_d = (t) -> eltype(t)(10.0)
+    LW_d = (t) -> eltype(t)(300.0)
+    bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d)
+    "Atmos"
+    precip = (t) -> eltype(t)(1e-6)
+    T_atmos = (t) -> eltype(t)(298.0)
+    u_atmos = (t) -> eltype(t)(4.0)
+    q_atmos = (t) -> eltype(t)(0.01)
+    h_atmos = FT(30)
+    ρ_atmos = (t) -> eltype(t)(1.13)
+    ρ_sfc = FT(1.15)
+    bucket_atmos = PrescribedAtmosphere(
+        precip,
+        T_atmos,
+        u_atmos,
+        q_atmos,
+        ρ_atmos,
+        h_atmos,
+        ρ_sfc,
+    )
+
+    model = BucketModel(
+        parameters = bucket_parameters,
+        domain = domain,
+        atmosphere = bucket_atmos,
+        radiation = bucket_rad,
+    )
+
+    # Initial conditions with no moisture
+    Y, p, coords = initialize(model)
+    Y.bucket.T_sfc .= 280.0
+    Y.bucket.W .= 0.149
+    Y.bucket.Ws .= 0.0
+    Y.bucket.S .= 0.0
+    ode_function! = make_ode_function(model)
+
+    t0 = 0.0
+    tf = 10000.0
+    prob = ODEProblem(ode_function!, Y, (t0, tf), p)
+    Δt = 100.0
+    # need a callback to get and store `p`
+    saved_values = SavedValues(FT, ClimaCore.Fields.FieldVector)
+    cb = SavingCallback(
+        (u, t, integrator) -> copy(integrator.p),
+        saved_values;
+        saveat = 0:Δt:tf,
+    )
+    sol = solve(prob, Euler(); dt = Δt, saveat = 0:Δt:tf, callback = cb)
+    # net soil water
+    W = [unique(parent(sol.u[k].bucket.W))[1] for k in 1:length(sol.t)]
+    Ws = [unique(parent(sol.u[k].bucket.Ws))[1] for k in 1:length(sol.t)]
+    T_sfc = [unique(parent(sol.u[k].bucket.T_sfc))[1] for k in 1:length(sol.t)]
+    R_n = [
+        unique(parent(saved_values.saveval[k].bucket.R_n))[1] for
+        k in 1:length(sol.t)
+    ]
+    SHF = [
+        unique(parent(saved_values.saveval[k].bucket.SHF))[1] for
+        k in 1:length(sol.t)
+    ]
+    LHF = [
+        unique(parent(saved_values.saveval[k].bucket.LHF))[1] for
+        k in 1:length(sol.t)
+    ]
+    E = [
+        unique(parent(saved_values.saveval[k].bucket.E))[1] for
+        k in 1:length(sol.t)
+    ]
+
+    F_g = -κ_soil .* (T_sfc .- 280.0) ./ d_soil
+    F_sfc = LHF .+ SHF .+ R_n
+
+    # dY(t+dt) = Y(t+dt) - W(t) = RHS|_t * dt for Euler stepping
+    # First element of `p` not filled in, so start at 2.
+    # If we call update aux before the simulation, it should be.
+
+
+    # Look at fractional error
+    dE_land = ρc_soil * (T_sfc[end] - T_sfc[2])
+    dE_expected = -1 / d_soil * sum(F_sfc[2:(end - 1)] .- F_g[2:(end - 1)]) * Δt
+    @test (dE_land - dE_expected) ./ (ρc_soil * sum(T_sfc) ./ length(sol.t)) <
+          1e-14
+    dW_land = W[end] + Ws[end] - W[2] - Ws[2]
+    dW_expected = sum(precip.(sol.t[2:(end - 1)]) .- E[2:(end - 1)]) * Δt
+
+    @test (dW_land - dW_expected) ./ 0.15 < 1e-14
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+include("./Bucket/bucket_test.jl")
 include("./Vegetation/root_test.jl")
 include("./LSM/lsm_test.jl")
 include("./domains.jl")


### PR DESCRIPTION
Replaces `initialize` for LSM with `initialize_prognostic`, `initialize_auxiliary`, and `Domains.coordinates` methods that (currently) return `FieldVectors`. LSM then goes through `initialize` in SharedUtilities.

Closes #56 