### PR TITLE
LSM Domain Flags

### DIFF
--- a/docs/src/APIs/ClimaLSM.md
+++ b/docs/src/APIs/ClimaLSM.md
@@ -14,6 +14,7 @@ ClimaLSM.land_components
 ClimaLSM.interaction_vars
 ClimaLSM.interaction_types
 ClimaLSM.interaction_domains
+ClimaLSM.domain
 ```
 
 ## Land Hydrology

--- a/docs/tutorials/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/LSM_single_column_tutorial.jl
@@ -360,9 +360,9 @@ propertynames(p.surface_water)
 # and the shared interaction term
 propertynames(p)
 # and finally, coordinates - useful for visualization of solutions:
-coords.soil
+coords.subsurface
 # and the coordinates of the surface variables:
-coords.surface_water
+coords.surface
 
 # And we can make the ode function as before:
 land_ode! = make_ode_function(land);

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -8,6 +8,8 @@ using .Domains
 include("SharedUtilities/models.jl")
 include("Bucket/Bucket.jl")
 
+export domain
+
 """
      AbstractLandModel{FT} <: AbstractModel{FT} 
 
@@ -32,37 +34,47 @@ abstract type AbstractLandModel{FT} <: AbstractModel{FT} end
 
 ClimaLSM.name(::AbstractLandModel) = :land
 
+"""
+    domain(model::AbstractModel)
+
+Returns a symbol indicating the model's domain, e.g. :surface or :subsurface
+"""
+domain(model::AbstractModel) = error(
+    "`domain` not implemented for $(Base.typename(typeof(model)).wrapper)",
+)
+
 function Domains.coordinates(model::AbstractLandModel)
     components = land_components(model)
     coords_list = map(components) do (component)
         Domains.coordinates(getproperty(model, component))
     end
+    domains_list = map(components) do (component)
+        domain(getproperty(model, component))
+    end
     coords =
-        ClimaCore.Fields.FieldVector(; NamedTuple{components}(coords_list)...)
+        ClimaCore.Fields.FieldVector(; NamedTuple{domains_list}(coords_list)...)
     return coords
 end
 
 function initialize_prognostic(model::AbstractLandModel{FT}, coords) where {FT}
-    components = propertynames(coords)
+    components = land_components(model)
     Y_state_list = map(components) do (component)
-        zero_state = map(_ -> zero(FT), getproperty(coords, component))
-        getproperty(
-            initialize_prognostic(getproperty(model, component), zero_state),
-            component,
-        )
+        submodel = getproperty(model, component)
+        zero_state =
+            map(_ -> zero(FT), getproperty(coords, domain(submodel)))
+        getproperty(initialize_prognostic(submodel, zero_state), component)
     end
     Y = ClimaCore.Fields.FieldVector(; NamedTuple{components}(Y_state_list)...)
     return Y
 end
 
 function initialize_auxiliary(model::AbstractLandModel{FT}, coords) where {FT}
-    components = propertynames(coords)
+    components = land_components(model)
     p_state_list = map(components) do (component)
-        zero_state = map(_ -> zero(FT), getproperty(coords, component))
-        getproperty(
-            initialize_auxiliary(getproperty(model, component), zero_state),
-            component,
-        )
+        submodel = getproperty(model, component)
+        zero_state =
+            map(_ -> zero(FT), getproperty(coords, domain(submodel)))
+        getproperty(initialize_auxiliary(submodel, zero_state), component)
     end
     p_interactions = initialize_interactions(model, coords)
     p = ClimaCore.Fields.FieldVector(;
@@ -72,20 +84,25 @@ function initialize_auxiliary(model::AbstractLandModel{FT}, coords) where {FT}
     return p
 end
 
-function make_update_aux(land::AbstractLandModel)
-    interactions_update_aux! = make_interactions_update_aux(land)
-    components = land_components(land)
-    update_aux_function_list =
-        map(x -> make_update_aux(getproperty(land, x)), components)
-    function update_aux!(p, Y, t)
-        for f! in update_aux_function_list
-            f!(p, Y, t)
-        end
-        interactions_update_aux!(p, Y, t) # this has to come last if it uses p.component.value!!
+"""
+    initialize_interactions(land::AbstractLandModel) end
+
+Initializes interaction variables, which are a type of auxiliary
+variable, to empty objects of the correct type for the model. 
+
+Interaction variables are specified by `interaction_vars`, their types
+by `interaction_types`, and their spaces by `interaction_spaces`. 
+This function should be called during `initialize_auxiliary` step.
+"""
+function initialize_interactions(land::AbstractLandModel, land_coords)
+    vars = interaction_vars(land)
+    types = interaction_types(land)
+    domains = interaction_domains(land)
+    interactions = map(zip(types, domains)) do (T, domain)
+        zero_instance = zero(T)
+        map(_ -> zero_instance, getproperty(land_coords, domain))
     end
-
-
-    return update_aux!
+    return NamedTuple{vars}(interactions)
 end
 
 function make_ode_function(land::AbstractLandModel)
@@ -100,6 +117,33 @@ function make_ode_function(land::AbstractLandModel)
     end
     return ode_function!
 end
+
+function make_update_aux(land::AbstractLandModel)
+    interactions_update_aux! = make_interactions_update_aux(land)
+    components = land_components(land)
+    update_aux_function_list =
+        map(x -> make_update_aux(getproperty(land, x)), components)
+    function update_aux!(p, Y, t)
+        for f! in update_aux_function_list
+            f!(p, Y, t)
+        end
+        interactions_update_aux!(p, Y, t) # this has to come last if it uses p.component.value!!
+    end
+    return update_aux!
+end
+
+"""
+    make_interactions_update_aux(land::AbstractLandModel) end
+
+Makes and returns a function which updates the interaction variables, 
+which are a type of auxiliary variable.
+
+The `update_aux!` function returned is evaluted during the right hand
+side evaluation.
+
+This is a stub which concrete types of LSMs extend.
+"""
+function make_interactions_update_aux(land::AbstractLandModel) end
 
 """
     land_components(land::AbstractLandModel)
@@ -164,49 +208,14 @@ interaction_types(m::AbstractLandModel) = ()
 """
    interaction_domains(m::AbstractModel)
 
-Returns the interaction domain symbols in the form of a tuple.
+Returns the interaction domain symbols in the form of a tuple e.g. :surface or :subsurface.
 
-For example, for a boundary interaction term, one would specify a model with a
-domain consisting of the boundary space. Most commonly, these are surface models.
 This is only required for variables shared between land submodels, and only needed
 for multi-component models, not standalone components. Component-specific variables
-should be listed as prognostic or auxiliary variables.
+should be listed as prognostic or auxiliary variables which do not require this to
+initialize.
 """
 interaction_domains(m::AbstractLandModel) = ()
-
-"""
-    initialize_interactions(land::AbstractLandModel) end
-
-Initializes interaction variables, which are a type of auxiliary
-variable, to empty objects of the correct type for the model. 
-
-Interaction variables are specified by `interaction_vars`, their types
-by `interaction_types`, and their domains by `interaction_domains`. 
-This function should be called during `initialize_auxiliary` step.
-"""
-function initialize_interactions(land::AbstractLandModel, land_coords)
-    vars = interaction_vars(land)
-    types = interaction_types(land)
-    domains = interaction_domains(land)
-    interactions = map(zip(types, domains)) do (T, domain)
-        zero_instance = zero(T)
-        map(_ -> zero_instance, getproperty(land_coords, domain))
-    end
-
-    return NamedTuple{vars}(interactions)
-end
-"""
-    make_interactions_update_aux(land::AbstractLandModel) end
-
-Makes and returns a function which updates the interaction variables, 
-which are a type of auxiliary variable.
-
-The `update_aux!` function returned is evaluted during the right hand
-side evaluation.
-
-This is a stub which concrete types of LSMs extend.
-"""
-function make_interactions_update_aux(land::AbstractLandModel) end
 
 # Methods extended by the LSM models we support
 include("SurfaceWater/Pond.jl")

--- a/src/Soil/Soil.jl
+++ b/src/Soil/Soil.jl
@@ -118,6 +118,7 @@ and water model, with phase change.
 abstract type AbstractSoilModel{FT} <: ClimaLSM.AbstractModel{FT} end
 
 ClimaLSM.name(::AbstractSoilModel) = :soil
+ClimaLSM.domain(::AbstractSoilModel) = :subsurface
 
 """
     coordinates(model::AbstractSoilModel)

--- a/src/SurfaceWater/Pond.jl
+++ b/src/SurfaceWater/Pond.jl
@@ -59,6 +59,7 @@ end
 ClimaLSM.prognostic_vars(model::PondModel) = (:η,)
 ClimaLSM.prognostic_types(model::PondModel{FT}) where {FT} = (FT,)
 ClimaLSM.name(::AbstractSurfaceWaterModel) = :surface_water
+ClimaLSM.domain(::AbstractSurfaceWaterModel) = :surface
 
 function ClimaLSM.make_rhs(model::PondModel)
     function rhs!(dY, Y, p, t)

--- a/src/Vegetation/Roots.jl
+++ b/src/Vegetation/Roots.jl
@@ -84,6 +84,7 @@ include multi-layer canopy models and possibly a big leaf model.
 abstract type AbstractVegetationModel{FT} <: AbstractModel{FT} end
 
 ClimaLSM.name(::AbstractVegetationModel) = :vegetation
+ClimaLSM.domain(::AbstractVegetationModel) = :surface
 
 """
     AbstractRootExtraction{FT <: AbstractFloat}

--- a/src/pond_soil_model.jl
+++ b/src/pond_soil_model.jl
@@ -79,7 +79,7 @@ interaction_vars(m::LandHydrology) = (:soil_infiltration,)
 
 interaction_types(m::LandHydrology{FT}) where {FT} = (FT,)
 
-interaction_domains(m::LandHydrology) = (:surface_water,)
+interaction_domains(m::LandHydrology) = (:surface,)
 
 #=
 If there is a pond present, flux BC should be -i_c

--- a/src/root_soil_model.jl
+++ b/src/root_soil_model.jl
@@ -80,7 +80,7 @@ interaction_vars(m::RootSoilModel) = (:root_extraction,)
 
 interaction_types(m::RootSoilModel{FT}) where {FT} = (FT,)
 
-interaction_domains(m::RootSoilModel) = (:soil,)
+interaction_domains(m::RootSoilModel) = (:subsurface,)
 
 """
     make_interactions_update_aux(

--- a/test/LSM/lsm_test.jl
+++ b/test/LSM/lsm_test.jl
@@ -81,7 +81,7 @@ FT = Float64
         end
         Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
     end
-    init_soil!(Y, coords.soil.z, land.soil.parameters)
+    init_soil!(Y, coords.subsurface.z, land.soil.parameters)
 
     ## soil is at total ψ+z = -3.0 #m
     ## Want ρgΨ_plant = ρg(-3) - ρg z_plant & convert to MPa

--- a/test/LSM/pond_soil_lsm.jl
+++ b/test/LSM/pond_soil_lsm.jl
@@ -65,7 +65,7 @@ FT = Float64
         end
         Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z, Ref(params))
     end
-    init_soil!(Y, coords.soil, land.soil.parameters)
+    init_soil!(Y, coords.subsurface, land.soil.parameters)
     # initialize the pond height to zero
     Y.surface_water.η .= 0.0
 


### PR DESCRIPTION
Changes `interaction_domains` flags to `:surface` and `:subsurface`. Reorganizes the structure returned by `coordinates(::AbstractLandModel)` to use these names. This does not impact standalone models.

Follows PR #59 

Closes Issue #58 