### PR TITLE
Albedo models

### DIFF
--- a/docs/src/APIs/ClimaLSM.md
+++ b/docs/src/APIs/ClimaLSM.md
@@ -41,7 +41,9 @@ ClimaLSM.PrescribedAtmosphere
 ClimaLSM.PrescribedRadiation
 ClimaLSM.AbstractAtmosphericDrivers
 ClimaLSM.AbstractRadiativeDrivers
+ClimaLSM.BulkAlbedo
 ClimaLSM.BucketModel
 ClimaLSM.surface_fluxes
 ClimaLSM.surface_air_density
 ClimaLSM.liquid_precipitation
+ClimaLSM.surface_albedo

--- a/src/Bucket/bucket_parameterizations.jl
+++ b/src/Bucket/bucket_parameterizations.jl
@@ -12,22 +12,24 @@ function heaviside(x::FT)::FT where {FT}
 end
 
 """
-    surface_albedo(α_soil::FT, α_snow::FT, S::FT, S_c::FT)::FT where {FT <: AbstractFloat}
+    surface_albedo(albedo::BulkAlbedo{FT}, coords, S::FT, S_c::FT)::FT where {FT <: AbstractFloat}
 
-Returns the surface albedo, linearly interpolating between the albedo
+Returns the bulk surface albedo, linearly interpolating between the albedo
 of snow and of soil, based on the snow water equivalent S relative to
 the parameter S_c.
 
-This is taken from Lague et al 2019.
+The linear interpolation is taken from Lague et al 2019.
 """
 function surface_albedo(
-    α_soil::FT,
-    α_snow::FT,
+    albedo::BulkAlbedo{FT},
+    coords,
     S::FT,
     S_c::FT,
 )::FT where {FT <: AbstractFloat}
+    (; α_snow, α_soil) = albedo
+    α_soil_values = α_soil(coords)
     safe_S::FT = max(S, eps(FT))
-    return (FT(1.0) - S / (S + S_c)) * α_soil + S / (S + S_c) * α_snow
+    return (FT(1.0) - S / (S + S_c)) * α_soil_values + S / (S + S_c) * α_snow
 end
 
 """

--- a/test/Bucket/bucket_test.jl
+++ b/test/Bucket/bucket_test.jl
@@ -12,7 +12,8 @@ using ClimaLSM.Bucket:
     BucketModel,
     BucketModelParameters,
     PrescribedAtmosphere,
-    PrescribedRadiativeFluxes
+    PrescribedRadiativeFluxes,
+    BulkAlbedo
 using ClimaLSM.Domains: coordinates, Plane
 using ClimaLSM: initialize, make_update_aux, make_ode_function
 
@@ -22,8 +23,9 @@ FT = Float64
 # Bucket model parameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const earth_param_set = EarthParameterSet()
-α_soil = FT(0.2) # soil albedo
+α_soil = (coordinate_point) -> FT(0.2) # soil albedo, spatially constant
 α_snow = FT(0.8) # snow albedo
+albedo = BulkAlbedo{FT}(α_snow, α_soil)
 S_c = FT(0.2)
 W_f = FT(0.15)
 d_soil = FT(100.0) # soil depth
@@ -37,8 +39,7 @@ bucket_parameters = BucketModelParameters(
     T0,
     κ_soil,
     ρc_soil,
-    α_soil,
-    α_snow,
+    albedo,
     S_c,
     W_f,
     z_0m,


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Add in an albedo model which allows for albedo of soil to be a function of space. Add in an exported function which computes the surface albedo of the land.

## Benefits and Risks
Allows for more realistic simulations, allows for the coupler to compute the albedo.

