### PR TITLE
initial commit; n compartments

### DIFF
--- a/src/SharedUtilities/Domains.jl
+++ b/src/SharedUtilities/Domains.jl
@@ -401,22 +401,119 @@ abstract type AbstractVegetationDomain{FT} <: AbstractDomain{FT} end
 Domain for a single bulk plant with roots of varying depths. The user needs
 to specify the depths of the root tips as wel as the heights of the
 compartments to be modeled within the plant. The compartment heights
-are expected to be sorted in ascending order.
+are expected to be sorted in ascending order. The number of stem and leaf
+compartments the plant should be divided into must be specified as well.
 """
 struct PlantHydraulicsDomain{FT} <: AbstractVegetationDomain{FT}
     "The depth of the root tips, in meters"
     root_depths::Vector{FT}
-    "The height of the stem and leaf compartments, in meters"
-    compartment_surfaces::Vector{FT}
-    "The height of the midpoint of the stem and leaf compartments, in meters"
+    "The number of stem compartments for the plant"
+    n_stem::Int64
+    "The number of leaf compartments for the plant"
+    n_leaf::Int64
+    "The height of the center of each leaf compartment/stem compartment, in meters"
     compartment_midpoints::Vector{FT}
+    "The height of the compartments' top faces, in meters"
+    compartment_surfaces::Vector{FT}
+    "The label (:stem or :leaf) of each compartment"
+    compartment_labels::Vector{Symbol}
+
+    """
+        function PlantHydraulicsDomain(
+            root_depths::Vector{FT},
+            n_stem::Int64,
+            n_leaf::Int64,
+            Δz::FT,
+            ) where {FT}
+
+    Creates an object of the PlantHydraulicsDomain struct type where every plant compartment is
+    the same length.
+    """
+    function PlantHydraulicsDomain(
+        root_depths::Vector{FT},
+        n_stem::Int64,
+        n_leaf::Int64,
+        Δz::FT,
+    ) where {FT}
+        @assert n_leaf != 0
+        compartment_midpoints = Vector{FT}(undef, n_stem + n_leaf)
+        compartment_midpoints = range(
+            start = Δz / 2,
+            step = Δz,
+            stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+        )
+        compartment_labels = Vector{Symbol}(undef, n_stem + n_leaf)
+        for i in 1:(n_stem + n_leaf)
+            if i <= n_stem
+                compartment_labels[i] = :stem
+            else
+                compartment_labels[i] = :leaf
+            end
+        end
+        compartment_surfaces =
+            range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf))
+        new{FT}(
+            root_depths,
+            n_stem,
+            n_leaf,
+            compartment_midpoints,
+            compartment_surfaces,
+            compartment_labels,
+        )
+    end
+
+    """
+        function PlantHydraulicsDomain(
+            root_depths::Vector{FT},
+            n_stem::Int64,
+            n_leaf::Int64,
+            compartment_midpoints::Vector{FT},
+            compartment_surfaces::Vector{FT},
+            ) where {FT}
+
+    Creates an object of the PlantHydraulicsDomain struct type where every plant compartment 
+    may not be the same length. Compartment midpoint heights and the height each compartment's
+    top is at are directly given so that the compartment lengths can vary if desired.
+    """
+    function PlantHydraulicsDomain(
+        root_depths::Vector{FT},
+        n_stem::Int64,
+        n_leaf::Int64,
+        compartment_midpoints::Vector{FT},
+        compartment_surfaces::Vector{FT},
+    ) where {FT}
+        @assert n_leaf != 0
+        @assert (n_leaf + n_stem) == length(compartment_midpoints)
+        @assert (n_leaf + n_stem) + 1 == length(compartment_surfaces)
+        for i in 1:length(compartment_midpoints)
+            @assert compartment_midpoints[i] ==
+                    (
+                (compartment_surfaces[i + 1] - compartment_surfaces[i]) / 2
+            ) + compartment_surfaces[i]
+        end
+        compartment_labels = Vector{Symbol}(undef, n_stem + n_leaf)
+        for i in 1:(n_stem + n_leaf)
+            if i <= n_stem
+                compartment_labels[i] = :stem
+            else
+                compartment_labels[i] = :leaf
+            end
+        end
+        new{FT}(
+            root_depths,
+            n_stem,
+            n_leaf,
+            compartment_midpoints,
+            compartment_surfaces,
+            compartment_labels,
+        )
+    end
 end
 
 function coordinates(domain::PlantHydraulicsDomain{FT}) where {FT}
-    return domain.compartment_midpoints # array of centers here
+    return domain.compartment_midpoints
 end
 
-# loop over coordinates, when initialize
 """
     AbstractLSMDomain{FT} <: AbstractDomain{FT}
 An abstract type for LSMDomains, which have two components: a surface

--- a/test/LSM/lsm_test.jl
+++ b/test/LSM/lsm_test.jl
@@ -20,9 +20,7 @@ FT = Float64
 @testset " Soil plant hydrology LSM integration test" begin
     saved_values = SavedValues(FT, ClimaCore.Fields.FieldVector)
     earth_param_set = create_lsm_parameters(FT)
-    K_sat_root = FT(1e-5) # Pierre's database (1e-6) (https://github.com/yalingliu-cu/plant-strategies/blob/master/Product%20details.pdf)
-    K_sat_stem = FT(1e-3)
-    K_sat_leaf = FT(1e-3)
+    K_sat = (root = FT(1e-5), stem = FT(1e-3), leaf = FT(1e-3))
     vg_α = FT(0.24)
     vg_n = FT(2)
     vg_m = FT(1) - FT(1) / vg_n
@@ -36,16 +34,19 @@ FT = Float64
     # be fixed eventually.
     z_stem_midpoint = FT(3)
     z_leaf_midpoint = FT(9)
-    plant_hydraulics_domain = PlantHydraulicsDomain{FT}(
+    n_stem = Int64(1)
+    n_leaf = Int64(1)
+    plant_hydraulics_domain = PlantHydraulicsDomain(
         z_root_depths,
-        [z_ground, z_stem_top, z_leaf_top],
+        n_stem,
+        n_leaf,
         [z_stem_midpoint, z_leaf_midpoint],
+        [z_ground, z_stem_top, z_leaf_top],
     )
+
     plant_hydraulics_ps =
         PlantHydraulics.PlantHydraulicsParameters{FT, typeof(earth_param_set)}(
-            K_sat_root,
-            K_sat_stem,
-            K_sat_leaf,
+            K_sat,
             vg_α,
             vg_n,
             vg_m,
@@ -105,7 +106,6 @@ FT = Float64
     ϑ_l_0 = [ϑ_l_stem_0, ϑ_l_leaf_0]
 
     Y.vegetation.ϑ_l .= ϑ_l_0
-
     ode! = make_ode_function(land)
     t0 = FT(0)
     tf = FT(2)

--- a/test/Vegetation/plant_hydraulics_test.jl
+++ b/test/Vegetation/plant_hydraulics_test.jl
@@ -17,33 +17,25 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 FT = Float64
 
 @testset "Plant hydraulics model integration tests" begin
-    K_sat_root = FT(1e-5) # (accelerated) see Kumar, 2008 and
+    K_sat = (root = FT(1e-5), stem = FT(1e-3), leaf = FT(1e-3))# (accelerated) see Kumar, 2008 and
     # Pierre's database for total global plant conductance (1/resistance) 
     # (https://github.com/yalingliu-cu/plant-strategies/blob/master/Product%20details.pdf)
-    K_sat_stem = FT(1e-3)
-    K_sat_leaf = FT(1e-3)
     vg_α = FT(0.24) # Fitted VG to Weibull curve parameters found in Venturas, 2018
     vg_n = FT(2)
     vg_m = FT(1) - FT(1) / vg_n
     ν = FT(0.495)
     S_s = FT(1e-3)
-    root_depths = [FT(-1.0)] # m, rooting depth
-    z_ground = FT(0.0)
-    z_stem_top = FT(5.0)
-    z_leaf_top = FT(10.0)
-    z_stem_midpoint = FT(2.5)
-    z_leaf_midpoint = FT(7.5)
+    z_root_depths = [FT(-1.0)] # m, rooting depth
+    Δz = FT(1.0) # height of compartments
+    n_stem = Int64(6)
+    n_leaf = Int64(5)
     earth_param_set = create_lsm_parameters(FT)
-    plant_hydraulics_domain = PlantHydraulicsDomain{FT}(
-        root_depths,
-        [z_ground, z_stem_top, z_leaf_top],
-        [z_stem_midpoint, z_leaf_midpoint],
-    )
+
+    plant_hydraulics_domain =
+        PlantHydraulicsDomain(z_root_depths, n_stem, n_leaf, Δz)
     param_set =
         PlantHydraulics.PlantHydraulicsParameters{FT, typeof(earth_param_set)}(
-            K_sat_root,
-            K_sat_stem,
-            K_sat_leaf,
+            K_sat,
             vg_α,
             vg_n,
             vg_m,
@@ -80,78 +72,55 @@ FT = Float64
     # Set system to hydrostatic equilibrium state by setting fluxes to zero, and setting LHS of both ODEs to 0
     function initial_rhs!(F, Y)
         T0 = FT(0)
-        flux_in_stem = sum(
-            flux.(
-                root_depths,
-                z_stem_midpoint,
-                p_soil0,
-                Y[1],
-                vg_α,
-                vg_n,
-                vg_m,
-                ν,
-                S_s,
-                K_sat_root,
-                K_sat_stem,
-            ),
-        )
-        flux_out_stem = flux(
-            z_stem_midpoint,
-            z_leaf_midpoint,
-            Y[1],
-            Y[2],
-            vg_α,
-            vg_n,
-            vg_m,
-            ν,
-            S_s,
-            K_sat_stem,
-            K_sat_leaf,
-        )
-
-        F[1] = flux_in_stem - T0
-        F[2] = flux_out_stem - T0
+        for i in 1:(n_leaf + n_stem)
+            if i == 1
+                flux_in = sum(
+                    flux.(
+                        z_root_depths,
+                        plant_hydraulics_domain.compartment_midpoints[i],
+                        p_soil0,
+                        Y[i],
+                        vg_α,
+                        vg_n,
+                        vg_m,
+                        ν,
+                        S_s,
+                        K_sat[:root],
+                        K_sat[plant_hydraulics_domain.compartment_labels[i]],
+                    ),
+                )
+            else
+                flux_in = flux(
+                    plant_hydraulics_domain.compartment_midpoints[i - 1],
+                    plant_hydraulics_domain.compartment_midpoints[i],
+                    Y[i - 1],
+                    Y[i],
+                    vg_α,
+                    vg_n,
+                    vg_m,
+                    ν,
+                    S_s,
+                    K_sat[plant_hydraulics_domain.compartment_labels[i - 1]],
+                    K_sat[plant_hydraulics_domain.compartment_labels[i]],
+                )
+            end
+            F[i] = flux_in - T0
+        end
     end
 
-    soln = nlsolve(initial_rhs!, [-0.03, -0.02])
-    p_stem_0 = soln.zero[1]
-    p_leaf_0 = soln.zero[2]
+    soln = nlsolve(initial_rhs!, Vector(-0.03:0.01:0.07))
 
-    S_l_stem_0 =
-        inverse_water_retention_curve(vg_α, vg_n, vg_m, p_stem_0, ν, S_s)
-    S_l_leaf_0 =
-        inverse_water_retention_curve(vg_α, vg_n, vg_m, p_leaf_0, ν, S_s)
+    S_l = inverse_water_retention_curve.(vg_α, vg_n, vg_m, soln.zero, ν, S_s)
 
-    ϑ_l_stem_0 = augmented_liquid_fraction(ν, S_l_stem_0)
-    ϑ_l_leaf_0 = augmented_liquid_fraction(ν, S_l_leaf_0)
+    ϑ_l_0 = augmented_liquid_fraction.(ν, S_l)
 
-    ϑ_l_0 = [ϑ_l_stem_0, ϑ_l_leaf_0]
     Y, p, coords = initialize(plant_hydraulics)
 
     Y.vegetation.ϑ_l .= ϑ_l_0
 
     plant_hydraulics_ode! = make_ode_function(plant_hydraulics)
 
-    hour = FT(60^2)
-    day = FT(24 * 60^2)
-    t0 = FT(0)
-    tf = FT(hour * 24 * 4)
-    dt = FT(1)
-
-    prob = ODEProblem(plant_hydraulics_ode!, Y, (t0, tf), p)
-    sol = solve(prob, Euler(), dt = dt)
-
     dY = similar(Y)
     plant_hydraulics_ode!(dY, Y, p, 0.0)
     @test sqrt(mean(dY.vegetation.ϑ_l .^ 2.0)) < 1e-8 # starts in equilibrium
-
-    ϑ_l_stem = reduce(hcat, sol.u)[1, :]
-    ϑ_l_leaf = reduce(hcat, sol.u)[2, :]
-
-    S_l_stem = effective_saturation.(ν, ϑ_l_stem)
-    S_l_leaf = effective_saturation.(ν, ϑ_l_leaf)
-
-    p_stem = water_retention_curve.(vg_α, vg_n, vg_m, S_l_stem, ν, S_s)
-    p_leaf = water_retention_curve.(vg_α, vg_n, vg_m, S_l_leaf, ν, S_s)
-
 end

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -200,3 +200,58 @@ end
         @test obtain_surface_space(shell.space) === surf.space
     end
 end
+
+
+@testset "PlantHydraulicsDomain" begin
+    for FT in TestFloatTypes
+        Δz = 1.0
+        roots = [FT(1.0), FT(2.0), FT(3.0)]
+        stem = Int64(5)
+        leaves = Int64(4)
+        comp_points = Vector(FT(0.5):FT(1.0):FT(8.5))
+        top_of_compartments = Vector(FT(0.0):FT(1.0):FT(9.0))
+        comp_labels =
+            [:stem, :stem, :stem, :stem, :stem, :leaf, :leaf, :leaf, :leaf]
+        test_tuple = (root = 1, stem = 2, leaf = 3)
+        @test test_tuple[:root] == 1
+
+        testing = PlantHydraulicsDomain(roots, stem, leaves, FT(Δz))
+        @test testing.root_depths == [1.0, 2.0, 3.0]
+        @test testing.n_stem == 5
+        @test testing.n_leaf == 4
+        @test testing.compartment_midpoints == comp_points
+        @test testing.compartment_surfaces == top_of_compartments
+        @test testing.compartment_labels == comp_labels
+        for i in 1:5
+            @test test_tuple[testing.compartment_labels[i]] == 2
+        end
+        for i in 6:9
+            @test test_tuple[testing.compartment_labels[i]] == 3
+        end
+
+        testing2 = PlantHydraulicsDomain(
+            roots,
+            stem,
+            leaves,
+            comp_points,
+            top_of_compartments,
+        )
+        @test testing2.root_depths == [1.0, 2.0, 3.0]
+        @test testing2.n_stem == 5
+        @test testing2.n_leaf == 4
+        @test testing2.compartment_midpoints ==
+              [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5]
+        @test testing2.compartment_surfaces ==
+              [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        @test testing2.compartment_labels == comp_labels
+        for i in 1:5
+            @test test_tuple[testing2.compartment_labels[i]] == 2
+        end
+        for i in 6:9
+            @test test_tuple[testing2.compartment_labels[i]] == 3
+        end
+
+        coords = coordinates(testing)
+        @test coords == comp_points
+    end
+end


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This pull request allows for vegetation to be divided up into an arbitrary amount of stem and leaf layers instead of being hardcoded for one of each, increasing the resolution and accuracy of the plant hydraulics model in the LSM.

## Benefits and Risks
Can choose the number of layers vegetation is divided into when calculating water content.
Increased resolution.
Can choose to have no stem layer compartments.

## Linked Issues

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
