### PR TITLE
included area indexes

### DIFF
--- a/test/LSM/lsm_test.jl
+++ b/test/LSM/lsm_test.jl
@@ -20,7 +20,12 @@ FT = Float64
 @testset " Soil plant hydrology LSM integration test" begin
     saved_values = SavedValues(FT, ClimaCore.Fields.FieldVector)
     earth_param_set = create_lsm_parameters(FT)
-    K_sat = (root = FT(1e-5), stem = FT(1e-3), leaf = FT(1e-3))
+    SAI = FT(0.00242) # Basal area per ground area
+    LAI = FT(4.2) # from Yujie's paper
+    f_root_to_shoot = FT(1.0 / 5.0) # guess
+    RAI = SAI * f_root_to_shoot # following CLM
+    area_index = (root = RAI, stem = SAI, leaf = LAI)
+    K_sat = (root = FT(1e-5), stem = FT(1e-3), leaf = FT(1e-3))# (accelerated) see Kumar, 2008 and
     vg_α = FT(0.24)
     vg_n = FT(2)
     vg_m = FT(1) - FT(1) / vg_n
@@ -46,6 +51,7 @@ FT = Float64
 
     plant_hydraulics_ps =
         PlantHydraulics.PlantHydraulicsParameters{FT, typeof(earth_param_set)}(
+            area_index,
             K_sat,
             vg_α,
             vg_n,

--- a/test/Vegetation/plant_hydraulics_test.jl
+++ b/test/Vegetation/plant_hydraulics_test.jl
@@ -17,6 +17,11 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 FT = Float64
 
 @testset "Plant hydraulics model integration tests" begin
+    SAI = FT(0.00242) # Basal area per ground area
+    LAI = FT(4.2) # from Yujie's paper
+    f_root_to_shoot = FT(1.0 / 5.0) # guess
+    RAI = SAI * f_root_to_shoot # following CLM
+    area_index = (root = RAI, stem = SAI, leaf = LAI)
     K_sat = (root = FT(1e-5), stem = FT(1e-3), leaf = FT(1e-3))# (accelerated) see Kumar, 2008 and
     # Pierre's database for total global plant conductance (1/resistance) 
     # (https://github.com/yalingliu-cu/plant-strategies/blob/master/Product%20details.pdf)
@@ -35,6 +40,7 @@ FT = Float64
         PlantHydraulicsDomain(z_root_depths, n_stem, n_leaf, Δz)
     param_set =
         PlantHydraulics.PlantHydraulicsParameters{FT, typeof(earth_param_set)}(
+            area_index,
             K_sat,
             vg_α,
             vg_n,


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
The purpose of this PR is to include area indexes (RAI, SAI, LAI) to account for the differences in conducting areas of each tree compartment. The area terms had been previously all set to 1m2 for simplicity.

## Benefits and Risks
The model should more accurately represent water fluxes and water content with this addition. 

## Linked Issues
(Provide references to any link issues. Use closes #issuenum to automatically close an open issue)
- Fixes #70

## PR Checklist
- [ x] This PR has a corresponding issue OR is linked to an SDI.
- [ x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [ x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [ x] Unit tests are included OR N/A.
- [ x] Code used in an integration test OR N/A.
- [ x] All tests ran successfully on my local machine OR N/A.
- [ x] All classes, modules, and function contain appropriate docstrings OR N/A.
- [ x] Documentation has been added/updated OR N/A.
