### PR TITLE
bc in shared utilities

### DIFF
--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -11,6 +11,8 @@ import .Parameters as LSMP
 include("SharedUtilities/Domains.jl")
 using .Domains
 include("SharedUtilities/models.jl")
+include("SharedUtilities/boundary_conditions.jl")
+include("SharedUtilities/sources.jl")
 include("Bucket/Bucket.jl")
 
 export domain
@@ -228,7 +230,6 @@ using .Pond
 import .Pond: surface_runoff
 include("Soil/Soil.jl")
 using .Soil
-import .Soil: source!, boundary_flux
 include("Vegetation/PlantHydraulics.jl")
 using .PlantHydraulics
 import .PlantHydraulics: flux_out_roots

--- a/src/SharedUtilities/boundary_conditions.jl
+++ b/src/SharedUtilities/boundary_conditions.jl
@@ -1,0 +1,80 @@
+export boundary_flux,
+    AbstractBC,
+    AbstractBoundary,
+    TopBoundary,
+    BottomBoundary,
+    diffusive_flux,
+    get_Δz
+
+"""
+    AbstractBC{FT <: AbstractFloat}
+An abstract type for types of boundary conditions, which will include
+prescribed functions of space and time as Dirichlet conditions or
+Neumann conditions, in addition to other 
+convenient conditions.
+"""
+abstract type AbstractBC{FT <: AbstractFloat} end
+
+"""
+    AbstractBoundary{}
+An abstract type to indicate which boundary we are doing calculations for.
+Currently, we support the top boundary (TopBoundary)
+and bottom boundary (BottomBoundary).
+"""
+abstract type AbstractBoundary{} end
+
+
+"""
+    TopBoundary{} <: AbstractBoundary{}
+A simple object which should be passed into a function to
+indicate that we are considering the top boundary of the soil.
+"""
+struct TopBoundary <: AbstractBoundary end
+
+"""
+    BottomBoundary{} <: AbstractBoundary{}
+A simple object which should be passed into a function to
+indicate that we are considering the bottom boundary of the soil.
+"""
+struct BottomBoundary <: AbstractBoundary end
+
+"""
+    get_Δz(z::ClimaCore.Fields.Field)
+A function to return a tuple containing the distance between the top boundary
+and its closest center, and the bottom boundary and its closest center, 
+both as Fields.
+"""
+function get_Δz(z::ClimaCore.Fields.Field)
+    # Extract the differences between levels of the face space
+    fs = ClimaLSM.Domains.obtain_face_space(axes(z))
+    z_face = ClimaCore.Fields.coordinate_field(fs).z
+    Δz = ClimaCore.Fields.Δz_field(z_face)
+
+    Δz_top = Fields.level(
+        Δz,
+        ClimaCore.Utilities.PlusHalf(ClimaCore.Spaces.nlevels(fs) - 1),
+    )
+    Δz_bottom = Fields.level(Δz, ClimaCore.Utilities.PlusHalf(0))
+    return Δz_top ./ 2, Δz_bottom ./ 2
+end
+
+"""
+    diffusive_flux(K, x_2, x_1, Δz)
+Calculates the diffusive flux of a quantity x (water content, temp, etc).
+Here, x_2 = x(z + Δz) and x_1 = x(z), so x_2 is at a larger z by convention.
+"""
+function diffusive_flux(K, x_2, x_1, Δz)
+    return @. -K * (x_2 - x_1) / Δz
+end
+
+"""
+    boundary_flux(bc::AbstractBC, bound_type::AbstractBoundary, Δz, _...)::ClimaCore.Fields.Field
+A function which returns the correct boundary flux  given
+    any boundary condition (BC). 
+"""
+function boundary_flux(
+    bc::AbstractBC,
+    bound_type::AbstractBoundary,
+    Δz,
+    _...,
+)::ClimaCore.Fields.Field end

--- a/src/SharedUtilities/sources.jl
+++ b/src/SharedUtilities/sources.jl
@@ -1,0 +1,23 @@
+export source!, AbstractSource
+
+"""
+    AbstractSource{FT <: AbstractFloat}
+An abstract type for types of source terms.
+"""
+abstract type AbstractSource{FT <: AbstractFloat} end
+
+"""
+     source!(dY::ClimaCore.Fields.FieldVector,
+             src::AbstractSource,
+             Y::ClimaCore.Fields.FieldVector,
+             p::ClimaCore.Fields.FieldVector
+             )::ClimaCore.Fields.Field
+A stub function, which is extended by ClimaLSM.
+"""
+function source!(
+    dY::ClimaCore.Fields.FieldVector,
+    src::AbstractSource,
+    Y::ClimaCore.Fields.FieldVector,
+    p::ClimaCore.Fields.FieldVector,
+    _...,
+)::ClimaCore.Fields.Field end

--- a/src/Soil/Soil.jl
+++ b/src/Soil/Soil.jl
@@ -1,4 +1,3 @@
-# To do: add in SoilHeatWaterModel, different boundary conditions, freeze thaw.
 module Soil
 #=
     Soil
@@ -72,15 +71,18 @@ import ClimaLSM:
     auxiliary_vars,
     name,
     prognostic_types,
-    auxiliary_types
+    auxiliary_types,
+    AbstractSource,
+    AbstractBC,
+    source!,
+    boundary_flux
 export RichardsModel,
     RichardsParameters,
     EnergyHydrology,
     EnergyHydrologyParameters,
-    boundary_flux,
-    AbstractBC,
     FluxBC,
     StateBC,
+    FreeDrainage,
     RootExtraction,
     AbstractSoilModel,
     AbstractSoilSource,
@@ -93,14 +95,11 @@ export RichardsModel,
     PhaseChange
 
 """
-    AbstractBC{FT <: AbstractFloat}
+    AbstractSoilBC{FT} <: ClimaLSM. AbstractBC{FT}
 
-An abstract type for types of boundary conditions, which will include
-prescribed functions of space and time as Dirichlet conditions or
-Neumann conditions, in addition to other 
-convenient soil-specific conditions, like free drainage.
+An abstract type for soil-specific types of boundary conditions, like free drainage.
 """
-abstract type AbstractBC{FT <: AbstractFloat} end
+abstract type AbstractSoilBC{FT} <: ClimaLSM.AbstractBC{FT} end
 
 """
     AbstractSoilSource{FT <: AbstractFloat}
@@ -111,7 +110,7 @@ In standalone mode, the only supported source type is freezing and
 thawing. ClimaLSM.jl creates additional sources to include as
 necessary e.g. root extraction (not available in stand alone mode).
 """
-abstract type AbstractSoilSource{FT <: AbstractFloat} end
+abstract type AbstractSoilSource{FT} <: ClimaLSM.AbstractSource{FT} end
 
 """
     AbstractSoilModel{FT} <: AbstractModel{FT} 
@@ -126,15 +125,6 @@ abstract type AbstractSoilModel{FT} <: ClimaLSM.AbstractModel{FT} end
 
 ClimaLSM.name(::AbstractSoilModel) = :soil
 ClimaLSM.domain(::AbstractSoilModel) = :subsurface
-
-"""
-    AbstractBoundary{}
-
-An abstract type to indicate which boundary we are doing calculations for.
-Currently, we support the top boundary (TopBoundary)
-and bottom boundary (BottomBoundary).
-"""
-abstract type AbstractBoundary{} end
 
 """
    horizontal_components!(dY::ClimaCore.Fields.FieldVector,
@@ -160,11 +150,7 @@ the domain type, updates `dY` in place.
 For column domains, no dss is needed.
 """
 function dss!(dY::ClimaCore.Fields.FieldVector, domain::Column) end
-# Todo: consider if we should introduce an AbstractHybridDomain so as 
-# to avoid listing with Union. Possibly not worth it at this point, but if
-# other domains
-# are added or if we end up doing this often, it might be nice. But it may
-# also be nice to be explicit.
+
 """
    dss!(dY::ClimaCore.Fields.FieldVector,domain::Union{HybridBox, SphericalShell})
 
@@ -181,88 +167,65 @@ function dss!(
 end
 
 """
-   StateBC{FT} <: AbstractBC{FT}
+   StateBC{FT} <: AbstractSoilBC{FT}
 
 A simple concrete type of boundary condition, which enforces a
 constant normal state at either the top or bottom of the domain.
 """
-struct StateBC{FT} <: AbstractBC{FT}
+struct StateBC{FT} <: AbstractSoilBC{FT}
     bc::FT
 end
 
 """
-   FluxBC{FT} <: AbstractBC{FT}
+   FluxBC{FT} <: AbstractSoilBC{FT}
 
 A simple concrete type of boundary condition, which enforces a
 constant normal flux at either the top or bottom of the domain.
 """
-struct FluxBC{FT} <: AbstractBC{FT}
+struct FluxBC{FT} <: AbstractSoilBC{FT}
     bc::FT
 end
 
 """
-    TopBoundary{} <: AbstractBoundary{}
+    FreeDrainage{FT} <: AbstractSoilBC{FT}
 
-A simple object which should be passed into a function to
-indicate that we are considering the top boundary of the soil.
+A concrete type of soil boundary condition, for use at 
+the BottomBoundary only, where the flux is set to be
+`F = -K∇h = -K`.
 """
-struct TopBoundary <: AbstractBoundary end
-
-"""
-    BottomBoundary{} <: AbstractBoundary{}
-
-A simple object which should be passed into a function to
-indicate that we are considering the bottom boundary of the soil.
-"""
-struct BottomBoundary <: AbstractBoundary end
+struct FreeDrainage{FT} <: AbstractSoilBC{FT} end
 
 """
-    get_Δz(z)
+    ClimaLSM.boundary_flux(bc::FluxBC, _, Δz, _...)::ClimaCore.Fields.Field
 
-A function to return a tuple containing the distance between the top boundary
-and its closest center, and the bottom boundary and its closest center, 
-both as Fields.
+A method of boundary fluxes which returns the desired flux.
+
+We add a field of zeros in order to convert the bc (float) into
+a field.
 """
-function get_Δz(z)
-    # Extract the differences between levels of the face space
-    fs = ClimaLSM.Domains.obtain_face_space(axes(z))
-    z_face = ClimaCore.Fields.coordinate_field(fs).z
-    Δz = ClimaCore.Fields.Δz_field(z_face)
-
-    Δz_top = Fields.level(
-        Δz,
-        ClimaCore.Utilities.PlusHalf(ClimaCore.Spaces.nlevels(fs) - 1),
-    )
-    Δz_bottom = Fields.level(Δz, ClimaCore.Utilities.PlusHalf(0))
-    return Δz_top ./ 2, Δz_bottom ./ 2
-end
-
-"""
-    diffusive_flux(K, x_2, x_1, Δz)
-
-Calculates the diffusive flux of a quantity x (water content, temp, etc).
-Here, x_2 = x(z + Δz) and x_1 = x(z), so x_2 is at a larger z by convention.
-"""
-function diffusive_flux(K, x_2, x_1, Δz)
-    return @. -K * (x_2 - x_1) / Δz
-end
-
-"""
-    boundary_flux(bc::AbstractBC, bound_type::AbstractBoundary, Δz::FT, _...)
-
-A function which returns the correct boundary flux (of type FluxBC) given
-    any boundary condition (BC) of type `FluxBC` or `StateBC`.
-A StateBC must be converted into a flux value before being returned.
-"""
-function boundary_flux end
-
-# A flux BC requires no conversion calculations
-function boundary_flux(bc::FluxBC, _, Δz, _...)
+function ClimaLSM.boundary_flux(
+    bc::FluxBC{FT},
+    boundary::ClimaLSM.AbstractBoundary,
+    Δz,
+    p,
+    _...,
+)::ClimaCore.Fields.Field where {FT}
     return bc.bc .+ ClimaCore.Fields.zeros(axes(Δz))
 end
 
-# Convert water state to flux at top boundary
-function boundary_flux(rre_bc::StateBC, ::TopBoundary, Δz, p, params)
+"""
+    ClimaLSM.boundary_flux(rre_bc::StateBC, ::ClimaLSM.TopBoundary, Δz, p, params)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which converts a state boundary condition on θ_l at the top of the
+domain into a flux of liquid water.
+"""
+function ClimaLSM.boundary_flux(
+    rre_bc::StateBC,
+    ::ClimaLSM.TopBoundary,
+    Δz,
+    p,
+    params,
+)::ClimaCore.Fields.Field
     # Approximate K_bc ≈ K_c, ψ_bc ≈ ψ_c (center closest to the boundary)
     p_len = Spaces.nlevels(axes(p.soil.K))
     K_c = Fields.level(p.soil.K, p_len)
@@ -273,11 +236,22 @@ function boundary_flux(rre_bc::StateBC, ::TopBoundary, Δz, p, params)
     ψ_bc = @. pressure_head(vg_α, vg_n, vg_m, θ_r, rre_bc.bc, ν, S_s)
 
     # Pass in (ψ_bc .+ Δz) as x_2 to account for contribution of gravity in RRE
-    return diffusive_flux(K_c, ψ_bc .+ Δz, ψ_c, Δz)
+    return ClimaLSM.diffusive_flux(K_c, ψ_bc .+ Δz, ψ_c, Δz)
 end
 
-# Convert water state to flux at bottom boundary
-function boundary_flux(rre_bc::StateBC, ::BottomBoundary, Δz, p, params)
+"""
+    ClimaLSM.boundary_flux(rre_bc::StateBC, ::ClimaLSM.BottomBoundary, Δz, p, params)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which converts a state boundary condition on θ_l at the bottom of the
+domain into a flux of liquid water.
+"""
+function ClimaLSM.boundary_flux(
+    rre_bc::StateBC,
+    ::ClimaLSM.BottomBoundary,
+    Δz,
+    p,
+    params,
+)::ClimaCore.Fields.Field
     # Approximate K_bc ≈ K_c, ψ_bc ≈ ψ_c (center closest to the boundary)
     K_c = Fields.level(p.soil.K, 1)
     ψ_c = Fields.level(p.soil.ψ, 1)
@@ -289,47 +263,66 @@ function boundary_flux(rre_bc::StateBC, ::BottomBoundary, Δz, p, params)
     # At the bottom boundary, ψ_c is at larger z than ψ_bc
     #  so we swap their order in the derivative calc
     # Pass in (ψ_c .+ Δz) as x_2 to account for contribution of gravity in RRE
-    return diffusive_flux(K_c, ψ_c .+ Δz, ψ_bc, Δz)
+    return ClimaLSM.diffusive_flux(K_c, ψ_c .+ Δz, ψ_bc, Δz)
 end
 
-# Convert heat state to flux at top boundary
-function boundary_flux(heat_bc::StateBC, ::TopBoundary, Δz, p)
+"""
+    ClimaLSM.boundary_flux(heat_bc_bc::StateBC, ::ClimaLSM.TopBoundary, Δz, p, params)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which converts a state boundary condition on temperatture at the top of the
+domain into a flux of energy.
+"""
+function ClimaLSM.boundary_flux(
+    heat_bc::StateBC,
+    ::ClimaLSM.TopBoundary,
+    Δz,
+    p,
+)::ClimaCore.Fields.Field
     # Approximate κ_bc ≈ κ_c (center closest to the boundary)
     p_len = Spaces.nlevels(axes(p.soil.T))
     T_c = Fields.level(p.soil.T, p_len)
     κ_c = Fields.level(p.soil.κ, p_len)
 
-    return diffusive_flux(κ_c, heat_bc.bc, T_c, Δz)
+    return ClimaLSM.diffusive_flux(κ_c, heat_bc.bc, T_c, Δz)
 end
 
-# Convert heat state to flux at bottom boundary
-function boundary_flux(heat_bc::StateBC, ::BottomBoundary, Δz, p)
+"""
+    ClimaLSM.boundary_flux(heat_bc_bc::StateBC, ::ClimaLSM.BottomBoundary, Δz, p, params)::ClimaCore.Fields.FieldVector
+
+A method of boundary fluxes which converts a state boundary condition on temperature at the bottom of the
+domain into a flux of energy.
+"""
+function ClimaLSM.boundary_flux(
+    heat_bc::StateBC,
+    ::ClimaLSM.BottomBoundary,
+    Δz,
+    p,
+)::ClimaCore.Fields.Field
     # Approximate κ_bc ≈ κ_c (center closest to the boundary)
     T_c = Fields.level(p.soil.T, 1)
     κ_c = Fields.level(p.soil.κ, 1)
 
     # At the bottom boundary, T_c is at larger z than T_bc
     #  so we swap their order in the derivative calc
-    return diffusive_flux(κ_c, T_c, heat_bc.bc, Δz)
+    return ClimaLSM.diffusive_flux(κ_c, T_c, heat_bc.bc, Δz)
 end
 
 """
-     source!(dY::ClimaCore.Fields.FieldVector,
-             src::AbstractSoilSource,
-             Y::ClimaCore.Fields.FieldVector,
-             p::ClimaCore.Fields.FieldVector
-             )
+    ClimaLSM.boundary_flux(bc::FreeDrainage{FT}, ::ClimaLSM.BottomBoundary, Δz, p, params)::ClimaCore.Fields.Field
 
-A stub function, which is extended by ClimaLSM.
-
+A method of boundary fluxes which enforces free drainage at the bottom
+of the domain.
 """
-function source!(
-    dY::ClimaCore.Fields.FieldVector,
-    src::AbstractSoilSource,
-    Y::ClimaCore.Fields.FieldVector,
-    p::ClimaCore.Fields.FieldVector,
-) end
-
+function ClimaLSM.boundary_flux(
+    bc::FreeDrainage{FT},
+    boundary::ClimaLSM.BottomBoundary,
+    Δz,
+    p,
+    _...,
+)::ClimaCore.Fields.Field where {FT}
+    K_c = Fields.level(p.soil.K, 1)
+    return -1 .* K_c
+end
 """
      heaviside(x::FT)::FT where {FT}
 

--- a/src/Soil/energy_hydrology.jl
+++ b/src/Soil/energy_hydrology.jl
@@ -226,7 +226,7 @@ function ClimaLSM.make_rhs(model::EnergyHydrology{FT}) where {FT}
         horizontal_components!(dY, model.domain, model, p, z)
 
         for src in model.sources
-            source!(dY, src, Y, p)
+            ClimaLSM.source!(dY, src, Y, p)
         end
 
         # This has to come last
@@ -389,7 +389,7 @@ end
 Computes the source terms for phase change.
 
 """
-function source!(
+function ClimaLSM.source!(
     dY::ClimaCore.Fields.FieldVector,
     src::PhaseChange{FT},
     Y::ClimaCore.Fields.FieldVector,

--- a/src/Soil/rre.jl
+++ b/src/Soil/rre.jl
@@ -134,7 +134,7 @@ function ClimaLSM.make_rhs(model::RichardsModel)
 
         # Source terms
         for src in model.sources
-            source!(dY, src, Y, p)
+            ClimaLSM.source!(dY, src, Y, p)
         end
 
         # This has to come last

--- a/src/pond_soil_model.jl
+++ b/src/pond_soil_model.jl
@@ -61,7 +61,7 @@ function LandHydrology{FT}(;
     sources = ()
     surface_runoff = PrognosticRunoff{FT}(precip)
     boundary_conditions =
-        (; water = (top = RunoffBC{FT}(), bottom = FluxBC(FT(0.0))))
+        (; water = (top = RunoffBC{FT}(), bottom = Soil.FreeDrainage{FT}()))
 
     soil = soil_model_type(;
         boundary_conditions = boundary_conditions,
@@ -228,9 +228,9 @@ function Pond.surface_runoff(
 end
 
 """
-    RunoffBC{FT} <: Soil.AbstractBC{FT}
+    RunoffBC{FT} <: Soil.AbstractSoilBC{FT}
 
-Concrete type of `Soil.AbstractBC` for use in LSM models,
+Concrete type of `Soil.AbstractSoilBC` for use in LSM models,
 where precipitation is passed in, but infiltration is computed
 prognostically. This infiltration is then used to set an upper
 boundary condition for the soil.
@@ -241,23 +241,23 @@ time,
 ensuring that the infiltration used for the boundary condition of soil
 is also used to compute the runoff for the surface water.
 """
-struct RunoffBC{FT} <: Soil.AbstractBC{FT} end
+struct RunoffBC{FT} <: Soil.AbstractSoilBC{FT} end
 
 """
-    function boundary_flux(
+    function ClimaLSM.boundary_flux(
         bc::RunoffBC{FT},
         _::TopBoundary,
         p::ClimaCore.Fields.FieldVector,
         t::FT,
     ) where {FT}
 
-Extension of the `Soil.boundary_flux` function, which returns the water volume
+Extension of the `ClimaLSM.boundary_flux` function, which returns the water volume
 boundary flux for the soil.
 At the top boundary, return the soil infiltration (computed each step and
 stored in `p.soil_infiltration`).
 At the bottom boundary, assume no flux.
 """
-function Soil.boundary_flux(
+function ClimaLSM.boundary_flux(
     _::RunoffBC{FT},
     _::TopBoundary,
     _,
@@ -265,11 +265,4 @@ function Soil.boundary_flux(
     _...,
 ) where {FT}
     return p.soil_infiltration
-end
-
-"""
-
-"""
-function boundary_flux(_::RunoffBC{FT}, _::BottomBoundary, _...) where {FT}
-    return FT(0)
 end

--- a/src/soil_plant_hydrology_model.jl
+++ b/src/soil_plant_hydrology_model.jl
@@ -204,17 +204,17 @@ from the soil.
 struct RootExtraction{FT} <: Soil.AbstractSoilSource{FT} end
 
 """
-    Soil.source!(dY::ClimaCore.Fields.FieldVector,
+    ClimaLSM.source!(dY::ClimaCore.Fields.FieldVector,
                           src::RootExtraction{FT},
                           Y::ClimaCore.Fields.FieldVector,
                           p::ClimaCore.Fields.FieldVector)::ClimaCore.Fields.Field  where {FT}
 
-An extension of the `Soil.source!` function,
+An extension of the `ClimaLSM.source!` function,
  which computes source terms for the 
 soil model; this method returns the water loss or gain due
 to roots when a plant hydraulic prognostic model is included.
 """
-function Soil.source!(
+function ClimaLSM.source!(
     dY::ClimaCore.Fields.FieldVector,
     src::RootExtraction{FT},
     Y::ClimaCore.Fields.FieldVector,


### PR DESCRIPTION

## Purpose 
Add boundary condition and source utilities to SharedUtilities. Then they are able to be used by other models besides soil.

It would be nice to move as much as possible over, but unless we come up with more general way of handling stateBC (e.g. for models with purely diffusive fluxes), those methods will live in individual modules.


## To-do
discuss with Julia :)


## Content

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [x] I have read and checked the items on the review checklist.
