### PR TITLE
Refactor climate drivers

### DIFF
--- a/docs/src/APIs/Bucket.md
+++ b/docs/src/APIs/Bucket.md
@@ -7,23 +7,14 @@ CurrentModule = ClimaLSM.Bucket
 
 ```@docs
 ClimaLSM.Bucket.BucketModelParameters
-ClimaLSM.Bucket.PrescribedAtmosphere
-ClimaLSM.Bucket.PrescribedRadiativeFluxes
-ClimaLSM.Bucket.AbstractAtmosphericDrivers
-ClimaLSM.Bucket.AbstractRadiativeDrivers
 ClimaLSM.Bucket.BulkAlbedoMap
 ClimaLSM.Bucket.BulkAlbedoFunction
 ClimaLSM.Bucket.BucketModel
 ```
 
-## Extendible Methods
+## Misc Functions
 
 ```@docs
-ClimaLSM.Bucket.surface_fluxes
-ClimaLSM.Bucket.net_radiation
-ClimaLSM.Bucket.surface_air_density
-ClimaLSM.Bucket.liquid_precipitation
-ClimaLSM.Bucket.snow_precipitation
 ClimaLSM.Bucket.surface_albedo
 ClimaLSM.Bucket.beta_factor
 ```

--- a/docs/src/APIs/SharedUtilities.md
+++ b/docs/src/APIs/SharedUtilities.md
@@ -50,3 +50,16 @@ ClimaLSM.boundary_flux
 ClimaLSM.diffusive_flux
 ClimaLSM.get_Δz
 ```
+
+## Drivers
+```@docs
+ClimaLSM.Drivers.PrescribedAtmosphere
+ClimaLSM.Drivers.PrescribedRadiativeFluxes
+ClimaLSM.Drivers.AbstractAtmosphericDrivers
+ClimaLSM.Drivers.AbstractRadiativeDrivers
+ClimaLSM.Drivers.surface_fluxes_at_a_point
+ClimaLSM.Drivers.radiative_fluxes_at_a_point
+ClimaLSM.Drivers.construct_atmos_ts
+ClimaLSM.Drivers.surface_air_density
+ClimaLSM.Drivers.liquid_precipitation
+ClimaLSM.Drivers.snow_precipitation

--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -133,12 +133,9 @@ import CLIMAParameters as CP
 
 # Lastly, let's bring in the bucket model types (from ClimaLSM) that we
 # will need access to.
-using ClimaLSM.Bucket:
-    BucketModel,
-    BucketModelParameters,
-    PrescribedAtmosphere,
-    PrescribedRadiativeFluxes,
-    BulkAlbedoFunction
+using ClimaLSM.Drivers: PrescribedAtmosphere, PrescribedRadiativeFluxes
+
+using ClimaLSM.Bucket: BucketModel, BucketModelParameters, BulkAlbedoFunction
 using ClimaLSM.Domains: coordinates, LSMSingleColumnDomain
 using ClimaLSM:
     initialize, make_update_aux, make_ode_function, make_set_initial_aux_state
@@ -210,9 +207,7 @@ bucket_domain =
 # radiative energy fluxes (`SW↓, LW↓`, W/m^2),
 # for the atmospheric temperature `T_a`,
 # wind speed `u_a` (m/s), specific humidity `q_a`, and air density
-# `ρ_a` (kg/m^3) at a reference height `h_a` (m),
-# as well as for the air density `ρ_sfc` (kg/m^3)
-# at the surface of the earth.
+# `ρ_a` (kg/m^3) at a reference height `h_a` (m).
 
 # Here we define the model drivers, starting with downward radiation.
 SW_d = (t) -> eltype(t)(300);
@@ -231,7 +226,6 @@ u_atmos = (t) -> eltype(t)(3.0);
 q_atmos = (t) -> eltype(t)(0.005);
 h_atmos = FT(2);
 ρ_atmos = (t) -> eltype(t)(1.13);
-ρ_sfc = FT(1.15);
 bucket_atmos = PrescribedAtmosphere(
     precip,
     snow_precip,
@@ -240,7 +234,6 @@ bucket_atmos = PrescribedAtmosphere(
     q_atmos,
     ρ_atmos,
     h_atmos,
-    ρ_sfc,
 );
 
 # Then, we create the model object, which contains the drivers, parameters,

--- a/docs/tutorials/Bucket/coupled_bucket.jl
+++ b/docs/tutorials/Bucket/coupled_bucket.jl
@@ -17,9 +17,7 @@
 # radiative energy fluxes,
 # for the atmospheric temperature `T_a`,
 # wind speed `u_a` (m/s), specific humidity `q_a`, and air density
-# `ρ_a` (kg/m^3) at a reference height `h_a` (m),
-# as well as for the air density `ρ_sfc` (kg/m^3)
-# at the surface of the earth.
+# `ρ_a` (kg/m^3) at a reference height `h_a` (m).
 
 # Turbulent surface fluxes are computed by the bucket model at each step of the
 # simulation, using the land surface properties
@@ -50,11 +48,8 @@
 
 # To begin, let's import some necessary abstract and concrete types, as well as methods.
 using ClimaLSM
-using ClimaLSM.Bucket:
-    BucketModel,
-    BucketModelParameters,
-    AbstractAtmosphericDrivers,
-    AbstractRadiativeDrivers
+using ClimaLSM.Drivers: AbstractAtmosphericDrivers, AbstractRadiativeDrivers
+using ClimaLSM.Bucket: BucketModel, BucketModelParameters
 
 import ClimaLSM.Bucket:
     surface_fluxes,
@@ -87,11 +82,10 @@ struct CoupledRadiativeFluxes{FT} <: AbstractRadiativeDrivers{FT} end
 
 # Then, we define a new method for `surface_fluxes` and `net_radiation` which dispatch for these types:
 function ClimaLSM.Bucket.surface_fluxes(
-    Y,
+    atmos::CoupledAtmosphere{FT},
     p,
     t,
-    parameters,
-    atmos::CoupledAtmosphere{FT},
+    _...,
 ) where {FT <: AbstractFloat}
     return (
         turbulent_energy_flux = p.bucket.turbulent_energy_flux,
@@ -101,11 +95,10 @@ end
 
 
 function ClimaLSM.Bucket.net_radiation(
-    Y,
+    radiation::CoupledRadiativeFluxes{FT},
     p,
     t,
-    parameters,
-    radiation::CoupledRadiativeFluxes{FT},
+    _...,
 ) where {FT <: AbstractFloat}
     return p.bucket.R_n
 end
@@ -124,15 +117,15 @@ end
 # return the prescribed values for these quantities.
 
 # In the coupled case, we need to extend these functions with a `CoupledAtmosphere` method:
-function ClimaLSM.Bucket.surface_air_density(p, atmos::CoupledAtmosphere)
+function ClimaLSM.Bucket.surface_air_density(atmos::CoupledAtmosphere, p, _...)
     return p.bucket.ρ_sfc
 end
 
-function ClimaLSM.Bucket.liquid_precipitation(p, atmos::CoupledAtmosphere, t)
+function ClimaLSM.Bucket.liquid_precipitation(atmos::CoupledAtmosphere, p, _)
     return p.bucket.P_liq
 end
 
-function ClimaLSM.Bucket.snow_precipitation(p, atmos::CoupledAtmosphere, t)
+function ClimaLSM.Bucket.snow_precipitation(atmos::CoupledAtmosphere, p, _)
     return p.bucket.P_snow
 end
 

--- a/src/Bucket/bucket_parameterizations.jl
+++ b/src/Bucket/bucket_parameterizations.jl
@@ -1,18 +1,6 @@
 """
-     heaviside(x::FT)::FT where {FT}
-
-Computes the heaviside function.
-"""
-function heaviside(x::FT)::FT where {FT}
-    if x > eps(FT)
-        return FT(1.0)
-    else
-        return FT(0.0)
-    end
-end
-
-"""
     beta_factor(W::FT, σS::FT, W_f::FT) where {FT}
+
 Computes the beta factor which scales the evaporation from the potential
 rate.
 """

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -11,6 +11,9 @@ import .Parameters as LSMP
 include("Regridder.jl")
 include("SharedUtilities/Domains.jl")
 using .Domains
+include("SharedUtilities/Drivers.jl")
+using .Drivers
+include("SharedUtilities/utils.jl")
 include("SharedUtilities/models.jl")
 include("SharedUtilities/boundary_conditions.jl")
 include("SharedUtilities/sources.jl")

--- a/src/SharedUtilities/Drivers.jl
+++ b/src/SharedUtilities/Drivers.jl
@@ -1,0 +1,323 @@
+module Drivers
+using Thermodynamics
+using ClimaCore
+using DocStringExtensions
+using UnPack
+using SurfaceFluxes
+using StaticArrays
+import ..Parameters as LSMP
+export AbstractAtmosphericDrivers,
+    AbstractRadiativeDrivers,
+    PrescribedAtmosphere,
+    PrescribedRadiativeFluxes,
+    compute_ρ_sfc,
+    construct_atmos_ts,
+    surface_fluxes_at_a_point,
+    radiative_fluxes_at_a_point,
+    liquid_precipitation,
+    snow_precipitation,
+    surface_air_density
+
+"""
+     AbstractAtmosphericDrivers{FT <: AbstractFloat}
+
+An abstract type of atmospheric drivers of the bucket model.
+"""
+abstract type AbstractAtmosphericDrivers{FT <: AbstractFloat} end
+
+"""
+     AbstractRadiativeDrivers{FT <: AbstractFloat}
+
+An abstract type of radiative drivers of the bucket model.
+"""
+abstract type AbstractRadiativeDrivers{FT <: AbstractFloat} end
+
+"""
+    PrescribedAtmosphere{FT, LP, SP, TA, UA, QA, RA} <: AbstractAtmosphericDrivers{FT}
+
+Container for holding prescribed atmospheric drivers and other
+information needed for computing turbulent surface fluxes when
+driving the bucket model in standalone mode.
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedAtmosphere{FT, LP, SP, TA, UA, QA, RA} <:
+       AbstractAtmosphericDrivers{FT}
+    "Precipitation (m/s) function of time: positive by definition"
+    liquid_precip::LP
+    "Snow precipitation (m/s) function of time: positive by definition"
+    snow_precip::SP
+    "Prescribed atmospheric temperature (function of time)  at the reference height (K)"
+    T::TA
+    "Prescribed wind speed (function of time)  at the reference height (m/s)"
+    u::UA
+    "Prescribed specific humidity (function of time)  at the reference height (_)"
+    q::QA
+    "Prescribed air density (function of time)  at the reference height (kg/m^3)"
+    ρ::RA
+    "Reference height, relative to surface elevation(m)"
+    h::FT
+    function PrescribedAtmosphere(liquid_precip, snow_precip, T, u, q, ρ, h)
+        args = (liquid_precip, snow_precip, T, u, q, ρ)
+        return new{typeof(h), typeof.(args)...}(args..., h)
+    end
+
+end
+
+"""
+    compute_ρ_sfc(thermo_params, ts_in, T_sfc)
+
+Computes the density of air at the surface, given the temperature
+at the surface T_sfc, the thermodynamic state of the atmosphere,
+ts_in, and a set of Clima.Thermodynamics parameters thermo_params.
+
+This assumes the ideal gas law and hydrostatic balance to
+extrapolate to the surface.
+
+"""
+function compute_ρ_sfc(thermo_params, ts_in, T_sfc)
+    T_int = Thermodynamics.air_temperature(thermo_params, ts_in)
+    Rm_int = Thermodynamics.gas_constant_air(thermo_params, ts_in)
+    ρ_air = Thermodynamics.air_density(thermo_params, ts_in)
+    ρ_sfc =
+        ρ_air *
+        (T_sfc / T_int)^(Thermodynamics.cv_m(thermo_params, ts_in) / Rm_int)
+    return ρ_sfc
+end
+
+"""
+    construct_atmos_ts(
+        atmos::PrescribedAtmosphere,
+        t::FT,
+        thermo_params,
+    ) where {FT}
+
+A helper function which constructs a Clima.Thermodynamics
+thermodynamic state given a PrescribedAtmosphere, a time
+at which the state is needed, and a set of Clima.Thermodynamics
+parameters thermo_params.
+"""
+function construct_atmos_ts(
+    atmos::PrescribedAtmosphere,
+    t::FT,
+    thermo_params,
+) where {FT}
+    ρ::FT = atmos.ρ(t)
+    T::FT = atmos.T(t)
+    q::FT = atmos.q(t)
+    ts_in = Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ, T, q)
+    return ts_in
+end
+
+
+"""
+    surface_fluxes(
+        atmos::PrescribedAtmosphere{FT},
+        p::ClimaCore.Fields.FieldVector,
+        t::FT,
+        name::Symbol
+        parameters;
+        β_sfc = FT(1.0)
+    ) where {FT <: AbstractFloat}
+
+Computes the turbulent surface flux terms at the ground for a standalone simulation,
+including turbulent energy fluxes as well as the water vapor flux 
+(in units of m^3/m^2/s of water).
+Positive fluxes indicate flow from the ground to the atmosphere.
+
+It solves for these given atmospheric conditions, stored in `atmos`,
+model parameters, and the surface conditions which
+are stored in the `aux` state at p.name.T_sfc, p.name.q_sfc,
+and p.name.ρ_sfc. 
+
+β_sfc is a factor which scales the evaporation away from the potential
+rate and has a default value of one. We may eventually store this in the aux
+state as well.
+"""
+function surface_fluxes(
+    atmos::PrescribedAtmosphere{FT},
+    p::ClimaCore.Fields.FieldVector,
+    t::FT,
+    name::Symbol,
+    parameters;
+    β_sfc = FT(1.0),
+) where {FT <: AbstractFloat}
+    return surface_fluxes_at_a_point.(
+        getproperty(p, name).T_sfc,
+        getproperty(p, name).q_sfc,
+        getproperty(p, name).ρ_sfc,
+        t,
+        β_sfc,
+        Ref(parameters),
+        Ref(atmos),
+    )
+end
+
+"""
+    surface_fluxes_at_a_point(
+        T_sfc::FT,
+        q_sfc::FT,
+        ρ_sfc::FT,
+        t::FT,
+        β_sfc::FT,
+        parameters,
+        atmos::PA,
+) where {FT <: AbstractFloat, PA <: PrescribedAtmosphere{FT}}
+
+Computes turbulent surface fluxes at a point on a surface given
+(1) the surface temperature, specific humidity, and air density,
+(2) the time at which the fluxes are needed,
+(3) a factor β_sfc  which scales the evaporation from the potential rate,
+(4) the parameter set for the model, which must have fields `earth_param_set`,
+and roughness lengths `z_0m, z_0b`.
+(5) the prescribed atmospheric state, stored in `atmos`.
+
+This returns an energy flux and a liquid water volume flux, stored in
+a tuple with self explanatory keys.
+"""
+function surface_fluxes_at_a_point(
+    T_sfc::FT,
+    q_sfc::FT,
+    ρ_sfc::FT,
+    t::FT,
+    β_sfc::FT,
+    parameters::P,
+    atmos::PA,
+) where {FT <: AbstractFloat, P, PA <: PrescribedAtmosphere{FT}}
+    @unpack z_0m, z_0b, earth_param_set = parameters
+    _ρ_liq = LSMP.ρ_cloud_liq(earth_param_set)
+    thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
+
+    u::FT = atmos.u(t)
+    h::FT = atmos.h
+
+    ts_in = construct_atmos_ts(atmos, t, thermo_params)
+    ts_sfc = Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sfc)
+
+    # h is relative to surface height, so we can set surface height to zero.
+    state_sfc = SurfaceFluxes.SurfaceValues(FT(0), SVector{2, FT}(0, 0), ts_sfc)
+    state_in = SurfaceFluxes.InteriorValues(h, SVector{2, FT}(u, 0), ts_in)
+
+    # State containers
+    sc = SurfaceFluxes.ValuesOnly{FT}(;
+        state_in,
+        state_sfc,
+        z0m = z_0m,
+        z0b = z_0b,
+        beta = β_sfc,
+    )
+    surface_flux_params = LSMP.surface_fluxes_parameters(earth_param_set)
+    conditions = SurfaceFluxes.surface_conditions(surface_flux_params, sc)
+
+    # Land needs a volume flux of water, not mass flux
+    evaporation =
+        SurfaceFluxes.evaporation(surface_flux_params, sc, conditions.Ch) /
+        _ρ_liq
+    return (
+        turbulent_energy_flux = conditions.lhf .+ conditions.shf,
+        evaporation = evaporation,
+    )
+end
+
+"""
+    PrescribedRadiativeFluxes{FT, SW, LW} <: AbstractRadiativeDrivers{FT}
+
+Container for the prescribed radiation functions needed to drive the
+bucket model in standalone mode.
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedRadiativeFluxes{FT, SW, LW} <: AbstractRadiativeDrivers{FT}
+    "Downward shortwave radiation function of time (W/m^2): positive indicates towards surface"
+    SW_d::SW
+    "Downward longwave radiation function of time (W/m^2): positive indicates towards surface"
+    LW_d::LW
+end
+
+PrescribedRadiativeFluxes(FT, SW_d, LW_d) =
+    PrescribedRadiativeFluxes{FT, typeof(SW_d), typeof(LW_d)}(SW_d, LW_d)
+
+
+
+"""
+    net_radiation(
+        radiation::PrescribedRadiativeFluxes{FT},
+        p::ClimaCore.Fields.FieldVector,
+        t::FT,
+        name::Symbol,
+        α,
+        ϵ,
+        earth_param_set,
+    ) where {FT <: AbstractFloat}
+
+Computes net radiative fluxes at the surface given
+(1) the aux state, which stores T_sfc
+(2) the albedo and emissivity - TODO: store in aux
+(3) the time at which the fluxes are needed,
+(4) the `earth_param_set`
+(5) the prescribed radiation state, stored in `radiation`.
+
+This returns an energy flux.
+"""
+function net_radiation(
+    radiation::PrescribedRadiativeFluxes{FT},
+    p::ClimaCore.Fields.FieldVector,
+    t::FT,
+    name::Symbol,
+    α,
+    ϵ,
+    earth_param_set,
+) where {FT <: AbstractFloat}
+    LW_d::FT = radiation.LW_d(t)
+    SW_d::FT = radiation.SW_d(t)
+    _σ = LSMP.Stefan(earth_param_set)
+    T_sfc = getproperty(p, name).T_sfc
+    # Recall that the user passed the LW and SW downwelling radiation,
+    # where positive values indicate toward surface, so we need a negative sign out front
+    # in order to inidicate positive R_n  = towards atmos.
+    R_n = @.(-(1 - α) * SW_d - ϵ * (LW_d - _σ * T_sfc^4))
+    return R_n
+end
+
+
+
+"""
+    liquid_precipitation(atmos::PrescribedAtmosphere, p, t)
+
+Returns the liquid precipitation (m/s) at the surface.
+"""
+function liquid_precipitation(atmos::PrescribedAtmosphere, p, t)
+    return atmos.liquid_precip(t)
+end
+
+"""
+    snow_precipitation(atmos::PrescribedAtmosphere, p, t)
+
+Returns the precipitation in snow (m of liquid water/s) at the surface.
+"""
+function snow_precipitation(atmos::PrescribedAtmosphere, p, t)
+    return atmos.snow_precip(t)
+end
+
+"""
+    surface_air_density(atmos::PrescribedAtmosphere,
+                        p,
+                        t,
+                        name::Symbol,
+                        earth_param_set,
+                        )
+
+Returns the air density (kg/m^3) at the surface.
+"""
+function surface_air_density(
+    atmos::PrescribedAtmosphere,
+    p,
+    t,
+    name::Symbol,
+    earth_param_set,
+)
+    thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
+    ts_in = construct_atmos_ts(atmos, t, thermo_params)
+    compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), getproperty(p, name).T_sfc)
+end
+
+
+end

--- a/src/SharedUtilities/utils.jl
+++ b/src/SharedUtilities/utils.jl
@@ -1,0 +1,12 @@
+"""
+     heaviside(x::FT)::FT where {FT}
+
+Computes the heaviside function.
+"""
+function heaviside(x::FT)::FT where {FT}
+    if x >= FT(0.0)
+        return FT(1.0)
+    else
+        return FT(0.0)
+    end
+end

--- a/src/Snow/Snow.jl
+++ b/src/Snow/Snow.jl
@@ -7,7 +7,6 @@ export SnowParameters
 
 """
     SnowParameters{FT <: AbstractFloat, PSE}
-
 A struct for storing parameters of the `SnowModel`.
 $(DocStringExtensions.FIELDS)
 """
@@ -15,11 +14,9 @@ struct SnowParameters{FT <: AbstractFloat, PSE}
     "Density of snow (kg/m^3)"
     ρ_snow::FT
     "Roughness length over snow for momentum (m)"
-    z0_m::FT
+    z_0m::FT
     "Roughness length over snow for scalars (m)"
-    z0_b::FT
-    "Displacement height over snow (m)"
-    d::FT
+    z_0b::FT
     "Albedo of snow (unitless)"
     α_snow::FT
     "Emissivity of snow (unitless)"
@@ -41,9 +38,8 @@ end
 """
    SnowParameters{FT}(Δt::FT;
                       ρ_snow = FT(200),
-                      z0_m = FT(0.0024),
-                      z0_b = FT(0.00024),
-                      d = FT(0),
+                      z_0m = FT(0.0024),
+                      z_0b = FT(0.00024),
                       α_snow = FT(0.8),
                       ϵ_snow = FT(0.99),
                       θ_r = FT(0.08),
@@ -58,9 +54,8 @@ all arguments but `earth_param_set`.
 function SnowParameters{FT}(
     Δt::FT;
     ρ_snow = FT(200),
-    z0_m = FT(0.0024),
-    z0_b = FT(0.00024),
-    d = FT(0),
+    z_0m = FT(0.0024),
+    z_0b = FT(0.00024),
     α_snow = FT(0.8),
     ϵ_snow = FT(0.99),
     θ_r = FT(0.08),
@@ -71,9 +66,8 @@ function SnowParameters{FT}(
 ) where {FT, PSE}
     return SnowParameters{FT, PSE}(
         ρ_snow,
-        z0_m,
-        z0_b,
-        d,
+        z_0m,
+        z_0b,
         α_snow,
         ϵ_snow,
         θ_r,

--- a/src/Soil/Soil.jl
+++ b/src/Soil/Soil.jl
@@ -75,7 +75,8 @@ import ClimaLSM:
     AbstractSource,
     AbstractBC,
     source!,
-    boundary_flux
+    boundary_flux,
+    heaviside
 export RichardsModel,
     RichardsParameters,
     EnergyHydrology,
@@ -328,18 +329,6 @@ function ClimaLSM.boundary_flux(
     return -1 .* K_c
 end
 
-"""
-     heaviside(x::FT)::FT where {FT}
-
-Computes the heaviside function.
-"""
-function heaviside(x::FT)::FT where {FT}
-    if x > eps(FT)
-        return FT(1.0)
-    else
-        return FT(0.0)
-    end
-end
 include("./rre.jl")
 include("./energy_hydrology.jl")
 include("./soil_hydrology_parameterizations.jl")

--- a/test/Bucket/albedo_map_bucket.jl
+++ b/test/Bucket/albedo_map_bucket.jl
@@ -7,12 +7,12 @@ import CLIMAParameters as CP
 if !("." in LOAD_PATH)
     push!(LOAD_PATH, ".")
 end
+using ClimaLSM.Drivers: PrescribedAtmosphere, PrescribedRadiativeFluxes
+
 using ClimaLSM.Regridder: MapInfo, regrid_netcdf_to_field
 using ClimaLSM.Bucket:
     BucketModel,
     BucketModelParameters,
-    PrescribedAtmosphere,
-    PrescribedRadiativeFluxes,
     BulkAlbedoMap,
     bareground_albedo_dataset_path
 using ClimaLSM.Domains:
@@ -66,7 +66,6 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         q_atmos = (t) -> eltype(t)(0.0) # no atmos water
         h_atmos = FT(1e-8)
         ρ_atmos = (t) -> eltype(t)(1.13)
-        ρ_sfc = FT(1.15)
         bucket_atmos = PrescribedAtmosphere(
             precip,
             precip,
@@ -75,7 +74,6 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
             q_atmos,
             ρ_atmos,
             h_atmos,
-            ρ_sfc,
         )
         Δt = FT(1.0)
         bucket_parameters = BucketModelParameters(

--- a/test/Snow/parameterizations.jl
+++ b/test/Snow/parameterizations.jl
@@ -17,10 +17,8 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     _ρ_l = FT(LSMP.ρ_cloud_liq(param_set))
     # Density of ice water (kg/m``^3``)
     _ρ_i = FT(LSMP.ρ_cloud_ice(param_set))
-    # Volum. isobaric heat capacity liquid water (J/m3/K)
-    _ρcp_l = FT(LSMP.cp_l(param_set) * _ρ_l)
-    # Volumetric isobaric heat capacity ice (J/m3/K)
-    _ρcp_i = FT(LSMP.cp_i(param_set) * _ρ_i)
+    _cp_l = FT(LSMP.cp_l(param_set))
+    _cp_i = FT(LSMP.cp_i(param_set))
     # Reference temperature (K)
     _T_ref = FT(LSMP.T_0(param_set))
     # Freezing temperature (K)
@@ -31,25 +29,21 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     κ_air = FT(LSMP.K_therm(param_set))
 
     ρ_snow = FT(200)
-    z0_m = FT(0.0024)
-    z0_b = FT(0.00024)
-    d = FT(0.0)
+    z_0m = FT(0.0024)
+    z_0b = FT(0.00024)
     α_snow = FT(0.8)
     ϵ_snow = FT(0.99)
     θ_r = FT(0.08)
     Ksat = FT(1e-3)
-    fS_c = FT(0.2)
     κ_ice = FT(2.21)
     Δt = FT(180.0)
     parameters = SnowParameters{FT}(Δt; earth_param_set = param_set)
     @test parameters.ρ_snow == ρ_snow
     @test typeof(parameters.ρ_snow) == FT
-    @test parameters.z0_m == z0_m
-    @test typeof(parameters.z0_m) == FT
-    @test parameters.z0_b == z0_b
-    @test typeof(parameters.z0_b) == FT
-    @test parameters.d == d
-    @test typeof(parameters.d) == FT
+    @test parameters.z_0m == z_0m
+    @test typeof(parameters.z_0m) == FT
+    @test parameters.z_0b == z_0b
+    @test typeof(parameters.z_0b) == FT
     @test parameters.α_snow == α_snow
     @test typeof(parameters.α_snow) == FT
     @test parameters.ϵ_snow == ϵ_snow
@@ -58,8 +52,6 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     @test typeof(parameters.Ksat) == FT
     @test parameters.θ_r == θ_r
     @test typeof(parameters.θ_r) == FT
-    @test parameters.fS_c == fS_c
-    @test typeof(parameters.fS_c) == FT
     @test parameters.κ_ice == κ_ice
     @test typeof(parameters.κ_ice) == FT
 
@@ -75,10 +67,8 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     SWE = cat(FT.(rand(100) .+ 0.2), FT(0), dims = 1)
     z = snow_depth.(SWE, ρ_snow, _ρ_l)
     @test all(z .== SWE * _ρ_l ./ ρ_snow)
-    @test specific_heat_capacity(FT(1.0), parameters) ==
-          FT(LSMP.cp_l(parameters.earth_param_set))
-    @test specific_heat_capacity(FT(0.0), parameters) ==
-          FT(LSMP.cp_i(parameters.earth_param_set))
+    @test specific_heat_capacity(FT(1.0), parameters) == _cp_l
+    @test specific_heat_capacity(FT(0.0), parameters) == _cp_i
     @test snow_thermal_conductivity(ρ_snow, parameters) ==
           κ_air +
           (FT(7.75e-5) * ρ_snow + FT(1.105e-6) * ρ_snow^2) * (κ_ice - κ_air)


### PR DESCRIPTION
## Background 

In the current version of the repo, the Bucket model makes use of a `PrescribedAtmos` and `PrescribedRadiation` struct for storing the prescribed "driver" functions for running the bucket model in standalone mode. These contain the downwards LW and SW radiation, as functions of time, as well as precipitation, q_atmos, T_atmos, u_atmos, rho_atmos, and the height at which these quantities are measured.

Given this, the bucket model has everything it needs to compute turbulent surface fluxes and a net radiation (as the bucket model provides its own roughness lengths, albedo, and emissivity). These are computed by the functions `surface_fluxes` and `net_radiation`, which are called in `update_aux!` to update the stored values of p.bucket.turbulent_surface_fluxes, p.bucket.evaporation and p.bucket.R_n, which get used in the rhs function as boundary conditions. Note that `surface_fluxes` is a wrapper function - it broadcasts `surface_fluxes_at_a_point` over the input fields. Currently the same is true for `net_radiation`.
E.g: https://github.com/CliMA/ClimaLSM.jl/blob/ff1212db13ad5aff7eff69d7cee6fbebcbfb2f1a/src/Bucket/Bucket.jl#L235, 
https://github.com/CliMA/ClimaLSM.jl/blob/ff1212db13ad5aff7eff69d7cee6fbebcbfb2f1a/src/Bucket/Bucket.jl#L552,
E.g. https://github.com/CliMA/ClimaLSM.jl/blob/ff1212db13ad5aff7eff69d7cee6fbebcbfb2f1a/src/Bucket/Bucket.jl#L531,
https://github.com/CliMA/ClimaLSM.jl/blob/ff1212db13ad5aff7eff69d7cee6fbebcbfb2f1a/src/Bucket/Bucket.jl#L731

If the first argument of the `net_radiation` and `surface_fluxes` is of type `Prescribed`, the land model computes its own fluxes. If the first argument is of type `Coupled`, the method will return the fields in `p` directly under the assumption that the coupler has already filled them in. For example, here is the code where the coupler extends the ClimaLSM method and adds a new `Coupled` type: https://github.com/CliMA/ClimaCoupler.jl/blob/4b17a28ad2e225d031990a5b43c1baa240b8d650/experiments/AMIP/moist_mpi_earth/bucket/bucket_init.jl#L41
https://github.com/CliMA/ClimaCoupler.jl/blob/4b17a28ad2e225d031990a5b43c1baa240b8d650/experiments/AMIP/moist_mpi_earth/bucket/bucket_init.jl#L82

## Purpose 
**Main file to review is src/SharedUtilties/Drivers.jl**

This PR moves all of this machinery from ClimaLSM.Bucket into a module stored in src/SharedUtilities/Drivers.jl, in the anticipation that the Snow model will want to run in standalone mode, as will the soil model, etc, and we dont want to redefine all of these surface flux computations etc for each model. It also anticipates that each model will have stored "p.X.T_sfc, p.X.q_sfc, p.X.\rho_sfc, p.X.alpha, p.X.epsilon", where X is the name of the model. This seems generic enough - a model has to specify these to compute surface fluxes, though it is overkill to store a field of floats if e.g. emissivity is 1 everywhere. But in the long run, for a varied land surface, this makes sense.

We have changed the ordering of the arguments so that all of these methods get `(atmos, p, t)` or `(radiation, p, t)` first. This is a breaking change for the coupled runs. Those methods need to be redefined to take arguments `(atmos, p, t, _...)` and `(radiation,p,t,_...)`.

## Questions 
Should we move the `coupled` methods and struct definitions to this Drivers.jl module? 
After chatting with @LenkaNovak we decided it made sense and worked well to keep them in the coupler repo.

## Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
