### PR TITLE
Use Ntuple for Plant Hydraulics variable types

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,7 +46,7 @@ steps:
 
       - label: "ozark_test"
         command: "julia --color=yes --project=experiments experiments/LSM/ozark_test.jl"
-        artifact_paths: "ozark_test/"
+        artifact_paths: "experiments/LSM/"
 
       - label: "Soilbiogeochem"
         command: "julia --color=yes --project=experiments experiments/Biogeochemistry/experiment.jl"

--- a/docs/src/APIs/SharedUtilities.md
+++ b/docs/src/APIs/SharedUtilities.md
@@ -8,8 +8,6 @@ CurrentModule = ClimaLSM
 ```@docs
 ClimaLSM.Domains.AbstractDomain
 ClimaLSM.Domains.AbstractLSMDomain
-ClimaLSM.Domains.PlantHydraulicsDomain
-ClimaLSM.Domains.AbstractVegetationDomain
 ClimaLSM.Domains.SphericalShell
 ClimaLSM.Domains.SphericalSurface
 ClimaLSM.Domains.HybridBox

--- a/src/SharedUtilities/Domains.jl
+++ b/src/SharedUtilities/Domains.jl
@@ -393,131 +393,7 @@ function SphericalSurface(;
     )
 end
 
-"""
-    AbstractVegetationDomain{FT} <: AbstractDomain{FT}
 
-TBD if this needed longer term.
-"""
-abstract type AbstractVegetationDomain{FT} <: AbstractDomain{FT} end
-
-"""
-   PlantHydraulicsDomain{FT} <: AbstractVegetationDomain{FT}
-
-Domain for a single bulk plant with roots of varying depths. The user needs
-to specify the depths of the root tips as wel as the heights of the
-compartments to be modeled within the plant. The compartment heights
-are expected to be sorted in ascending order. The number of stem and leaf
-compartments the plant should be divided into must be specified as well.
-"""
-struct PlantHydraulicsDomain{FT} <: AbstractVegetationDomain{FT}
-    "The depth of the root tips, in meters"
-    root_depths::Vector{FT}
-    "The number of stem compartments for the plant"
-    n_stem::Int64
-    "The number of leaf compartments for the plant"
-    n_leaf::Int64
-    "The height of the center of each leaf compartment/stem compartment, in meters"
-    compartment_midpoints::Vector{FT}
-    "The height of the compartments' top faces, in meters"
-    compartment_surfaces::Vector{FT}
-    "The label (:stem or :leaf) of each compartment"
-    compartment_labels::Vector{Symbol}
-
-    """
-        function PlantHydraulicsDomain(
-            root_depths::Vector{FT},
-            n_stem::Int64,
-            n_leaf::Int64,
-            Δz::FT,
-            ) where {FT}
-
-    Creates an object of the PlantHydraulicsDomain struct type where every plant compartment is
-    the same length.
-    """
-    function PlantHydraulicsDomain(
-        root_depths::Vector{FT},
-        n_stem::Int64,
-        n_leaf::Int64,
-        Δz::FT,
-    ) where {FT}
-        @assert n_leaf != 0
-        compartment_midpoints = Vector{FT}(undef, n_stem + n_leaf)
-        compartment_midpoints = range(
-            start = Δz / 2,
-            step = Δz,
-            stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-        )
-        compartment_labels = Vector{Symbol}(undef, n_stem + n_leaf)
-        for i in 1:(n_stem + n_leaf)
-            if i <= n_stem
-                compartment_labels[i] = :stem
-            else
-                compartment_labels[i] = :leaf
-            end
-        end
-        compartment_surfaces =
-            range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf))
-        new{FT}(
-            root_depths,
-            n_stem,
-            n_leaf,
-            compartment_midpoints,
-            compartment_surfaces,
-            compartment_labels,
-        )
-    end
-
-    """
-        function PlantHydraulicsDomain(
-            root_depths::Vector{FT},
-            n_stem::Int64,
-            n_leaf::Int64,
-            compartment_midpoints::Vector{FT},
-            compartment_surfaces::Vector{FT},
-            ) where {FT}
-
-    Creates an object of the PlantHydraulicsDomain struct type where every plant compartment 
-    may not be the same length. Compartment midpoint heights and the height each compartment's
-    top is at are directly given so that the compartment lengths can vary if desired.
-    """
-    function PlantHydraulicsDomain(
-        root_depths::Vector{FT},
-        n_stem::Int64,
-        n_leaf::Int64,
-        compartment_midpoints::Vector{FT},
-        compartment_surfaces::Vector{FT},
-    ) where {FT}
-        @assert n_leaf != 0
-        @assert (n_leaf + n_stem) == length(compartment_midpoints)
-        @assert (n_leaf + n_stem) + 1 == length(compartment_surfaces)
-        for i in 1:length(compartment_midpoints)
-            @assert compartment_midpoints[i] ==
-                    (
-                (compartment_surfaces[i + 1] - compartment_surfaces[i]) / 2
-            ) + compartment_surfaces[i]
-        end
-        compartment_labels = Vector{Symbol}(undef, n_stem + n_leaf)
-        for i in 1:(n_stem + n_leaf)
-            if i <= n_stem
-                compartment_labels[i] = :stem
-            else
-                compartment_labels[i] = :leaf
-            end
-        end
-        new{FT}(
-            root_depths,
-            n_stem,
-            n_leaf,
-            compartment_midpoints,
-            compartment_surfaces,
-            compartment_labels,
-        )
-    end
-end
-
-function coordinates(domain::PlantHydraulicsDomain{FT}) where {FT}
-    return domain.compartment_midpoints
-end
 
 """
     AbstractLSMDomain{FT} <: AbstractDomain{FT}
@@ -763,14 +639,8 @@ function obtain_surface_space(cs::ClimaCore.Spaces.CenterFiniteDifferenceSpace)
     )
 end
 
-export AbstractDomain, AbstractVegetationDomain, AbstractLSMDomain
-export Column,
-    Plane,
-    HybridBox,
-    PlantHydraulicsDomain,
-    Point,
-    SphericalShell,
-    SphericalSurface
+export AbstractDomain, AbstractLSMDomain
+export Column, Plane, HybridBox, Point, SphericalShell, SphericalSurface
 export LSMSingleColumnDomain, LSMMultiColumnDomain, LSMSphericalShellDomain
 export coordinates, obtain_face_space, obtain_surface_space
 

--- a/src/SharedUtilities/models.jl
+++ b/src/SharedUtilities/models.jl
@@ -223,11 +223,6 @@ We may need to consider this default more as we add diverse components and
 """
 function initialize(model::AbstractModel{FT}) where {FT}
     coords = Domains.coordinates(model)
-
-    # Q: do we need separate initialize_prognostic and initialize_auxiliary methods?
-    # A: yes - code is the same other than call to auxiliary_vars or prognostic_vars
-    # however we do need to build separate FieldVectors => shared initialize_vars() method?
-    # auxiliary_types, auxiliary_spaces, prognostic_types, prognostic_spaces
     Y = initialize_prognostic(model, coords)
     p = initialize_auxiliary(model, coords)
     return Y, p, coords

--- a/test/Vegetation/plant_hydraulics_test.jl
+++ b/test/Vegetation/plant_hydraulics_test.jl
@@ -1,9 +1,7 @@
 using Test
 using Statistics
-using DiffEqCallbacks
 using UnPack
 using NLsolve
-using OrdinaryDiffEq: ODEProblem, solve, Euler, RK4
 using ClimaCore
 import CLIMAParameters as CP
 
@@ -11,44 +9,64 @@ if !("." in LOAD_PATH)
     push!(LOAD_PATH, ".")
 end
 using ClimaLSM
-using ClimaLSM.Domains: PlantHydraulicsDomain
+using ClimaLSM.Domains: Point, Plane
 using ClimaLSM.PlantHydraulics
 import ClimaLSM
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
 FT = Float64
-
+domains = [
+    Point(; z_sfc = FT(0.0)),
+    Plane(;
+        xlim = (0.0, 1.0),
+        ylim = (0.0, 1.0),
+        nelements = (2, 2),
+        periodic = (true, true),
+        npolynomial = 1,
+    ),
+]
 @testset "Plant hydraulics model integration tests" begin
-    # Parameters are the same as the ones used in the Ozark tutorial
-    RAI = FT(1) # m2/m2
-    SAI = FT(1) # m2/m2
-    LAI = FT(1) # m2/m2
-    area_index = (root = RAI, stem = SAI, leaf = LAI)
-    K_sat_plant = 1.8e-8 # m/s. Typical conductivity range is [1e-8, 1e-5] m/s. See Kumar, 2008 and
-    # Pierre Gentine's database for total global plant conductance (1/resistance) 
-    # (https://github.com/yalingliu-cu/plant-strategies/blob/master/Product%20details.pdf)
-    K_sat_root = FT(K_sat_plant) # m/s
-    K_sat_stem = FT(K_sat_plant)
-    K_sat_leaf = FT(K_sat_plant)
-    K_sat = (root = K_sat_root, stem = K_sat_stem, leaf = K_sat_leaf)
-    plant_vg_α = FT(0.002) # 1/m
-    plant_vg_n = FT(4.2) # unitless
-    plant_vg_m = FT(1) - FT(1) / plant_vg_n
-    plant_ν = FT(0.7) # m3/m3
-    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    root_depths = -Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0 # 1st element is the deepest root depth 
-    function root_distribution(z::T) where {T}
-        return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-    end
-    Δz = FT(1.0) # height of compartments
-    n_stem = Int64(6) # number of stem elements
-    n_leaf = Int64(5) # number of leaf elements
-    earth_param_set = create_lsm_parameters(FT)
+    for domain in domains
+        # Parameters are the same as the ones used in the Ozark tutorial
+        RAI = FT(1) # m2/m2
+        SAI = FT(1) # m2/m2
+        LAI = FT(1) # m2/m2
+        area_index = (root = RAI, stem = SAI, leaf = LAI)
+        K_sat_plant = 1.8e-8 # m/s. Typical conductivity range is [1e-8, 1e-5] m/s. See Kumar, 2008 and
+        # Pierre Gentine's database for total global plant conductance (1/resistance) 
+        # (https://github.com/yalingliu-cu/plant-strategies/blob/master/Product%20details.pdf)
+        K_sat_root = FT(K_sat_plant) # m/s
+        K_sat_stem = FT(K_sat_plant)
+        K_sat_leaf = FT(K_sat_plant)
+        K_sat = (root = K_sat_root, stem = K_sat_stem, leaf = K_sat_leaf)
+        plant_vg_α = FT(0.002) # 1/m
+        plant_vg_n = FT(4.2) # unitless
+        plant_vg_m = FT(1) - FT(1) / plant_vg_n
+        plant_ν = FT(0.7) # m3/m3
+        plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+        root_depths = -Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0 # 1st element is the deepest root depth 
+        function root_distribution(z::T) where {T}
+            return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+        end
+        Δz = FT(1.0) # height of compartments
+        n_stem = Int64(6) # number of stem elements
+        n_leaf = Int64(5) # number of leaf elements
+        compartment_midpoints = Vector(
+            range(
+                start = Δz / 2,
+                step = Δz,
+                stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+            ),
+        )
+        compartment_surfaces =
+            Vector(range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)))
+        earth_param_set = create_lsm_parameters(FT)
 
-    plant_hydraulics_domain =
-        PlantHydraulicsDomain(root_depths, n_stem, n_leaf, Δz)
-    param_set =
-        PlantHydraulics.PlantHydraulicsParameters{FT, typeof(earth_param_set)}(
+        plant_hydraulics_domain = domain
+        param_set = PlantHydraulics.PlantHydraulicsParameters{
+            FT,
+            typeof(earth_param_set),
+        }(
             area_index,
             K_sat,
             plant_vg_α,
@@ -60,84 +78,104 @@ FT = Float64
             earth_param_set,
         )
 
-    function leaf_transpiration(t::FT) where {FT}
-        T = FT(0)
-    end
-
-    ψ_soil0 = [FT(0.0)]
-    transpiration =
-        PrescribedTranspiration{FT}((t::FT) -> leaf_transpiration(t))
-    root_extraction = PrescribedSoilPressure{FT}((t::FT) -> ψ_soil0)
-    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-        domain = plant_hydraulics_domain,
-        parameters = param_set,
-        root_extraction = root_extraction,
-        transpiration = transpiration,
-    )
-
-    # Set system to hydrostatic equilibrium state by setting fluxes to zero, and setting LHS of both ODEs to 0
-    function initial_rhs!(F, Y)
-        T0 = FT(0)
-        for i in 1:(n_leaf + n_stem)
-            if i == 1
-                flux_in = sum(
-                    flux.(
-                        root_depths,
-                        plant_hydraulics_domain.compartment_midpoints[i],
-                        ψ_soil0,
-                        Y[i],
-                        plant_vg_α,
-                        plant_vg_n,
-                        plant_vg_m,
-                        plant_ν,
-                        plant_S_s,
-                        K_sat[:root],
-                        K_sat[:stem],
-                    ) .* root_distribution.(root_depths) .* (
-                        vcat(root_depths, [0.0])[2:end] -
-                        vcat(root_depths, [0.0])[1:(end - 1)]
-                    ),
-                )
-            else
-                flux_in = flux(
-                    plant_hydraulics_domain.compartment_midpoints[i - 1],
-                    plant_hydraulics_domain.compartment_midpoints[i],
-                    Y[i - 1],
-                    Y[i],
-                    plant_vg_α,
-                    plant_vg_n,
-                    plant_vg_m,
-                    plant_ν,
-                    plant_S_s,
-                    K_sat[plant_hydraulics_domain.compartment_labels[i - 1]],
-                    K_sat[plant_hydraulics_domain.compartment_labels[i]],
-                )
-            end
-            F[i] = flux_in - T0
+        function leaf_transpiration(t::FT) where {FT}
+            T = FT(0)
         end
-    end
 
-    soln = nlsolve(initial_rhs!, Vector(-0.03:0.01:0.07))
+        ψ_soil0 = FT(0.0)
+        transpiration =
+            PrescribedTranspiration{FT}((t::FT) -> leaf_transpiration(t))
+        root_extraction = PrescribedSoilPressure{FT}((t::FT) -> ψ_soil0)
 
-    S_l =
-        inverse_water_retention_curve.(
-            plant_vg_α,
-            plant_vg_n,
-            plant_vg_m,
-            soln.zero,
-            plant_ν,
-            plant_S_s,
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            domain = plant_hydraulics_domain,
+            parameters = param_set,
+            root_extraction = root_extraction,
+            transpiration = transpiration,
+            root_depths = root_depths,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_surfaces,
+            compartment_midpoints = compartment_midpoints,
         )
 
-    ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
+        # Set system to hydrostatic equilibrium state by setting fluxes to zero, and setting LHS of both ODEs to 0
+        function initial_rhs!(F, Y)
+            T0A = FT(0) * area_index[:leaf]
+            for i in 1:(n_leaf + n_stem)
+                if i == 1
+                    fa =
+                        sum(
+                            flux.(
+                                root_depths,
+                                plant_hydraulics.compartment_midpoints[i],
+                                ψ_soil0,
+                                Y[i],
+                                plant_vg_α,
+                                plant_vg_n,
+                                plant_vg_m,
+                                plant_ν,
+                                plant_S_s,
+                                K_sat[:root],
+                                K_sat[:stem],
+                            ) .* root_distribution.(root_depths) .* (
+                                vcat(root_depths, [0.0])[2:end] -
+                                vcat(root_depths, [0.0])[1:(end - 1)]
+                            ),
+                        ) * area_index[:root]
+                else
+                    fa =
+                        flux(
+                            plant_hydraulics.compartment_midpoints[i - 1],
+                            plant_hydraulics.compartment_midpoints[i],
+                            Y[i - 1],
+                            Y[i],
+                            plant_vg_α,
+                            plant_vg_n,
+                            plant_vg_m,
+                            plant_ν,
+                            plant_S_s,
+                            K_sat[plant_hydraulics.compartment_labels[i - 1]],
+                            K_sat[plant_hydraulics.compartment_labels[i]],
+                        ) * (
+                            area_index[plant_hydraulics.compartment_labels[1]] +
+                            area_index[plant_hydraulics.compartment_labels[2]]
+                        ) / 2
+                end
+                F[i] = fa - T0A
+            end
+        end
 
-    Y, p, coords = initialize(plant_hydraulics)
+        soln = nlsolve(initial_rhs!, Vector(-0.03:0.01:0.07))
 
-    Y.vegetation.ϑ_l .= ϑ_l_0
+        S_l =
+            inverse_water_retention_curve.(
+                plant_vg_α,
+                plant_vg_n,
+                plant_vg_m,
+                soln.zero,
+                plant_ν,
+                plant_S_s,
+            )
 
-    plant_hydraulics_ode! = make_ode_function(plant_hydraulics)
+        ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
 
-    dY = similar(Y)
-    plant_hydraulics_ode!(dY, Y, p, 0.0)
-    @test sqrt(mean(dY.vegetation.ϑ_l .^ 2.0)) < 1e-8 # starts in equilibrium
+        Y, p, coords = initialize(plant_hydraulics)
+        for i in 1:(n_stem + n_leaf)
+            Y.vegetation.ϑ_l[i] .= ϑ_l_0[i]
+        end
+
+
+        plant_hydraulics_ode! = make_ode_function(plant_hydraulics)
+
+        dY = similar(Y)
+        plant_hydraulics_ode!(dY, Y, p, 0.0)
+        m = similar(dY.vegetation.ϑ_l[1])
+        for i in 1:(n_stem + n_leaf)
+            @. m += dY.vegetation.ϑ_l[i]^2.0 ./ (n_stem + n_leaf)
+        end
+
+
+        @test mean(parent(sqrt.(m))) < 1e-8 # starts in equilibrium
+    end
 end

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -7,7 +7,6 @@ using ClimaLSM
 using ClimaLSM: Domains
 using ClimaLSM.Domains:
     Column,
-    PlantHydraulicsDomain,
     HybridBox,
     Plane,
     Point,
@@ -198,70 +197,5 @@ end
         @test coordinates(surf) === coordinates(domain).surface
         @test coordinates(domain).subsurface === coordinates(shell)
         @test obtain_surface_space(shell.space) === surf.space
-    end
-end
-
-
-@testset "PlantHydraulicsDomain" begin
-    for FT in TestFloatTypes
-        Δz = 1.0
-        roots = [FT(1.0), FT(2.0), FT(3.0)]
-        stem = Int64(5)
-        leaves = Int64(4)
-        comp_points = Vector(FT(0.5):FT(1.0):FT(8.5))
-        top_of_compartments = Vector(FT(0.0):FT(1.0):FT(9.0))
-        comp_labels =
-            [:stem, :stem, :stem, :stem, :stem, :leaf, :leaf, :leaf, :leaf]
-        test_tuple = (root = 1, stem = 2, leaf = 3)
-        @test test_tuple[:root] == 1
-
-        testing = PlantHydraulicsDomain(roots, stem, leaves, FT(Δz))
-        @test testing.root_depths == [1.0, 2.0, 3.0]
-        @test testing.n_stem == 5
-        @test testing.n_leaf == 4
-        @test testing.compartment_midpoints == comp_points
-        @test testing.compartment_surfaces == top_of_compartments
-        @test testing.compartment_labels == comp_labels
-        # Check that root depth array is monotonic and increasing 
-        @test(
-            (
-                (
-                    testing.root_depths[i + 1] - testing.root_depths[i] for
-                    i in 1:(length(testing.root_depths) - 1)
-                ) .> FT(0)
-            ) == Bool.(ones(length(testing.root_depths) - 1))
-        )
-
-        for i in 1:5
-            @test test_tuple[testing.compartment_labels[i]] == 2
-        end
-        for i in 6:9
-            @test test_tuple[testing.compartment_labels[i]] == 3
-        end
-
-        testing2 = PlantHydraulicsDomain(
-            roots,
-            stem,
-            leaves,
-            comp_points,
-            top_of_compartments,
-        )
-        @test testing2.root_depths == [1.0, 2.0, 3.0]
-        @test testing2.n_stem == 5
-        @test testing2.n_leaf == 4
-        @test testing2.compartment_midpoints ==
-              [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5]
-        @test testing2.compartment_surfaces ==
-              [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
-        @test testing2.compartment_labels == comp_labels
-        for i in 1:5
-            @test test_tuple[testing2.compartment_labels[i]] == 2
-        end
-        for i in 6:9
-            @test test_tuple[testing2.compartment_labels[i]] == 3
-        end
-
-        coords = coordinates(testing)
-        @test coords == comp_points
     end
 end


### PR DESCRIPTION
## Purpose 
The plant hydraulics model requires an array of numbers at each coordinate point. Previously, we had kind of hacked this by making the "coordinates" of a PlantHydraulicsDomain an array, and then at each point, we had a scalar variable. But in the long run, we want the coordinates to be the lat/lon of the surface, and we want to have an array-like variable at each point. We also then do not need to introduce a special Domain for plant hydraulics, and can instead use the same domain as the other model components (the surface of the Earth). 

In this PR, we remove the PlantHydraulicsDomain. We make the prognostic and aux variables for the plant hydraulics models Ntuples, instead of scalars. This required changing some of the RHS code in the src/Vegetation/PlantHydraulics.jl file. All other changed files are propagating this into docs, unit tests, and experiments.

## Content
1. Removes the plant hydraulics domain.
2. Sticks the necessary info from that Plant Hydraulics domain struct into the model struct
3. Changes the type of the prognostic variable for PlantHydraulics so that it works with the existing Plane and Point domains (closely linked to ClimaCore domains)
4. Cleans up some repetitive computation in the RHS
5. Propagates changes to unit tests and docs.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
