### PR TITLE
Compute boundary fluxes at each boundary, rather than by component

### DIFF
--- a/docs/src/APIs/Soil.md
+++ b/docs/src/APIs/Soil.md
@@ -49,9 +49,9 @@ ClimaLSM.Soil.EnergyHydrologyParameters
 
 ```@docs
 ClimaLSM.Soil.AbstractSoilBC
-ClimaLSM.Soil.StateBC
+ClimaLSM.Soil.MoistureStateBC
 ClimaLSM.Soil.FluxBC
-ClimaLSM.Soil.StateBC
+ClimaLSM.Soil.TemperatureStateBC
 ClimaLSM.Soil.FreeDrainage
 ClimaLSM.Soil.AbstractSoilSource
 ClimaLSM.Soil.PhaseChange

--- a/docs/tutorials/Soil/freezing_front.jl
+++ b/docs/tutorials/Soil/freezing_front.jl
@@ -152,8 +152,8 @@ function top_heat_flux(p, t)
 end
 top_heat_flux_bc = FluxBC(top_heat_flux)
 boundary_fluxes = (;
-    water = (top = zero_flux_bc, bottom = zero_flux_bc),
-    heat = (top = top_heat_flux_bc, bottom = zero_flux_bc),
+    top = (water = zero_flux_bc, heat = top_heat_flux_bc),
+    bottom = (water = zero_flux_bc, heat = zero_flux_bc),
 );
 
 # Create the source term instance. Our phase change model requires

--- a/docs/tutorials/Soil/richards_equation.jl
+++ b/docs/tutorials/Soil/richards_equation.jl
@@ -111,7 +111,8 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
 surface_flux = Soil.FluxBC((p, t) -> eltype(t)(0.0))
 bottom_flux = Soil.FluxBC((p, t) -> eltype(t)(0.0))
-boundary_conditions = (; water = (top = surface_flux, bottom = bottom_flux));
+boundary_conditions =
+    (; top = (water = surface_flux,), bottom = (water = bottom_flux,));
 
 # Lastly, in this case we don't have any sources, so we pass an empty tuple:
 sources = ();

--- a/docs/tutorials/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/Soil/soil_energy_hydrology.jl
@@ -179,8 +179,8 @@ bottom_heat_flux = FluxBC((p, t) -> eltype(t)(0.0));
 
 # We wrap up all of those in a NamedTuple:
 boundary_fluxes = (;
-    water = (top = surface_water_flux, bottom = bottom_water_flux),
-    heat = (top = surface_heat_flux, bottom = bottom_heat_flux),
+    top = (water = surface_water_flux, heat = surface_heat_flux),
+    bottom = (water = bottom_water_flux, heat = bottom_water_flux),
 );
 
 

--- a/experiments/Biogeochemistry/experiment.jl
+++ b/experiments/Biogeochemistry/experiment.jl
@@ -66,7 +66,7 @@ nelems = 20
 lsm_domain = LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelems)
 
 top_flux_bc_w = Soil.FluxBC((p, t) -> eltype(t)(-0.00001))
-bot_flux_bc_w = Soil.FreeDrainage{FT}()
+bot_flux_bc_w = Soil.FreeDrainage()
 
 top_flux_bc_h = Soil.FluxBC((p, t) -> eltype(t)(0.0))
 bot_flux_bc_h = Soil.FluxBC((p, t) -> eltype(t)(0.0))
@@ -74,8 +74,8 @@ bot_flux_bc_h = Soil.FluxBC((p, t) -> eltype(t)(0.0))
 
 sources = (PhaseChange{FT}(Δz),)
 boundary_fluxes = (;
-    water = (top = top_flux_bc_w, bottom = bot_flux_bc_w),
-    heat = (top = top_flux_bc_h, bottom = bot_flux_bc_h),
+    top = (water = top_flux_bc_w, heat = bot_flux_bc_h),
+    bottom = (water = bot_flux_bc_w, heat = bot_flux_bc_h),
 )
 soil_args = (;
     boundary_conditions = boundary_fluxes,
@@ -95,7 +95,8 @@ C = FT(100)
 co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> eltype(t)(0.0))
 co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> eltype(t)(0.0))
 co2_sources = (MicrobeProduction{FT}(),)
-co2_boundary_conditions = (; CO2 = (top = co2_top_bc, bottom = co2_bot_bc))
+co2_boundary_conditions =
+    (; top = (CO2 = co2_top_bc,), bottom = (CO2 = co2_bot_bc,))
 soil_drivers = Soil.Biogeochemistry.SoilDrivers(
     Soil.Biogeochemistry.PrognosticMet(),
     Soil.Biogeochemistry.PrescribedSOC(Csom),

--- a/experiments/Soil/richards_comparison.jl
+++ b/experiments/Soil/richards_comparison.jl
@@ -35,10 +35,11 @@ FT = Float64
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
     z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
 
-    top_state_bc = StateBC((p, t) -> eltype(t)(ν - 1e-3))
-    bot_flux_bc = FreeDrainage{FT}()
+    top_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν - 1e-3))
+    bot_flux_bc = FreeDrainage()
     sources = ()
-    boundary_states = (; water = (top = top_state_bc, bottom = bot_flux_bc))
+    boundary_states =
+        (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
     params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
 
     soil = Soil.RichardsModel{FT}(;
@@ -97,10 +98,12 @@ end
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
     z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
 
-    top_state_bc = StateBC((p, t) -> eltype(t)(0.267))
-    bot_flux_bc = FreeDrainage{FT}()
+    top_state_bc = MoistureStateBC((p, t) -> eltype(t)(0.267))
+    bot_flux_bc = FreeDrainage()
     sources = ()
-    boundary_states = (; water = (top = top_state_bc, bottom = bot_flux_bc))
+    boundary_states =
+        (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+
     params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
 
     soil = Soil.RichardsModel{FT}(;

--- a/src/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -204,7 +204,7 @@ function ClimaLSM.make_rhs(model::SoilCO2Model)
         Δz_top, Δz_bottom = get_Δz(z)
 
         top_flux_bc = boundary_flux(
-            model.boundary_conditions.CO2.top,
+            model.boundary_conditions.top.CO2,
             TopBoundary(),
             Δz_top,
             Y,
@@ -212,7 +212,7 @@ function ClimaLSM.make_rhs(model::SoilCO2Model)
             t,
         )
         bot_flux_bc = boundary_flux(
-            model.boundary_conditions.CO2.bottom,
+            model.boundary_conditions.bottom.CO2,
             BottomBoundary(),
             Δz_bottom,
             Y,

--- a/src/Soil/Soil.jl
+++ b/src/Soil/Soil.jl
@@ -73,30 +73,17 @@ import ClimaLSM:
     prognostic_types,
     auxiliary_types,
     AbstractSource,
-    AbstractBC,
     source!,
-    boundary_flux,
     heaviside
 export RichardsModel,
     RichardsParameters,
     EnergyHydrology,
     EnergyHydrologyParameters,
-    FluxBC,
-    StateBC,
-    FreeDrainage,
     AbstractSoilModel,
     AbstractSoilSource,
-    FluxBC,
     PhaseChange
-#PrecipFreeDrainage,
-#boundary_fluxes,
 
-"""
-    AbstractSoilBC <: ClimaLSM. AbstractBC
 
-An abstract type for soil-specific types of boundary conditions, like free drainage.
-"""
-abstract type AbstractSoilBC <: ClimaLSM.AbstractBC end
 
 """
     AbstractSoilSource{FT} <:  ClimaLSM.AbstractSource{FT}
@@ -163,172 +150,9 @@ function dss!(
     end
 end
 
-"""
-   StateBC <: AbstractSoilBC
-
-A simple concrete type of boundary condition, which enforces a
-state boundary condition f(p,t) at either the top or bottom of the domain.
-"""
-struct StateBC <: AbstractSoilBC
-    bc::Function
-end
-
-"""
-   FluxBC <: AbstractSoilBC
-
-A simple concrete type of boundary condition, which enforces a
-normal flux boundary condition f(p,t) at either the top or bottom of the domain.
-"""
-struct FluxBC <: AbstractSoilBC
-    bc::Function
-end
-
-"""
-    FreeDrainage{FT} <: AbstractSoilBC
-A concrete type of soil boundary condition, for use at 
-the BottomBoundary only, where the flux is set to be
-`F = -K∇h = -K`.
-"""
-struct FreeDrainage{FT} <: AbstractSoilBC end
-
-"""
-    ClimaLSM.boundary_flux(bc::FluxBC, _, Δz, _...)::ClimaCore.Fields.Field
-
-A method of boundary fluxes which returns the desired flux.
-
-We add a field of zeros in order to convert the bc (float) into
-a field.
-"""
-function ClimaLSM.boundary_flux(
-    bc::FluxBC,
-    boundary::ClimaLSM.AbstractBoundary,
-    Δz::ClimaCore.Fields.Field,
-    p::ClimaCore.Fields.FieldVector,
-    t::FT,
-    _...,
-)::ClimaCore.Fields.Field where {FT}
-    return bc.bc(p, t) .+ ClimaCore.Fields.zeros(axes(Δz))
-end
-
-"""
-    ClimaLSM.boundary_flux(rre_bc::StateBC, ::ClimaLSM.TopBoundary, Δz, p, t, params)::ClimaCore.Fields.Field
-
-A method of boundary fluxes which converts a state boundary condition on θ_l at the top of the
-domain into a flux of liquid water.
-"""
-function ClimaLSM.boundary_flux(
-    rre_bc::StateBC,
-    ::ClimaLSM.TopBoundary,
-    Δz,
-    p,
-    t,
-    params,
-)::ClimaCore.Fields.Field
-    # Approximate K_bc ≈ K_c, ψ_bc ≈ ψ_c (center closest to the boundary)
-    p_len = Spaces.nlevels(axes(p.soil.K))
-    K_c = Fields.level(p.soil.K, p_len)
-    ψ_c = Fields.level(p.soil.ψ, p_len)
-
-    # Calculate pressure head using boundary condition
-    @unpack vg_α, vg_n, vg_m, θ_r, ν, S_s = params
-    θ_bc = rre_bc.bc(p, t)
-    ψ_bc = @. pressure_head(vg_α, vg_n, vg_m, θ_r, θ_bc, ν, S_s)
-
-    # Pass in (ψ_bc .+ Δz) as x_2 to account for contribution of gravity in RRE
-    return ClimaLSM.diffusive_flux(K_c, ψ_bc .+ Δz, ψ_c, Δz)
-end
-
-"""
-    ClimaLSM.boundary_flux(rre_bc::StateBC, ::ClimaLSM.BottomBoundary, Δz, p, t, params)::ClimaCore.Fields.Field
-
-A method of boundary fluxes which converts a state boundary condition on θ_l at the bottom of the
-domain into a flux of liquid water.
-"""
-function ClimaLSM.boundary_flux(
-    rre_bc::StateBC,
-    ::ClimaLSM.BottomBoundary,
-    Δz,
-    p,
-    t,
-    params,
-)::ClimaCore.Fields.Field
-    # Approximate K_bc ≈ K_c, ψ_bc ≈ ψ_c (center closest to the boundary)
-    K_c = Fields.level(p.soil.K, 1)
-    ψ_c = Fields.level(p.soil.ψ, 1)
-
-    # Calculate pressure head using boundary condition
-    @unpack vg_α, vg_n, vg_m, θ_r, ν, S_s = params
-    θ_bc = rre_bc.bc(p, t)
-    ψ_bc = @. pressure_head(vg_α, vg_n, vg_m, θ_r, θ_bc, ν, S_s)
-
-    # At the bottom boundary, ψ_c is at larger z than ψ_bc
-    #  so we swap their order in the derivative calc
-    # Pass in (ψ_c .+ Δz) as x_2 to account for contribution of gravity in RRE
-    return ClimaLSM.diffusive_flux(K_c, ψ_c .+ Δz, ψ_bc, Δz)
-end
 
 
-"""
-    ClimaLSM.boundary_flux(heat_bc::StateBC, ::ClimaLSM.TopBoundary, Δz, p, t)::ClimaCore.Fields.Field
-
-A method of boundary fluxes which converts a state boundary condition on temperature at the top of the
-domain into a flux of energy.
-"""
-function ClimaLSM.boundary_flux(
-    heat_bc::StateBC,
-    ::ClimaLSM.TopBoundary,
-    Δz,
-    p,
-    t,
-)::ClimaCore.Fields.Field
-    # Approximate κ_bc ≈ κ_c (center closest to the boundary)
-    p_len = Spaces.nlevels(axes(p.soil.T))
-    T_c = Fields.level(p.soil.T, p_len)
-    κ_c = Fields.level(p.soil.κ, p_len)
-
-    T_bc = heat_bc.bc(p, t)
-    return ClimaLSM.diffusive_flux(κ_c, T_bc, T_c, Δz)
-end
-
-"""
-    ClimaLSM.boundary_flux(heat_bc::StateBC, ::ClimaLSM.BottomBoundary, Δz, p, t)::ClimaCore.Fields.Field
-
-A method of boundary fluxes which converts a state boundary condition on temperature at the bottom of the
-domain into a flux of energy.
-"""
-function ClimaLSM.boundary_flux(
-    heat_bc::StateBC,
-    ::ClimaLSM.BottomBoundary,
-    Δz,
-    p,
-    t,
-)::ClimaCore.Fields.Field
-    # Approximate κ_bc ≈ κ_c (center closest to the boundary)
-    T_c = Fields.level(p.soil.T, 1)
-    κ_c = Fields.level(p.soil.κ, 1)
-    T_bc = heat_bc.bc(p, t)
-    return ClimaLSM.diffusive_flux(κ_c, T_c, T_bc, Δz)
-end
-
-
-"""
-    ClimaLSM.boundary_flux(bc::FreeDrainage{FT}, ::ClimaLSM.BottomBoundary, Δz, p, t)::ClimaCore.Fields.Field
-
-A method of boundary fluxes which enforces free drainage at the bottom
-of the domain.
-"""
-function ClimaLSM.boundary_flux(
-    bc::FreeDrainage{FT},
-    boundary::ClimaLSM.BottomBoundary,
-    Δz,
-    p,
-    t,
-    params,
-)::ClimaCore.Fields.Field where {FT}
-    K_c = Fields.level(p.soil.K, 1)
-    return -1 .* K_c
-end
-
+include("./boundary_conditions.jl")
 include("./rre.jl")
 include("./energy_hydrology.jl")
 include("./soil_hydrology_parameterizations.jl")

--- a/src/Soil/boundary_conditions.jl
+++ b/src/Soil/boundary_conditions.jl
@@ -1,0 +1,198 @@
+import ClimaLSM: AbstractBC, boundary_flux
+export TemperatureStateBC, MoistureStateBC, FreeDrainage, FluxBC
+
+"""
+    AbstractSoilBC <: ClimaLSM. AbstractBC
+
+An abstract type for soil-specific types of boundary conditions, like free drainage.
+"""
+abstract type AbstractSoilBC <: ClimaLSM.AbstractBC end
+
+"""
+   MoistureStateBC <: AbstractSoilBC
+
+A simple concrete type of boundary condition, which enforces a
+state boundary condition ϑ_l = f(p,t) at either the top or bottom of the domain.
+"""
+struct MoistureStateBC <: AbstractSoilBC
+    bc::Function
+end
+
+"""
+   TemperatureStateBC <: AbstractSoilBC
+
+A simple concrete type of boundary condition, which enforces a
+state boundary condition T = f(p,t) at either the top or bottom of the domain.
+"""
+struct TemperatureStateBC <: AbstractSoilBC
+    bc::Function
+end
+
+"""
+   FluxBC <: AbstractSoilBC
+
+A simple concrete type of boundary condition, which enforces a
+normal flux boundary condition f(p,t) at either the top or bottom of the domain.
+"""
+struct FluxBC <: AbstractSoilBC
+    bc::Function
+end
+
+
+"""
+    FreeDrainage <: AbstractSoilBC
+A concrete type of soil boundary condition, for use at 
+the BottomBoundary only, where the flux is set to be
+`F = -K∇h = -K`.
+"""
+struct FreeDrainage <: AbstractSoilBC end
+
+"""
+    ClimaLSM.boundary_flux(bc::FluxBC, _, Δz, _...)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which returns the desired flux.
+
+We add a field of zeros in order to convert the bc (float) into
+a field.
+"""
+function ClimaLSM.boundary_flux(
+    bc::FluxBC,
+    boundary::ClimaLSM.AbstractBoundary,
+    Δz::ClimaCore.Fields.Field,
+    p::ClimaCore.Fields.FieldVector,
+    t,
+    params,
+)::ClimaCore.Fields.Field
+    return bc.bc(p, t) .+ ClimaCore.Fields.zeros(axes(Δz))
+end
+
+"""
+    ClimaLSM.boundary_flux(rre_bc::MoistureStateBC, ::ClimaLSM.TopBoundary, Δz, p, t, params)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which converts a state boundary condition on θ_l at the top of the
+domain into a flux of liquid water.
+"""
+function ClimaLSM.boundary_flux(
+    rre_bc::MoistureStateBC,
+    ::ClimaLSM.TopBoundary,
+    Δz,
+    p,
+    t,
+    params,
+)::ClimaCore.Fields.Field
+    # Approximate K_bc ≈ K_c, ψ_bc ≈ ψ_c (center closest to the boundary)
+    p_len = Spaces.nlevels(axes(p.soil.K))
+    K_c = Fields.level(p.soil.K, p_len)
+    ψ_c = Fields.level(p.soil.ψ, p_len)
+
+    # Calculate pressure head using boundary condition
+    @unpack vg_α, vg_n, vg_m, θ_r, ν, S_s = params
+    θ_bc = rre_bc.bc(p, t)
+    ψ_bc = @. pressure_head(vg_α, vg_n, vg_m, θ_r, θ_bc, ν, S_s)
+
+    # Pass in (ψ_bc .+ Δz) as x_2 to account for contribution of gravity in RRE
+    return ClimaLSM.diffusive_flux(K_c, ψ_bc .+ Δz, ψ_c, Δz)
+end
+
+"""
+    ClimaLSM.boundary_flux(rre_bc::MoistureStateBC, ::ClimaLSM.BottomBoundary, Δz, p, t, params)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which converts a state boundary condition on θ_l at the bottom of the
+domain into a flux of liquid water.
+"""
+function ClimaLSM.boundary_flux(
+    rre_bc::MoistureStateBC,
+    ::ClimaLSM.BottomBoundary,
+    Δz,
+    p,
+    t,
+    params,
+)::ClimaCore.Fields.Field
+    # Approximate K_bc ≈ K_c, ψ_bc ≈ ψ_c (center closest to the boundary)
+    K_c = Fields.level(p.soil.K, 1)
+    ψ_c = Fields.level(p.soil.ψ, 1)
+
+    # Calculate pressure head using boundary condition
+    @unpack vg_α, vg_n, vg_m, θ_r, ν, S_s = params
+    θ_bc = rre_bc.bc(p, t)
+    ψ_bc = @. pressure_head(vg_α, vg_n, vg_m, θ_r, θ_bc, ν, S_s)
+
+    # At the bottom boundary, ψ_c is at larger z than ψ_bc
+    #  so we swap their order in the derivative calc
+    # Pass in (ψ_c .+ Δz) as x_2 to account for contribution of gravity in RRE
+    return ClimaLSM.diffusive_flux(K_c, ψ_c .+ Δz, ψ_bc, Δz)
+end
+
+
+"""
+    ClimaLSM.boundary_flux(heat_bc::TemperatureStateBC, ::ClimaLSM.TopBoundary, Δz, p, t)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which converts a state boundary condition on temperature at the top of the
+domain into a flux of energy.
+"""
+function ClimaLSM.boundary_flux(
+    heat_bc::TemperatureStateBC,
+    ::ClimaLSM.TopBoundary,
+    Δz,
+    p,
+    t,
+    params,
+)::ClimaCore.Fields.Field
+    # Approximate κ_bc ≈ κ_c (center closest to the boundary)
+    p_len = Spaces.nlevels(axes(p.soil.T))
+    T_c = Fields.level(p.soil.T, p_len)
+    κ_c = Fields.level(p.soil.κ, p_len)
+
+    T_bc = heat_bc.bc(p, t)
+    return ClimaLSM.diffusive_flux(κ_c, T_bc, T_c, Δz)
+end
+
+"""
+    ClimaLSM.boundary_flux(heat_bc::TemperatureStateBC, ::ClimaLSM.BottomBoundary, Δz, p, t)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which converts a state boundary condition on temperature at the bottom of the
+domain into a flux of energy.
+"""
+function ClimaLSM.boundary_flux(
+    heat_bc::TemperatureStateBC,
+    ::ClimaLSM.BottomBoundary,
+    Δz,
+    p,
+    t,
+    params,
+)::ClimaCore.Fields.Field
+    # Approximate κ_bc ≈ κ_c (center closest to the boundary)
+    T_c = Fields.level(p.soil.T, 1)
+    κ_c = Fields.level(p.soil.κ, 1)
+    T_bc = heat_bc.bc(p, t)
+    return ClimaLSM.diffusive_flux(κ_c, T_c, T_bc, Δz)
+end
+
+
+"""
+    ClimaLSM.boundary_flux(bc::FreeDrainage{FT}, ::ClimaLSM.BottomBoundary, Δz, p, t)::ClimaCore.Fields.Field
+
+A method of boundary fluxes which enforces free drainage at the bottom
+of the domain.
+"""
+function ClimaLSM.boundary_flux(
+    bc::FreeDrainage,
+    boundary::ClimaLSM.BottomBoundary,
+    Δz,
+    p,
+    t,
+    params,
+)::ClimaCore.Fields.Field
+    K_c = Fields.level(p.soil.K, 1)
+    return -1 .* K_c
+end
+
+"""
+    soil_boundary_fluxes(bc::NamedTuple, boundary, Δz, p, t, params)
+
+Returns the boundary fluxes for ϑ_l and ρe_int, in that order.
+"""
+function soil_boundary_fluxes(bc::NamedTuple, boundary, Δz, p, t, params)
+    return ClimaLSM.boundary_flux(bc.water, boundary, Δz, p, t, params),
+    ClimaLSM.boundary_flux(bc.heat, boundary, Δz, p, t, params)
+end

--- a/src/Soil/energy_hydrology.jl
+++ b/src/Soil/energy_hydrology.jl
@@ -126,7 +126,7 @@ end
     EnergyHydrology{FT}(;
         parameters::PS
         domain::D,
-        rre_heat_boundary_conditions::RREHeatBoundaryConditions{FT},
+        boundary_conditions::NamedTuple,
         sources::Tuple,
     ) where {FT, D, PS}
 
@@ -160,36 +160,21 @@ function ClimaLSM.make_rhs(model::EnergyHydrology{FT}) where {FT}
         Δz_top, Δz_bottom = get_Δz(z)
 
         # Convert all boundary conditions to FluxBCs
-        rre_top_flux_bc = boundary_flux(
-            model.boundary_conditions.water.top,
+        rre_top_flux_bc, heat_top_flux_bc = soil_boundary_fluxes(
+            model.boundary_conditions.top,
             TopBoundary(),
             Δz_top,
             p,
             t,
             model.parameters,
         )
-        rre_bot_flux_bc = boundary_flux(
-            model.boundary_conditions.water.bottom,
+        rre_bot_flux_bc, heat_bot_flux_bc = soil_boundary_fluxes(
+            model.boundary_conditions.bottom,
             BottomBoundary(),
             Δz_bottom,
             p,
             t,
             model.parameters,
-        )
-
-        heat_top_flux_bc = boundary_flux(
-            model.boundary_conditions.heat.top,
-            TopBoundary(),
-            Δz_top,
-            p,
-            t,
-        )
-        heat_bot_flux_bc = boundary_flux(
-            model.boundary_conditions.heat.bottom,
-            BottomBoundary(),
-            Δz_bottom,
-            p,
-            t,
         )
 
         interpc2f = Operators.InterpolateC2F()

--- a/src/Soil/rre.jl
+++ b/src/Soil/rre.jl
@@ -92,7 +92,7 @@ function ClimaLSM.make_rhs(model::RichardsModel)
         Δz_top, Δz_bottom = get_Δz(z)
 
         top_flux_bc = boundary_flux(
-            model.boundary_conditions.water.top,
+            model.boundary_conditions.top.water,
             TopBoundary(),
             Δz_top,
             p,
@@ -100,7 +100,7 @@ function ClimaLSM.make_rhs(model::RichardsModel)
             model.parameters,
         )
         bot_flux_bc = boundary_flux(
-            model.boundary_conditions.water.bottom,
+            model.boundary_conditions.bottom.water,
             BottomBoundary(),
             Δz_bottom,
             p,

--- a/src/pond_soil_model.jl
+++ b/src/pond_soil_model.jl
@@ -61,7 +61,7 @@ function LandHydrology{FT}(;
     sources = ()
     surface_runoff = PrognosticRunoff{FT}(precip)
     boundary_conditions =
-        (; water = (top = RunoffBC(), bottom = Soil.FreeDrainage{FT}()))
+        (; top = (water = RunoffBC(),), bottom = (water = Soil.FreeDrainage(),))
 
     soil = soil_model_type(;
         boundary_conditions = boundary_conditions,

--- a/src/soil_plant_hydrology_model.jl
+++ b/src/soil_plant_hydrology_model.jl
@@ -67,10 +67,8 @@ function SoilPlantHydrologyModel{FT}(;
     )
 
     boundary_conditions = (;
-        water = (
-            top = FluxBC((p, t) -> eltype(t)(precipitation(t))),
-            bottom = Soil.FreeDrainage{FT}(),
-        )
+        top = (water = FluxBC((p, t) -> eltype(t)(precipitation(t))),),
+        bottom = (water = Soil.FreeDrainage(),),
     )
 
     soil = soil_model_type(;

--- a/test/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -37,7 +37,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     top_bc = SoilCO2StateBC((p, t) -> eltype(t)(3000.0))
     bot_bc = SoilCO2StateBC((p, t) -> eltype(t)(100.0))
     sources = (MicrobeProduction{FT}(),)
-    boundary_conditions = (; CO2 = (top = top_bc, bottom = bot_bc))
+    boundary_conditions = (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
 
     soil_drivers = SoilDrivers(PrescribedMet(T_soil, θ_l), PrescribedSOC(Csom))
     model = SoilCO2Model{FT}(;
@@ -75,7 +75,7 @@ end
     top_bc = SoilCO2StateBC((p, t) -> eltype(t)(C))
     bot_bc = SoilCO2StateBC((p, t) -> eltype(t)(C))
     sources = ()
-    boundary_conditions = (; CO2 = (top = top_bc, bottom = bot_bc))
+    boundary_conditions = (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
 
     soil_drivers = SoilDrivers(PrescribedMet(T_soil, θ_l), PrescribedSOC(Csom))
     model = SoilCO2Model{FT}(;

--- a/test/Soil/soil_test_3d.jl
+++ b/test/Soil/soil_test_3d.jl
@@ -36,7 +36,8 @@ FT = Float64
     top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     sources = ()
-    boundary_fluxes = (; water = (top = top_flux_bc, bottom = bot_flux_bc))
+    boundary_fluxes =
+        (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
     params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
 
     soil = Soil.RichardsModel{FT}(;
@@ -260,8 +261,8 @@ end
     top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     boundary_fluxes = (;
-        water = (top = top_flux_bc, bottom = bot_flux_bc),
-        heat = (top = top_flux_bc, bottom = bot_flux_bc),
+        top = (water = top_flux_bc, heat = top_flux_bc),
+        bottom = (water = bot_flux_bc, heat = bot_flux_bc),
     )
     sources = ()
 
@@ -348,7 +349,8 @@ end
     top_flux_bc = FluxBC((p, t) -> eltype(t)(K_sat))
     bot_flux_bc = FluxBC((p, t) -> eltype(t)(K_sat))
     sources = ()
-    boundary_fluxes = (; water = (top = top_flux_bc, bottom = bot_flux_bc))
+    boundary_fluxes =
+        (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
 
     soil = Soil.RichardsModel{FT}(;
         parameters = parameters,

--- a/test/Soil/soiltest.jl
+++ b/test/Soil/soiltest.jl
@@ -144,7 +144,8 @@ end
     top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     sources = ()
-    boundary_fluxes = (; water = (top = top_flux_bc, bottom = bot_flux_bc))
+    boundary_fluxes =
+        (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
     params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
 
     soil = Soil.RichardsModel{FT}(;
@@ -207,10 +208,11 @@ end
     nelems = 50
 
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    top_state_bc = StateBC((p, t) -> eltype(t)(ν / 2))
-    bot_state_bc = StateBC((p, t) -> eltype(t)(ν))
+    top_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν / 2))
+    bot_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν))
     sources = ()
-    boundary_states = (; water = (top = top_state_bc, bottom = bot_state_bc))
+    boundary_states =
+        (; top = (water = top_state_bc,), bottom = (water = bot_state_bc,))
     params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
 
     soil = Soil.RichardsModel{FT}(;
@@ -265,9 +267,10 @@ end
 
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
     top_flux_bc = FluxBC((p, t) -> eltype(t)(0))
-    bot_state_bc = StateBC((p, t) -> eltype(t)(ν / 2))
+    bot_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν / 2))
     sources = ()
-    boundary_conditions = (; water = (top = top_flux_bc, bottom = bot_state_bc))
+    boundary_conditions =
+        (; top = (water = top_flux_bc,), bottom = (water = bot_state_bc,))
     params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
 
     soil = Soil.RichardsModel{FT}(;
@@ -341,8 +344,8 @@ end
     sources = ()
     # Use the same BCs for RRE and heat
     boundary_fluxes = (;
-        water = (top = top_flux_bc, bottom = bot_flux_bc),
-        heat = (top = top_flux_bc, bottom = bot_flux_bc),
+        top = (water = top_flux_bc, heat = top_flux_bc),
+        bottom = (water = bot_flux_bc, heat = bot_flux_bc),
     )
 
 
@@ -719,8 +722,8 @@ end
     top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
     boundary_fluxes = (;
-        water = (top = top_flux_bc, bottom = bot_flux_bc),
-        heat = (top = top_flux_bc, bottom = bot_flux_bc),
+        top = (water = top_flux_bc, heat = top_flux_bc),
+        bottom = (water = bot_flux_bc, heat = bot_flux_bc),
     )
 
     sources = (PhaseChange{FT}(Δz),)


### PR DESCRIPTION
## Purpose 
We are currently computing the boundary fluxes per side and per component (water, heat). This will require duplicate calls to surface fluxes when we drive the soil model with reanalysis data (atmospheric conditions). This is because surface fluxes computes the energy and water fluxes at the same time.

## Content
1. Rearrange BC so they are passed in as `(top = (water = ..., heat = ...), bottom = (water = ..., heat = ....))` instead of `(water = (top = ...., bottom = ....), heat = (top = ...., bottom = ....))`. 
2. Propagate this to Biogeochemistry for consistency, although I dont think it makes a difference at this point.
3. Update tests and tutorials.
4. I also clarified the use of StateBC between water and heat, by introducing `MoistureStateBC` and `TemperatureStateBC`, because before our dispatch relied on # of arguments, and this seemed less reliable.
5. Introduce wrapper function for the soil energy and hydrology model, which calls boundary_flux for each component:

```
function soil_boundary_fluxes(bc::NamedTuple, boundary, Δz, p, t, params)
    return ClimaLSM.boundary_flux(bc.water, boundary, Δz, p, t, params),
    ClimaLSM.boundary_flux(bc.heat, boundary, Δz, p, t, params)
end
```

This is what we can dispatch off of when the bc is of type "AtmosSurfaceFluxes" (or whatever) - when we want to use surface fluxes & prescribed atmos conditions. This is not needed for Richards equation, because there is only a single component.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
