### PR TITLE
added comparison to Bonan into buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,6 +40,10 @@ steps:
         command: "julia --color=yes --project=test test/Bucket/albedo_map_bucket.jl"
         artifact_paths: "albedo_map/"
 
+      - label: "Richards comparison to Bonan"
+        command: "julia --color=yes --project=experiments experiments/Soil/richards_comparison.jl"
+        artifact_paths: "experiments/Soil/*png"
+
       - label: "ozark_test"
         command: "julia --color=yes --project=experiments experiments/LSM/ozark_test.jl"
         artifact_paths: "ozark_test/"

--- a/experiments/Soil/richards_comparison.jl
+++ b/experiments/Soil/richards_comparison.jl
@@ -1,0 +1,145 @@
+using Test
+using Plots
+using DelimitedFiles
+using Statistics
+using ArtifactWrappers
+using OrdinaryDiffEq: ODEProblem, solve, RK4
+using ClimaCore
+import CLIMAParameters as CP
+
+if !("." in LOAD_PATH)
+    push!(LOAD_PATH, ".")
+end
+using ClimaLSM
+using ClimaLSM.Domains: Column
+using ClimaLSM.Soil
+
+import ClimaLSM
+import ClimaLSM.Parameters as LSMP
+
+include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
+
+FT = Float64
+
+@testset "Richards comparison to Bonan; clay" begin
+    ν = FT(0.495)
+    K_sat = FT(0.0443 / 3600 / 100) # m/s
+    S_s = FT(1e-3) #inverse meters
+    vg_n = FT(1.43)
+    vg_α = FT(2.6) # inverse meters
+    vg_m = FT(1) - FT(1) / vg_n
+    θ_r = FT(0.124)
+    zmax = FT(0)
+    zmin = FT(-1.5)
+    nelems = 150
+    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+    z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
+
+    top_state_bc = StateBC((p, t) -> eltype(t)(ν - 1e-3))
+    bot_flux_bc = FreeDrainage{FT}()
+    sources = ()
+    boundary_states = (; water = (top = top_state_bc, bottom = bot_flux_bc))
+    params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
+
+    soil = Soil.RichardsModel{FT}(;
+        parameters = params,
+        domain = soil_domain,
+        boundary_conditions = boundary_states,
+        sources = sources,
+    )
+
+    Y, p, coords = initialize(soil)
+
+    # specify ICs
+    Y.soil.ϑ_l .= FT(0.24)
+    soil_ode! = make_ode_function(soil)
+
+    t0 = FT(0)
+    tf = FT(1e6)
+    dt = FT(0.25)
+    prob = ODEProblem(soil_ode!, Y, (t0, tf), p)
+    sol = solve(prob, RK4(); dt = dt, saveat = 10000)
+
+    N = length(sol.t)
+    ϑ_l = parent(sol.u[N].soil.ϑ_l)
+    bonan_clay_dataset = ArtifactWrapper(
+        @__DIR__,
+        "richards_clay",
+        ArtifactFile[ArtifactFile(
+            url = "https://caltech.box.com/shared/static/nk89znth59gcsdb65lnywnzjnuno3h6k.txt",
+            filename = "clay_bonan_sp801_22323.txt",
+        ),],
+    )
+    datapath = get_data_folder(bonan_clay_dataset)
+    data = joinpath(datapath, "clay_bonan_sp801_22323.txt")
+    ds_bonan = readdlm(data)
+    bonan_moisture = reverse(ds_bonan[:, 1])
+    bonan_z = reverse(ds_bonan[:, 2]) ./ 100.0
+    @test sqrt.(mean((bonan_moisture .- ϑ_l) .^ 2.0)) < FT(1e-3)
+    plot(ϑ_l, parent(z), label = "Clima")
+    plot!(bonan_moisture, bonan_z, label = "Bonan's Matlab code")
+    savefig("./experiments/Soil/clay_comparison_bonan_matlab.png")
+
+end
+
+
+@testset "Richards comparison to Bonan; sand" begin
+    ν = FT(0.287)
+    K_sat = FT(34 / 3600 / 100) # m/s
+    S_s = FT(1e-3) #inverse meters
+    vg_n = FT(3.96)
+    vg_α = FT(2.7) # inverse meters
+    vg_m = FT(1) - FT(1) / vg_n
+    θ_r = FT(0.075)
+    zmax = FT(0)
+    zmin = FT(-1.5)
+    nelems = 150
+    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+    z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
+
+    top_state_bc = StateBC((p, t) -> eltype(t)(0.267))
+    bot_flux_bc = FreeDrainage{FT}()
+    sources = ()
+    boundary_states = (; water = (top = top_state_bc, bottom = bot_flux_bc))
+    params = Soil.RichardsParameters{FT}(ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r)
+
+    soil = Soil.RichardsModel{FT}(;
+        parameters = params,
+        domain = soil_domain,
+        boundary_conditions = boundary_states,
+        sources = sources,
+    )
+
+    Y, p, coords = initialize(soil)
+
+    # specify ICs
+    Y.soil.ϑ_l .= FT(0.1)
+    soil_ode! = make_ode_function(soil)
+
+    t0 = FT(0)
+    tf = FT(60 * 60 * 0.8)
+    dt = FT(0.25)
+    prob = ODEProblem(soil_ode!, Y, (t0, tf), p)
+    sol = solve(prob, RK4(); dt = dt, saveat = 60 * dt)
+
+    N = length(sol.t)
+    ϑ_l = parent(sol.u[N].soil.ϑ_l)
+    bonan_sand_dataset = ArtifactWrapper(
+        @__DIR__,
+        "richards_sand",
+        ArtifactFile[ArtifactFile(
+            url = "https://caltech.box.com/shared/static/2vk7bvyjah8xd5b7wxcqy72yfd2myjss.csv",
+            filename = "sand_bonan_sp801.csv",
+        ),],
+    )
+    datapath = get_data_folder(bonan_sand_dataset)
+    data = joinpath(datapath, "sand_bonan_sp801.csv")
+    ds_bonan = readdlm(data, ',')
+    bonan_moisture = reverse(ds_bonan[:, 1])
+    bonan_z = reverse(ds_bonan[:, 2]) ./ 100.0
+    @test sqrt.(mean((bonan_moisture .- ϑ_l) .^ 2.0)) < FT(1e-3)
+    plot(ϑ_l, parent(z), label = "Clima")
+    plot!(bonan_moisture, bonan_z, label = "Bonan's Matlab code")
+    savefig("./experiments/Soil/sand_comparison_bonan_matlab.png")
+
+end


### PR DESCRIPTION
## Purpose 
Add the comparisons to Bonan's matlab simulations to buildkite.
Part of testing #157 

Solutions generated using https://github.com/gbonan/bonanmodeling/tree/master/sp_08_01
with haverkamp expression for K not being used - we used the standard vG version by commenting out these lines
https://github.com/gbonan/bonanmodeling/blob/master/sp_08_01/van_Genuchten.m#L36-L41


## To-do


## Content
Adds a line to the buildkite pipeline, and adds in a script which runs two Richards equation simulations, for clay and sand, and compares to solutions computed using Bonan's matlab code.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
