### PR TITLE
Generalize the driver interface

### DIFF
--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -133,12 +133,16 @@ import CLIMAParameters as CP
 
 # Lastly, let's bring in the bucket model types (from ClimaLSM) that we
 # will need access to.
-using ClimaLSM.Drivers: PrescribedAtmosphere, PrescribedRadiativeFluxes
 
 using ClimaLSM.Bucket: BucketModel, BucketModelParameters, BulkAlbedoFunction
 using ClimaLSM.Domains: coordinates, LSMSingleColumnDomain
 using ClimaLSM:
-    initialize, make_update_aux, make_ode_function, make_set_initial_aux_state
+    initialize,
+    make_update_aux,
+    make_ode_function,
+    make_set_initial_aux_state,
+    PrescribedAtmosphere,
+    PrescribedRadiativeFluxes
 # We also want to plot the solution
 using Plots
 

--- a/docs/tutorials/Bucket/coupled_bucket.jl
+++ b/docs/tutorials/Bucket/coupled_bucket.jl
@@ -48,7 +48,7 @@
 
 # To begin, let's import some necessary abstract and concrete types, as well as methods.
 using ClimaLSM
-using ClimaLSM.Drivers: AbstractAtmosphericDrivers, AbstractRadiativeDrivers
+using ClimaLSM: AbstractAtmosphericDrivers, AbstractRadiativeDrivers
 using ClimaLSM.Bucket: BucketModel, BucketModelParameters
 
 import ClimaLSM.Bucket:
@@ -83,8 +83,8 @@ struct CoupledRadiativeFluxes{FT} <: AbstractRadiativeDrivers{FT} end
 # Then, we define a new method for `surface_fluxes` and `net_radiation` which dispatch for these types:
 function ClimaLSM.Bucket.surface_fluxes(
     atmos::CoupledAtmosphere{FT},
+    model::BucketModel{FT},
     p,
-    t,
     _...,
 ) where {FT <: AbstractFloat}
     return (
@@ -96,8 +96,8 @@ end
 
 function ClimaLSM.Bucket.net_radiation(
     radiation::CoupledRadiativeFluxes{FT},
+    model::BucketModel{FT},
     p,
-    t,
     _...,
 ) where {FT <: AbstractFloat}
     return p.bucket.R_n
@@ -117,7 +117,13 @@ end
 # return the prescribed values for these quantities.
 
 # In the coupled case, we need to extend these functions with a `CoupledAtmosphere` method:
-function ClimaLSM.Bucket.surface_air_density(atmos::CoupledAtmosphere, p, _...)
+function ClimaLSM.surface_air_density(
+    atmos::CoupledAtmosphere,
+    model::BucketModel,
+    Y,
+    p,
+    _...,
+)
     return p.bucket.ρ_sfc
 end
 

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -11,10 +11,9 @@ import .Parameters as LSMP
 include("Regridder.jl")
 include("SharedUtilities/Domains.jl")
 using .Domains
-include("SharedUtilities/Drivers.jl")
-using .Drivers
-include("SharedUtilities/utils.jl")
 include("SharedUtilities/models.jl")
+include("SharedUtilities/drivers.jl")
+include("SharedUtilities/utils.jl")
 include("SharedUtilities/boundary_conditions.jl")
 include("SharedUtilities/sources.jl")
 include("Bucket/Bucket.jl")

--- a/test/Bucket/albedo_map_bucket.jl
+++ b/test/Bucket/albedo_map_bucket.jl
@@ -7,8 +7,6 @@ import CLIMAParameters as CP
 if !("." in LOAD_PATH)
     push!(LOAD_PATH, ".")
 end
-using ClimaLSM.Drivers: PrescribedAtmosphere, PrescribedRadiativeFluxes
-
 using ClimaLSM.Regridder: MapInfo, regrid_netcdf_to_field
 using ClimaLSM.Bucket:
     BucketModel,
@@ -18,7 +16,14 @@ using ClimaLSM.Bucket:
 using ClimaLSM.Domains:
     coordinates, LSMSingleColumnDomain, LSMSphericalShellDomain
 using ClimaLSM:
-    initialize, make_update_aux, make_ode_function, make_set_initial_aux_state
+    initialize,
+    make_update_aux,
+    make_ode_function,
+    make_set_initial_aux_state,
+    PrescribedAtmosphere,
+    PrescribedRadiativeFluxes
+
+
 
 # Bucket model parameters
 import ClimaLSM

--- a/test/Bucket/snow_bucket_tests.jl
+++ b/test/Bucket/snow_bucket_tests.jl
@@ -7,7 +7,6 @@ if !("." in LOAD_PATH)
     push!(LOAD_PATH, ".")
 end
 
-using ClimaLSM.Drivers: PrescribedAtmosphere, PrescribedRadiativeFluxes
 
 using ClimaLSM.Bucket:
     BucketModel,
@@ -20,7 +19,12 @@ using ClimaLSM.Domains:
     LSMMultiColumnDomain,
     LSMSphericalShellDomain
 using ClimaLSM:
-    initialize, make_update_aux, make_ode_function, make_set_initial_aux_state
+    initialize,
+    make_update_aux,
+    make_ode_function,
+    make_set_initial_aux_state,
+    PrescribedAtmosphere,
+    PrescribedRadiativeFluxes
 
 FT = Float64
 

--- a/test/Bucket/soil_bucket_tests.jl
+++ b/test/Bucket/soil_bucket_tests.jl
@@ -7,7 +7,7 @@ import CLIMAParameters as CP
 if !("." in LOAD_PATH)
     push!(LOAD_PATH, ".")
 end
-using ClimaLSM.Drivers: PrescribedAtmosphere, PrescribedRadiativeFluxes
+
 using ClimaLSM.Bucket: BucketModel, BucketModelParameters, BulkAlbedoFunction
 using ClimaLSM.Domains:
     coordinates,
@@ -15,7 +15,12 @@ using ClimaLSM.Domains:
     LSMMultiColumnDomain,
     LSMSphericalShellDomain
 using ClimaLSM:
-    initialize, make_update_aux, make_ode_function, make_set_initial_aux_state
+    initialize,
+    make_update_aux,
+    make_ode_function,
+    make_set_initial_aux_state,
+    PrescribedAtmosphere,
+    PrescribedRadiativeFluxes
 
 
 FT = Float64


### PR DESCRIPTION
## Purpose 
Cleans up the interface for `surface_fluxes` and `net_radiation`, by introducing helper functions which return T_sfc, q_sfc, rho_sfc, albedo, and emissivity for the model being used. This should be the most general case, as different models will store these things in different place, or not even at all (computed on the fly). 

The helper functions can also be called by the coupler when these quantities are needed. I think this can stand in for some helper functions that the coupler has already defined:
https://github.com/CliMA/ClimaCoupler.jl/blob/5b7dfcfbd07caaab3592bf83b9d8db53ea2fc80e/experiments/AMIP/moist_mpi_earth/bucket/bucket_utils.jl#L8

and longer term, we can try and remove all of those helper functions in the coupler?

## Content

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
