### PR TITLE
Modify drivers to include zenith angle, co2 concentration, and to use pressure over air density

### DIFF
--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -229,14 +229,14 @@ T_atmos = (t) -> eltype(t)(275.0 + 5.0 * sin(2.0 * π * t / 86400 + 7200));
 u_atmos = (t) -> eltype(t)(3.0);
 q_atmos = (t) -> eltype(t)(0.005);
 h_atmos = FT(2);
-ρ_atmos = (t) -> eltype(t)(1.13);
+P_atmos = (t) -> eltype(t)(101325);
 bucket_atmos = PrescribedAtmosphere(
     precip,
     snow_precip,
     T_atmos,
     u_atmos,
     q_atmos,
-    ρ_atmos,
+    P_atmos,
     h_atmos,
 );
 

--- a/src/Bucket/Bucket.jl
+++ b/src/Bucket/Bucket.jl
@@ -42,7 +42,8 @@ import ClimaLSM:
     surface_specific_humidity,
     surface_evaporative_scaling,
     surface_albedo,
-    surface_emissivity
+    surface_emissivity,
+    surface_height
 export BucketModelParameters,
     BucketModel,
     BulkAlbedoFunction,
@@ -469,9 +470,9 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
 
         # Compute turbulent surface fluxes
 
-        turbulent_fluxes = surface_fluxes(model.atmos, model, Y, p, t)
-        p.bucket.turbulent_energy_flux .= turbulent_fluxes.turbulent_energy_flux
-        p.bucket.evaporation .= turbulent_fluxes.evaporation
+        conditions = surface_fluxes(model.atmos, model, Y, p, t)
+        p.bucket.turbulent_energy_flux .= conditions.lhf .+ conditions.shf
+        p.bucket.evaporation .= conditions.vapor_flux
 
         # Radiative fluxes
         p.bucket.R_n .= net_radiation(model.radiation, model, Y, p, t)

--- a/src/Bucket/bucket_parameterizations.jl
+++ b/src/Bucket/bucket_parameterizations.jl
@@ -33,12 +33,12 @@ end
 a helper function which returns the surface temperature for the bucket 
 model, which is stored in the aux state.
 """
-function ClimaLSM.surface_temperature(model::BucketModel, Y, p)
+function ClimaLSM.surface_temperature(model::BucketModel, Y, p, t)
     return p.bucket.T_sfc
 end
 
 """
-    ClimaLSM.surface_temperature(model::BucketModel, Y, p)
+    ClimaLSM.surface_specific_humidity(model::BucketModel, Y, p)
 
 a helper function which returns the surface specific humidity for the bucket 
 model, which is stored in the aux state.
@@ -48,7 +48,17 @@ function ClimaLSM.surface_specific_humidity(model::BucketModel, Y, p, _...)
 end
 
 """
-    ClimaLSM.surface_temperature(model::BucketModel, Y, p)
+    ClimaLSM.surface_height(model::BucketModel, Y, p)
+
+a helper function which returns the surface height for the bucket 
+model, which is zero currently.
+"""
+function ClimaLSM.surface_height(model::BucketModel{FT}, Y, p) where {FT}
+    return FT(0)
+end
+
+"""
+    ClimaLSM.surface_air_density(model::BucketModel, Y, p)
 
 a helper function which computes and returns the surface air density for the bucket 
 model.

--- a/test/Bucket/albedo_map_bucket.jl
+++ b/test/Bucket/albedo_map_bucket.jl
@@ -70,14 +70,14 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         u_atmos = (t) -> eltype(t)(1.0)
         q_atmos = (t) -> eltype(t)(0.0) # no atmos water
         h_atmos = FT(1e-8)
-        ρ_atmos = (t) -> eltype(t)(1.13)
+        P_atmos = (t) -> eltype(t)(101325)
         bucket_atmos = PrescribedAtmosphere(
             precip,
             precip,
             T_atmos,
             u_atmos,
             q_atmos,
-            ρ_atmos,
+            P_atmos,
             h_atmos,
         )
         Δt = FT(1.0)

--- a/test/Bucket/snow_bucket_tests.jl
+++ b/test/Bucket/snow_bucket_tests.jl
@@ -75,14 +75,14 @@ for bucket_domain in bucket_domains
         u_atmos = (t) -> eltype(t)(10.0)
         q_atmos = (t) -> eltype(t)(0.03)
         h_atmos = FT(3)
-        ρ_atmos = (t) -> eltype(t)(1.13)
+        P_atmos = (t) -> eltype(t)(101325) # Pa
         bucket_atmos = PrescribedAtmosphere(
             precip,
             precip,
             T_atmos,
             u_atmos,
             q_atmos,
-            ρ_atmos,
+            P_atmos,
             h_atmos,
         )
         Δt = FT(1.0)

--- a/test/Bucket/soil_bucket_tests.jl
+++ b/test/Bucket/soil_bucket_tests.jl
@@ -71,14 +71,14 @@ for bucket_domain in bucket_domains
         u_atmos = (t) -> eltype(t)(1.0)
         q_atmos = (t) -> eltype(t)(0.0) # no atmos water
         h_atmos = FT(1e-8)
-        ρ_atmos = (t) -> eltype(t)(1.13)
+        P_atmos = (t) -> eltype(t)(101325)
         bucket_atmos = PrescribedAtmosphere(
             precip,
             precip,
             T_atmos,
             u_atmos,
             q_atmos,
-            ρ_atmos,
+            P_atmos,
             h_atmos,
         )
         Δt = FT(1.0)
@@ -135,14 +135,14 @@ for bucket_domain in bucket_domains
         u_atmos = (t) -> eltype(t)(4.0)
         q_atmos = (t) -> eltype(t)(0.01)
         h_atmos = FT(30)
-        ρ_atmos = (t) -> eltype(t)(1.13)
+        P_atmos = (t) -> eltype(t)(101325)
         bucket_atmos = PrescribedAtmosphere(
             precip,
             (t) -> eltype(t)(0.0),
             T_atmos,
             u_atmos,
             q_atmos,
-            ρ_atmos,
+            P_atmos,
             h_atmos,
         )
         Δt = FT(100.0)


### PR DESCRIPTION
## Purpose 
In preparation for the canopy model merge, this modifies the Prescribed driver types (Atmos and Radiation) to include zenith angle (in radiation) and co2 concentration (in atmos). It also switches from air density to pressure. We also now pass back LHF and SHF separately, and surface fluxes now takes into account the height of the surface in addition to the height of the atmosphere.

Major changes are made in SharedUtilities/drivers.jl. All other file changes are just propagating these changes.

## Content
As described above. doc strings are updated and so are tests/docs, etc.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
