### PR TITLE
LH appears in soil, snow, and bucket models

### DIFF
--- a/src/Soil/Soil.jl
+++ b/src/Soil/Soil.jl
@@ -59,6 +59,7 @@ using ClimaLSM
 using UnPack
 using DocStringExtensions
 using ClimaCore
+using Thermodynamics
 import ..Parameters as LSMP
 import ClimaCore: Fields, Operators, Geometry, Spaces
 

--- a/src/Soil/soil_heat_parameterizations.jl
+++ b/src/Soil/soil_heat_parameterizations.jl
@@ -1,4 +1,3 @@
-
 using UnPack
 export volumetric_internal_energy,
     temperature_from_ρe_int,
@@ -53,16 +52,17 @@ function phase_change_source(
     @unpack ν, vg_α, vg_n, vg_m, θ_r, earth_param_set = params
     _ρ_i = FT(LSMP.ρ_cloud_ice(earth_param_set))
     _ρ_l = FT(LSMP.ρ_cloud_liq(earth_param_set))
-    _LH_f0 = FT(LSMP.LH_f0(earth_param_set))
     _T_freeze = FT(LSMP.T_freeze(earth_param_set))
     _grav = FT(LSMP.grav(earth_param_set))
+    thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
+    _LH_fT = Thermodynamics.latent_heat_fusion(thermo_params, T)
     # According to Dall'Amico (text above equation 1), ψw0 corresponds
     # to the matric potential corresponding to the total water content (liquid and ice).
     θtot = min(_ρ_i / _ρ_l * θ_i + θ_l, ν)
     # This is consistent with Equation (22) of Dall'Amico
     ψw0 = matric_potential(vg_α, vg_n, vg_m, effective_saturation(ν, θtot, θ_r))
 
-    ψT = _LH_f0 / _T_freeze / _grav * (T - _T_freeze) * heaviside(_T_freeze - T)
+    ψT = _LH_fT / _T_freeze / _grav * (T - _T_freeze) * heaviside(_T_freeze - T)
     # Equation (23) of Dall'Amico
     θstar =
         inverse_matric_potential(vg_α, vg_n, vg_m, ψw0 + ψT) * (ν - θ_r) + θ_r


### PR DESCRIPTION
## Purpose 
Update code so that latent heats depend on temperature where it needs to.


## To-do
- ID all locations where LH is used: snow parameterizations (T and liquid content from internal energy), soil parameterizations (phase change and T from internal energy), and the bucket model (melt fluxes)
- ID which ones need to depend on temperature: the latent heat appearing in the Clausis-Clapeyron equation should depend on T, I think. I updated the docs so that this is the case. The latent heat appearing in the internal energy should be at the reference point, so this is not updated in snow or in soil. 
- TBD: revisit bucket model use of LH


## Content
- Update the latent heat appearing the soil phase change term to be dependent on temperature. This is correct is if the LH appearing in Clausius-Clapeyron depend on T.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
