### PR TITLE
adds new function for creating surface field with center values

### DIFF
--- a/docs/src/APIs/SharedUtilities.md
+++ b/docs/src/APIs/SharedUtilities.md
@@ -20,6 +20,7 @@ ClimaLSM.Domains.LSMSphericalShellDomain
 ClimaLSM.Domains.coordinates
 ClimaLSM.Domains.obtain_face_space
 ClimaLSM.Domains.obtain_surface_space
+ClimaLSM.Domains.top_center_to_surface
 ```
 
 ## Models

--- a/src/Bucket/Bucket.jl
+++ b/src/Bucket/Bucket.jl
@@ -437,23 +437,7 @@ Creates the update_aux! function for the BucketModel.
 """
 function make_update_aux(model::BucketModel{FT}) where {FT}
     function update_aux!(p, Y, t)
-        face_space =
-            ClimaLSM.Domains.obtain_face_space(model.domain.subsurface.space)
-        N = ClimaCore.Spaces.nlevels(face_space)
-        interp_c2f = ClimaCore.Operators.InterpolateC2F(
-            top = ClimaCore.Operators.Extrapolate(),
-            bottom = ClimaCore.Operators.Extrapolate(),
-        )
-        surface_space = model.domain.surface.space
-        p.bucket.T_sfc .= ClimaCore.Fields.Field(
-            ClimaCore.Fields.field_values(
-                ClimaCore.Fields.level(
-                    interp_c2f.(Y.bucket.T),
-                    ClimaCore.Utilities.PlusHalf(N - 1),
-                ),
-            ),
-            surface_space,
-        )
+        p.bucket.T_sfc .= ClimaLSM.Domains.top_center_to_surface(Y.bucket.T)
         p.bucket.ρ_sfc .=
             surface_air_density(model.atmos, model, Y, p, t, p.bucket.T_sfc)
 

--- a/src/Soil/energy_hydrology.jl
+++ b/src/Soil/energy_hydrology.jl
@@ -449,22 +449,7 @@ function ClimaLSM.surface_temperature(
     p,
     t,
 ) where {FT}
-    face_space = ClimaLSM.Domains.obtain_face_space(model.domain.space)
-    N = ClimaCore.Spaces.nlevels(face_space)
-    interp_c2f = ClimaCore.Operators.InterpolateC2F(
-        top = ClimaCore.Operators.Extrapolate(),
-        bottom = ClimaCore.Operators.Extrapolate(),
-    )
-    surface_space = ClimaLSM.Domains.obtain_surface_space(model.domain.space)
-    return ClimaCore.Fields.Field(
-        ClimaCore.Fields.field_values(
-            ClimaCore.Fields.level(
-                interp_c2f.(p.soil.T),
-                ClimaCore.Utilities.PlusHalf(N - 1),
-            ),
-        ),
-        surface_space,
-    )
+    return ClimaLSM.Domains.top_center_to_surface(p.soil.T)
 end
 
 """
@@ -568,22 +553,7 @@ function ClimaLSM.surface_specific_humidity(
     M_w = LSMP.molar_mass_water(model.parameters.earth_param_set)
     thermo_params =
         LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    face_space = ClimaLSM.Domains.obtain_face_space(model.domain.space)
-    N = ClimaCore.Spaces.nlevels(face_space)
-    interp_c2f = ClimaCore.Operators.InterpolateC2F(
-        top = ClimaCore.Operators.Extrapolate(),
-        bottom = ClimaCore.Operators.Extrapolate(),
-    )
-    surface_space = ClimaLSM.Domains.obtain_surface_space(model.domain.space)
-    ψ_sfc = ClimaCore.Fields.Field(
-        ClimaCore.Fields.field_values(
-            ClimaCore.Fields.level(
-                interp_c2f.(p.soil.ψ),
-                ClimaCore.Utilities.PlusHalf(N - 1),
-            ),
-        ),
-        surface_space,
-    )
+    ψ_sfc = ClimaLSM.Domains.top_center_to_surface(p.soil.ψ)
     q_sat =
         Thermodynamics.q_vap_saturation_generic.(
             Ref(thermo_params),


### PR DESCRIPTION
## Purpose 
We had some duplicate code that created a surface field from the top center values. We made a function which does this and implemented it to reduce duplication.


## To-do
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.



----
- [X] I have read and checked the items on the review checklist.
