### PR TITLE
imp, exp tendency functions instead of ode_function/rhs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,38 @@ Model <: AbstractModel
 All models have the same abstract supertype, and have shared functionality.
 There is the the option to define new methods particular to your model, or to
 fall back on defaults. The functions each new Model type can define are:
-- make_rhs()
+- make_compute_exp_tendency()
+- make_compute_imp_tendency()
 - make_update_aux()
+- make_exp_tendency()
+- make_imp_tendency()
 - initialize_prognostic()
 - initialize_auxiliary()
 - initialize()
 - prognostic_vars()
 - auxiliary_vars()
-    
+
 Each model will also have some notion of a domain with coordinates, parameter sets,
 and boundary conditions or other prescribed drivers.
+
+The AbstractModel type is extended by the types AbstractImExModel, which allows for
+mixed implicit and explicit timestepping, and AbstractExpModel, which only allows
+for explicit timestepping.
+AbstractModel is also extended by AbstractLandModel, which contains component
+models of type AbstractModel.
 
 Examples:
 
 Component Models:
-RichardsModel <: AbstractSoilModel <: AbstractModel [runnable w/o LandModel wrapper as well]
+RichardsModel <: AbstractSoilModel <: AbstractImExModel <: AbstractModel [runnable w/o LandModel wrapper as well]
 
-PlantHydraulicsModel <: AbstractVegetationModel <: AbstractModel  [runnable w/o LandModel wrapper as well]
+PlantHydraulicsModel <: AbstractVegetationModel <: AbstractExpModel <: AbstractModel  [runnable w/o LandModel wrapper as well]
 
-PondModel <: AbstractSurfaceWaterModel  <: AbstractModel  [runnable w/o LandModel wrapper as well]
+PondModel <: AbstractSurfaceWaterModel  <: AbstractExpModel <: AbstractModel  [runnable w/o LandModel wrapper as well]
 
 Combined Models:
 
-SoilPlantHydrologyModel <: AbstractModel (constructs the individual ComponentModels based on arguments)
+SoilPlantHydrologyModel <: AbstractLandModel <: AbstractModel (constructs the individual ComponentModels based on arguments)
 
 |||
 |---------------------:|:----------------------------------------------|

--- a/docs/src/APIs/SharedUtilities.md
+++ b/docs/src/APIs/SharedUtilities.md
@@ -27,8 +27,12 @@ ClimaLSM.Domains.top_center_to_surface
 
 ```@docs
 ClimaLSM.AbstractModel
-ClimaLSM.make_ode_function
-ClimaLSM.make_rhs
+ClimaLSM.AbstractImExModel
+ClimaLSM.AbstractExpModel
+ClimaLSM.make_exp_tendency
+ClimaLSM.make_imp_tendency
+ClimaLSM.make_compute_exp_tendency
+ClimaLSM.make_compute_imp_tendency
 ClimaLSM.make_update_aux
 ClimaLSM.make_set_initial_aux_state
 ClimaLSM.prognostic_vars

--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -142,7 +142,7 @@ using ClimaLSM.Domains: coordinates, LSMSingleColumnDomain
 using ClimaLSM:
     initialize,
     make_update_aux,
-    make_ode_function,
+    make_exp_tendency,
     make_set_initial_aux_state,
     PrescribedAtmosphere,
     PrescribedRadiativeFluxes
@@ -288,13 +288,13 @@ t0 = FT(0.0);
 set_initial_aux_state! = make_set_initial_aux_state(model);
 set_initial_aux_state!(p, Y, t0);
 
-# Then to create the entire right hand side function for the system
+# Then to create the entire right hand side (tendency) function for the system
 # of ordinary differential equations:
-ode_function! = make_ode_function(model);
+exp_tendency! = make_exp_tendency(model);
 
 # Then we can set up the simulation and solve it:
 tf = FT(7 * 86400);
-prob = ODEProblem(ode_function!, Y, (t0, tf), p);
+prob = ODEProblem(exp_tendency!, Y, (t0, tf), p);
 # We need a callback to get and store the auxiliary fields, as they
 # are not stored by default.
 saved_values = SavedValues(FT, ClimaCore.Fields.FieldVector);

--- a/docs/tutorials/Soil/freezing_front.jl
+++ b/docs/tutorials/Soil/freezing_front.jl
@@ -1,6 +1,6 @@
 # # Modeling a freezing front in unsaturated soil
 
-# Before reading this tutorial, 
+# Before reading this tutorial,
 # we recommend that you look over the coupled energy
 # and water [tutorial](@ref Soil/soil_energy_hydrology.md).
 # That tutorial showed how to solve the heat equation for soil volumetric
@@ -201,12 +201,12 @@ init_soil!(Y, coords.z, soil.parameters);
 
 # Create the ode function for the [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl)
 # ODEProblem, and choose a timestep, integration timespan, etc:
-ode! = make_ode_function(soil)
+exp_tendency! = make_exp_tendency(soil)
 t0 = FT(0)
 dt = FT(60)
 tf = FT(3600 * 50)
 
-prob = ODEProblem(ode!, Y, (t0, tf), p);
+prob = ODEProblem(exp_tendency!, Y, (t0, tf), p);
 
 # Now we can solve the problem. Here we use an RK4 timestepper:
 sol = solve(prob, RK4(); dt = dt, saveat = 0:3600:tf);

--- a/docs/tutorials/Soil/richards_equation.jl
+++ b/docs/tutorials/Soil/richards_equation.jl
@@ -126,7 +126,7 @@ soil = Soil.RichardsModel{FT}(;
     boundary_conditions = boundary_conditions,
     sources = sources,
 );
-soil_ode! = make_ode_function(soil);
+exp_tendency! = make_exp_tendency(soil);
 
 # # Set up the simulation
 # We can now initialize the prognostic and auxiliary variable vectors, and take
@@ -149,7 +149,7 @@ timeend = FT(60 * 60 * 24 * 36)
 dt = FT(100);
 
 # And then we can solve the system of equations, using [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl):
-prob = ODEProblem(soil_ode!, Y, (t0, timeend), p)
+prob = ODEProblem(exp_tendency!, Y, (t0, timeend), p)
 sol = solve(prob, RK4(); dt = dt, adaptive = false);
 
 # # Create some plots

--- a/docs/tutorials/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/Soil/soil_energy_hydrology.jl
@@ -201,7 +201,7 @@ soil = Soil.EnergyHydrology{FT}(;
     sources = sources,
 );
 
-soil_ode! = make_ode_function(soil);
+exp_tendency! = make_exp_tendency(soil);
 # # Set up the simulation
 # We can now initialize the prognostic and auxiliary variable vectors, and take
 # a peek at what those variables are:
@@ -242,7 +242,7 @@ end
 
 init_soil!(Y, coords.z, soil.parameters);
 # Updating the auxiliary to the initial state is not necessary, because
-# the first step of the ode_function is to update the auxiliary state.
+# the first step of the tendency function is to update the auxiliary state.
 # However, we want to plot the initial state in this tutorial, so
 # we update it here.
 update_aux! = make_update_aux(soil)
@@ -261,7 +261,7 @@ cb = SavingCallback(
     saved_values;
     saveat = 0:43200:timeend,
 )
-prob = ODEProblem(soil_ode!, Y, (t0, timeend), p);
+prob = ODEProblem(exp_tendency!, Y, (t0, timeend), p);
 sol = solve(prob, RK4(); dt = dt, saveat = 0:43200:timeend, callback = cb);
 
 # Extract output

--- a/experiments/LSM/ozark/ozark.jl
+++ b/experiments/LSM/ozark/ozark.jl
@@ -132,7 +132,7 @@ canopy_component_args = (;
     conductance = conductance_args,
     hydraulics = plant_hydraulics_args,
 )
-# Other info needed                         
+# Other info needed
 shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     LAI,
     h_stem + h_leaf,
@@ -158,7 +158,7 @@ land = SoilPlantHydrologyModel{FT}(;
     canopy_model_args = canopy_model_args,
 )
 Y, p, cds = initialize(land)
-ode! = make_ode_function(land)
+exp_tendency! = make_exp_tendency(land)
 
 #Initial conditions
 Y.soil.ϑ_l = FT(0.35)
@@ -185,7 +185,7 @@ update_aux!(p, Y, 0.0)
 
 # Simulation
 sv = SavedValues(FT, ClimaCore.Fields.FieldVector)
-prob = ODEProblem(ode!, Y, (t0, tf), p);
+prob = ODEProblem(exp_tendency!, Y, (t0, tf), p);
 cb = SavingCallback(
     (u, t, integrator) -> copy(integrator.p),
     sv;

--- a/experiments/Standalone/Biogeochemistry/experiment.jl
+++ b/experiments/Standalone/Biogeochemistry/experiment.jl
@@ -139,13 +139,13 @@ t0 = FT(0.0)
 update_aux! = make_update_aux(model)
 update_aux!(p, Y, t0)
 
-Soil_bio_ode! = make_ode_function(model)
+Soil_bio_exp_tendency! = make_exp_tendency(model)
 tf = FT(10000)
 dt = FT(10)
 saved_values = SavedValues(FT, ClimaCore.Fields.FieldVector)
 
 cb = SavingCallback((u, t, integrator) -> copy(integrator.p), saved_values)
-prob = ODEProblem(Soil_bio_ode!, Y, (t0, tf), p)
+prob = ODEProblem(Soil_bio_exp_tendency!, Y, (t0, tf), p)
 sol = solve(prob, Euler(); dt = dt, callback = cb)
 
 # Animation

--- a/experiments/Standalone/Soil/evaporation.jl
+++ b/experiments/Standalone/Soil/evaporation.jl
@@ -141,9 +141,9 @@ tf = FT(24 * 3600 * 15)
 dt = FT(100)
 
 init_soil!(Y, cds.z, soil.parameters)
-soil_ode! = make_ode_function(soil)
+soil_exp_tendency! = make_exp_tendency(soil)
 
-prob = ODEProblem(soil_ode!, Y, (t0, tf), p)
+prob = ODEProblem(soil_exp_tendency!, Y, (t0, tf), p)
 sol = solve(prob, RK4(); dt = dt, saveat = 3600);
 
 (; ν, vg_m, vg_n, θ_r, d_ds) = soil.parameters

--- a/experiments/Standalone/Soil/richards_comparison.jl
+++ b/experiments/Standalone/Soil/richards_comparison.jl
@@ -49,12 +49,12 @@ FT = Float64
 
     # specify ICs
     Y.soil.ϑ_l .= FT(0.24)
-    soil_ode! = make_ode_function(soil)
+    soil_exp_tendency! = make_exp_tendency(soil)
 
     t0 = FT(0)
     tf = FT(1e6)
     dt = FT(0.25)
-    prob = ODEProblem(soil_ode!, Y, (t0, tf), p)
+    prob = ODEProblem(soil_exp_tendency!, Y, (t0, tf), p)
     sol = solve(prob, RK4(); dt = dt, saveat = 10000)
 
     N = length(sol.t)
@@ -112,12 +112,12 @@ end
 
     # specify ICs
     Y.soil.ϑ_l .= FT(0.1)
-    soil_ode! = make_ode_function(soil)
+    soil_exp_tendency! = make_exp_tendency(soil)
 
     t0 = FT(0)
     tf = FT(60 * 60 * 0.8)
     dt = FT(0.25)
-    prob = ODEProblem(soil_ode!, Y, (t0, tf), p)
+    prob = ODEProblem(soil_exp_tendency!, Y, (t0, tf), p)
     sol = solve(prob, RK4(); dt = dt, saveat = 60 * dt)
 
     N = length(sol.t)

--- a/src/Soil/Soil.jl
+++ b/src/Soil/Soil.jl
@@ -7,7 +7,7 @@ in standalone mode.
 
 The soil model is assumed to have a set of prognostic `Y` and
 auxiliary `p` variables, which describe the state of the
-soil system. The system is evolved in time by solving 
+soil system. The system is evolved in time by solving
 equations of the form
 
 ```
@@ -16,9 +16,9 @@ equations of the form
 
 ```
 
-i.e. partial (or ordinary) differential equations depending 
+i.e. partial (or ordinary) differential equations depending
 on state `Y`,
-auxiliary functions of the state `p`, and other parameters 
+auxiliary functions of the state `p`, and other parameters
 represented by the ellipses. The operator `D` indicates a generic
 nonlinear differential operator.  Not every model
 requires auxilary variables, but these are useful for storing
@@ -31,7 +31,7 @@ Currently, both the Richardson Richards Equation (RRE; hydrology alone)
 and an integrated soil energy and hydrology model are supported.
 
 Addition of additional versions of soil
-models requires defining a model type (of super type 
+models requires defining a model type (of super type
 `AbstractSoilModel`), and extending the methods
 imported by Models.jl, as needed, for computing the
 right hand side functions of the ordinary differential equations
@@ -41,9 +41,9 @@ the right hand side is evaluated.
 This code base assumes that DifferentialEquations.jl
 will be used for evolving the system in time,
 and that the array-like objected being stepped forward
-is a `ClimaCore.Fields.FieldVector`. 
+is a `ClimaCore.Fields.FieldVector`.
 
-The `FieldVector` type is used in order to make use of 
+The `FieldVector` type is used in order to make use of
 `ClimaCore` functionality when solving PDEs (`ClimaCore` handles
 all of the spatial discretization and operator functionality)
  and for ease of handling multi-column models.
@@ -66,9 +66,10 @@ using Thermodynamics
 import ClimaLSM.Domains: Column, HybridBox, SphericalShell
 using ClimaLSM: AbstractTridiagonalW
 import ClimaLSM:
-    AbstractModel,
+    AbstractImExModel,
     make_update_aux,
-    make_rhs,
+    make_compute_exp_tendency,
+    make_compute_imp_tendency,
     make_update_jacobian,
     prognostic_vars,
     auxiliary_vars,
@@ -100,14 +101,14 @@ export RichardsModel,
 
 An abstract type for types of source terms for the soil equations.
 
-In standalone mode, the only supported source type is freezing and 
+In standalone mode, the only supported source type is freezing and
 thawing. ClimaLSM.jl creates additional sources to include as
 necessary e.g. root extraction (not available in stand alone mode).
 """
 abstract type AbstractSoilSource{FT} <: ClimaLSM.AbstractSource{FT} end
 
 """
-    AbstractSoilModel{FT} <: AbstractModel{FT} 
+    AbstractSoilModel{FT} <: ClimaLSM.AbstractImExModel{FT}
 
 The abstract type for all soil models.
 
@@ -115,7 +116,7 @@ Currently, we only have plans to support a RichardsModel, simulating
 the flow of liquid water through soil via the Richardson-Richards equation,
 and a fully integrated soil heat and water model, with phase change.
 """
-abstract type AbstractSoilModel{FT} <: ClimaLSM.AbstractModel{FT} end
+abstract type AbstractSoilModel{FT} <: ClimaLSM.AbstractImExModel{FT} end
 
 ClimaLSM.name(::AbstractSoilModel) = :soil
 ClimaLSM.domain(::AbstractSoilModel) = :subsurface

--- a/src/Soil/energy_hydrology.jl
+++ b/src/Soil/energy_hydrology.jl
@@ -125,7 +125,7 @@ end
 """
     EnergyHydrology <: AbstractSoilModel
 
-A model for simulating the flow of water and heat 
+A model for simulating the flow of water and heat
 in a porous medium by solving the Richardson-Richards equation
 and the heat equation, including terms for phase change.
 
@@ -163,19 +163,22 @@ function EnergyHydrology{FT}(;
 end
 
 """
-    make_rhs(model::EnergyHydrology)
+    make_compute_exp_tendency(model::EnergyHydrology)
 
-An extension of the function `make_rhs`, for the integrated soil
-energy and heat equations, including phase change.
+An extension of the function `make_compute_exp_tendency`, for the integrated
+soil energy and heat equations, including phase change.
 
 This function creates and returns a function which computes the entire
-right hand side of the PDE for `Y.soil.ϑ_l, Y.soil.θ_i, Y.soil.ρe_int`, 
+right hand side of the PDE for `Y.soil.ϑ_l, Y.soil.θ_i, Y.soil.ρe_int`,
 and updates `dY.soil` in place with those values.
+All of these quantities will be stepped explicitly.
 
 This has been written so as to work with Differential Equations.jl.
 """
-function ClimaLSM.make_rhs(model::EnergyHydrology{FT}) where {FT}
-    function rhs!(dY, Y, p, t)
+function ClimaLSM.make_compute_exp_tendency(
+    model::EnergyHydrology{FT},
+) where {FT}
+    function compute_exp_tendency!(dY, Y, p, t)
         z = ClimaCore.Fields.coordinate_field(model.domain.space).z
         Δz_top, Δz_bottom = get_Δz(z)
 
@@ -208,7 +211,7 @@ function ClimaLSM.make_rhs(model::EnergyHydrology{FT}) where {FT}
         # Passing WVector to gradient BC is passing a normal flux.
 
 
-        # Richards-Richardson RHS:
+        # Richards-Richardson RHS
         divf2c_rre = Operators.DivergenceF2C(
             top = Operators.SetValue(Geometry.WVector.(rre_top_flux_bc)),
             bottom = Operators.SetValue(Geometry.WVector.(rre_bot_flux_bc)),
@@ -243,7 +246,7 @@ function ClimaLSM.make_rhs(model::EnergyHydrology{FT}) where {FT}
         # This has to come last
         dss!(dY, model.domain)
     end
-    return rhs!
+    return compute_exp_tendency!
 end
 
 """
@@ -443,7 +446,7 @@ end
         t,
     ) where {FT}
 
-Returns the surface temperature field of the 
+Returns the surface temperature field of the
 `EnergyHydrology` soil model.
 
 The assumption is that the soil surface temperature
@@ -466,7 +469,7 @@ end
         p,
     ) where {FT}
 
-Returns the surface emissivity field of the 
+Returns the surface emissivity field of the
 `EnergyHydrology` soil model.
 """
 function ClimaLSM.surface_emissivity(
@@ -484,7 +487,7 @@ end
         p,
     ) where {FT}
 
-Returns the surface albedo field of the 
+Returns the surface albedo field of the
 `EnergyHydrology` soil model.
 """
 function ClimaLSM.surface_albedo(model::EnergyHydrology{FT}, Y, p) where {FT}
@@ -501,14 +504,14 @@ end
         T_sfc
     ) where {FT}
 
-Returns the surface air density field of the 
-`EnergyHydrology` soil model for the 
+Returns the surface air density field of the
+`EnergyHydrology` soil model for the
 `PrescribedAtmosphere` case.
 
 This assumes the ideal gas law and hydrostatic
 balance to estimate the air density at the surface
 from the values of surface temperature and the atmospheric
-thermodynamic state, 
+thermodynamic state,
 because the surface air density is not a prognostic
 variable of the soil model.
 """
@@ -536,7 +539,7 @@ end
         ρ_sfc
     ) where {FT}
 
-Returns the surface specific humidity field of the 
+Returns the surface specific humidity field of the
 `EnergyHydrology` soil model.
 
 This models the surface specific humidity as

--- a/src/Soil/rre.jl
+++ b/src/Soil/rre.jl
@@ -74,10 +74,10 @@ end
 
 
 """
-    make_rhs(model::RichardsModel)
+    make_compute_exp_tendency(model::RichardsModel)
 
-An extension of the function `make_rhs`, for the Richardson-
-Richards equation. 
+An extension of the function `make_compute_exp_tendency`, for the Richardson-
+Richards equation.
 
 This function creates and returns a function which computes the entire
 right hand side of the PDE for `ϑ_l`, and updates `dY.soil.ϑ_l` in place
@@ -85,8 +85,8 @@ with that value.
 
 This has been written so as to work with Differential Equations.jl.
 """
-function ClimaLSM.make_rhs(model::RichardsModel)
-    function rhs!(dY, Y, p, t)
+function ClimaLSM.make_compute_exp_tendency(model::RichardsModel)
+    function compute_exp_tendency!(dY, Y, p, t)
         (; ν, vg_α, vg_n, vg_m, K_sat, S_s, θ_r) = model.parameters
         z = ClimaCore.Fields.coordinate_field(model.domain.space).z
         Δz_top, Δz_bottom = get_Δz(z)
@@ -142,7 +142,7 @@ function ClimaLSM.make_rhs(model::RichardsModel)
         # This has to come last
         dss!(dY, model.domain)
     end
-    return rhs!
+    return compute_exp_tendency!
 end
 
 
@@ -181,12 +181,12 @@ ClimaLSM.prognostic_types(soil::RichardsModel{FT}) where {FT} = (FT,)
 """
     auxiliary_vars(soil::RichardsModel)
 
-A function which returns the names of the auxiliary variables 
+A function which returns the names of the auxiliary variables
 of `RichardsModel`.
 
 Note that auxiliary variables are not needed for such a simple model.
 We could instead compute the conductivity and matric potential within the
-rhs function explicitly, rather than compute and store them in the 
+tendency function explicitly, rather than compute and store them in the
 auxiliary vector `p`. We did so in this case as a demonstration.
 """
 ClimaLSM.auxiliary_vars(soil::RichardsModel) = (:K, :ψ)
@@ -195,7 +195,7 @@ ClimaLSM.auxiliary_types(soil::RichardsModel{FT}) where {FT} = (FT, FT)
     make_update_aux(model::RichardsModel)
 
 An extension of the function `make_update_aux`, for the Richardson-
-Richards equation. 
+Richards equation.
 
 This function creates and returns a function which updates the auxiliary
 variables `p.soil.variable` in place.
@@ -251,7 +251,7 @@ end
 )
 
 Outer constructor for the RichardsTridiagonalW Jacobian
-matrix struct. 
+matrix struct.
 
 Initializes all variables to zeros.
 """

--- a/src/Vegetation/component_models.jl
+++ b/src/Vegetation/component_models.jl
@@ -5,16 +5,16 @@
 
 An abstract type for canopy component parameterizations.
 
-Canopy component parameterizations do not run in standalone 
-mode, but only as part of a `CanopyModel`. As such, they 
-do not require all of the functionality of 
-`AbstractModel`s,  and they are not `AbstractModel`s 
+Canopy component parameterizations do not run in standalone
+mode, but only as part of a `CanopyModel`. As such, they
+do not require all of the functionality of
+`AbstractModel`s,  and they are not `AbstractModel`s
 themselves. The `CanopyModel` is an `AbstractModel`.
 
 However, some of the same functionality is nice to have
 for canopy components, especially when defining the variables,
 which is why we introduce the
-`AbstractCanopyComponent` type and extend many of the 
+`AbstractCanopyComponent` type and extend many of the
 methods for `ClimaLSM.AbstractModel`s for
 the canopy component parameterizations.
 """
@@ -97,16 +97,16 @@ function initialize_auxiliary(
 end
 
 """
-     ClimaLSM.make_rhs(component::AbstractCanopyComponent, canopy)
+     ClimaLSM.make_compute_exp_tendency(component::AbstractCanopyComponent, canopy)
 
-Creates the rhs!(dY,Y,p,t) function for the canopy `component`.
+Creates the compute_exp_tendency!(dY,Y,p,t) function for the canopy `component`.
 
 Since component models are not standalone models, other information
-may be needed and passed in (via the `canopy` model itself). 
-The right hand side for the entire canopy model can make use of 
+may be needed and passed in (via the `canopy` model itself).
+The right hand side for the entire canopy model can make use of
 these functions for the individual components.
 """
-function ClimaLSM.make_rhs(::AbstractCanopyComponent, canopy)
-    function rhs!(dY, Y, p, t) end
-    return rhs!
+function ClimaLSM.make_compute_exp_tendency(::AbstractCanopyComponent, canopy)
+    function compute_exp_tendency!(dY, Y, p, t) end
+    return compute_exp_tendency!
 end

--- a/test/Bucket/albedo_map_bucket.jl
+++ b/test/Bucket/albedo_map_bucket.jl
@@ -15,7 +15,6 @@ using ClimaLSM.Domains:
 using ClimaLSM:
     initialize,
     make_update_aux,
-    make_ode_function,
     make_set_initial_aux_state,
     PrescribedAtmosphere,
     PrescribedRadiativeFluxes

--- a/test/Bucket/snow_bucket_tests.jl
+++ b/test/Bucket/snow_bucket_tests.jl
@@ -15,7 +15,7 @@ using ClimaLSM.Domains:
 using ClimaLSM:
     initialize,
     make_update_aux,
-    make_ode_function,
+    make_exp_tendency,
     make_set_initial_aux_state,
     PrescribedAtmosphere,
     PrescribedRadiativeFluxes
@@ -109,10 +109,10 @@ for bucket_domain in bucket_domains
         t0 = FT(0.0)
         dY = similar(Y)
 
-        ode_function! = make_ode_function(model)
+        exp_tendency! = make_exp_tendency(model)
         set_initial_aux_state! = make_set_initial_aux_state(model)
         set_initial_aux_state!(p, Y, t0)
-        ode_function!(dY, Y, p, t0)
+        exp_tendency!(dY, Y, p, t0)
 
         _LH_f0 = LSMP.LH_f0(model.parameters.earth_param_set)
         _ρ_liq = LSMP.ρ_cloud_liq(model.parameters.earth_param_set)

--- a/test/LSM/pond_soil_lsm.jl
+++ b/test/LSM/pond_soil_lsm.jl
@@ -67,11 +67,11 @@ FT = Float64
     Y.surface_water.η .= 0.0
     dY = similar(Y)
 
-    ode! = make_ode_function(land)
+    exp_tendency! = make_exp_tendency(land)
     t = FT(0)
     dt = FT(1)
     for step in 1:10
-        ode!(dY, Y, p, t)
+        exp_tendency!(dY, Y, p, t)
         t = t + dt
         @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
     end
@@ -165,11 +165,11 @@ end
     # initialize the pond height to zero
     Y.surface_water.η .= 0.0
     dY = similar(Y)
-    ode! = make_ode_function(land)
+    exp_tendency! = make_exp_tendency(land)
     t = FT(0)
     dt = FT(1)
     for step in 1:10
-        ode!(dY, Y, p, t)
+        exp_tendency!(dY, Y, p, t)
         t = t + dt
         @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
     end

--- a/test/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -43,9 +43,9 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
     Y, p, coords = initialize(model)
     dY = similar(Y)
-    ode! = make_ode_function(model)
+    exp_tendency! = make_exp_tendency(model)
     t = FT(1)
-    ode!(dY, Y, p, t)
+    exp_tendency!(dY, Y, p, t)
     @test dY.soilco2.C ≈ p.soilco2.Sm
 end
 
@@ -81,9 +81,9 @@ end
 
     Y, p, coords = initialize(model)
     dY = similar(Y)
-    ode! = make_ode_function(model)
+    exp_tendency! = make_exp_tendency(model)
     t = FT(1)
     Y.soilco2.C .= FT(C)
-    ode!(dY, Y, p, t)
+    exp_tendency!(dY, Y, p, t)
     @test sum(dY.soilco2.C) ≈ FT(0.0)
 end

--- a/test/Soil/soil_bc.jl
+++ b/test/Soil/soil_bc.jl
@@ -6,7 +6,7 @@ using ClimaLSM.Domains: HybridBox, SphericalShell
 FT = Float64
 
 @testset "WVector usage in gradient" begin
-    # In our RHS, we want to set a boundary condition on flux, which is a gradient
+    # In our tendency, we want to set a boundary condition on flux, which is a gradient
     # of a scalar. This should be a covariant vector. In the case of no topography,
     # the Wvector points in the same direction as the covariant vector.
 

--- a/test/Soil/soil_test_3d.jl
+++ b/test/Soil/soil_test_3d.jl
@@ -61,11 +61,11 @@ FT = Float64
         end
         Ysoil.soil.ϑ_l .= hydrostatic_profile.(x, z, Ref(params))
     end
-    soil_ode! = make_ode_function(soil)
+    exp_tendency! = make_exp_tendency(soil)
     Y, p, coords = initialize(soil)
     init_soil!(Y, coords.x, coords.z, soil.parameters)
     dY = similar(Y)
-    soil_ode!(dY, Y, p, 0.0)
+    exp_tendency!(dY, Y, p, 0.0)
 
     function dθdx(x, z)
         z_∇ = zmin / 2.0 + (zmax - zmin) / 10.0 * sin(π * 2 * x / xmax)
@@ -306,17 +306,17 @@ end
 
 
 
-    soil_ode! = make_ode_function(soil)
+    exp_tendency! = make_exp_tendency(soil)
     dY = similar(Y)
-    soil_ode!(dY, Y, p, 0.0)
-    ## dY should be zero. Look at dY/Y. 
+    exp_tendency!(dY, Y, p, 0.0)
+    ## dY should be zero. Look at dY/Y.
     @test maximum(abs.(parent(dY.soil.ϑ_l))) / ν < 5e-12
     @test maximum(abs.(parent(dY.soil.θ_i))) / ν < 5e-12
     @test maximum(abs.(parent(dY.soil.ρe_int))) ./ 2.052e7 < 5e-12
 end
 
 
-@testset "Soil hydrology RHS on sphere" begin
+@testset "Soil hydrology tendency on sphere" begin
     ν = FT(0.44)
     K_sat = FT(1.0)
     S_s = FT(1e-3) #inverse meters
@@ -375,9 +375,9 @@ end
         Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
     end
     init_soil!(Y, coords.z, soil.parameters)
-    soil_ode! = make_ode_function(soil)
+    exp_tendency! = make_exp_tendency(soil)
     dY = similar(Y)
-    soil_ode!(dY, Y, p, 0.0)
+    exp_tendency!(dY, Y, p, 0.0)
     ## dY should be zero except at the boundary, where it should be ±30.
     @test (mean(unique(parent(ClimaCore.level(dY.soil.ϑ_l, 1)))) - 30.0) / ν <
           1e-11

--- a/test/Soil/soiltest.jl
+++ b/test/Soil/soiltest.jl
@@ -167,19 +167,17 @@ end
 
     init_soil!(Y, coords.z, soil.parameters)
 
-    soil_ode! = make_ode_function(soil)
-
     t0 = FT(0)
     dY = similar(Y)
-    ode! = make_ode_function(soil)
-    ode!(dY, Y, p, t0)
+    exp_tendency! = make_exp_tendency(soil)
+    exp_tendency!(dY, Y, p, t0)
     @test mean(parent(dY)) < 1e-8
     # should be hydrostatic equilibrium at every layer, at each step:
     @test mean(parent(p.soil.ψ .+ coords.z)[:] .+ 10.0) < 1e-10
 end
 
 
-@testset "Soil Energy and Water RHS unit tests" begin
+@testset "Soil Energy and Water tendency unit tests" begin
     earth_param_set = create_lsm_parameters(FT)
     ν = FT(0.495)
     K_sat = FT(0.0443 / 3600 / 100) # m/s
@@ -256,9 +254,9 @@ end
     end
 
     init_soil_heat!(Y, coords.z, soil_heat_on.parameters)
-    soil_ode! = make_ode_function(soil_heat_on)
+    exp_tendency! = make_exp_tendency(soil_heat_on)
     dY = similar(Y)
-    soil_ode!(dY, Y, p, 0.0)
+    exp_tendency!(dY, Y, p, 0.0)
     F_face = 0.0
     κ = parent(p.soil.κ)
     F_below = -0.5 * (κ[end] + κ[end - 1]) * (-Δz + 0.5)
@@ -311,9 +309,9 @@ end
     end
 
     init_soil_water!(Y, coords.z, soil_water_on.parameters)
-    soil_ode! = make_ode_function(soil_water_on)
+    exp_tendency! = make_exp_tendency(soil_water_on)
     dY = similar(Y)
-    soil_ode!(dY, Y, p, 0.0)
+    exp_tendency!(dY, Y, p, 0.0)
     function dKdθ(θ::FT)::FT where {FT}
         S = (θ - θ_r) / (ν - θ_r)
         if S < 1
@@ -452,9 +450,9 @@ end
     end
 
     init_soil_off!(Y, coords.z, soil_both_off.parameters)
-    soil_ode! = make_ode_function(soil_both_off)
+    exp_tendency! = make_exp_tendency(soil_both_off)
     dY = similar(Y)
-    soil_ode!(dY, Y, p, 0.0)
+    exp_tendency!(dY, Y, p, 0.0)
     @test maximum(abs.(parent(dY.soil.ρe_int))) == 0.0
     @test maximum(abs.(parent(dY.soil.ϑ_l))) == 0.0
     @test maximum(abs.(parent(dY.soil.θ_i))) == 0.0
@@ -499,9 +497,9 @@ end
     end
 
     init_soil_on!(Y, coords.z, soil_both_on.parameters)
-    soil_ode! = make_ode_function(soil_both_on)
+    exp_tendency! = make_exp_tendency(soil_both_on)
     dY = similar(Y)
-    soil_ode!(dY, Y, p, 0.0)
+    exp_tendency!(dY, Y, p, 0.0)
     @test maximum(abs.(parent(dY.soil.θ_i))) == 0.0
 
     θ = parent(Y.soil.ϑ_l)# on the center
@@ -635,7 +633,7 @@ end
     end
 
     init_soil_heat!(Y, coords.z, soil_heat_on.parameters)
-    soil_ode! = make_ode_function(soil_heat_on)
+    exp_tendency! = make_exp_tendency(soil_heat_on)
     dY = similar(Y)
     dY .= FT(0.0)
     source!(dY, sources[1], Y, p, soil_heat_on)

--- a/test/SurfaceWater/pond_test.jl
+++ b/test/SurfaceWater/pond_test.jl
@@ -25,7 +25,7 @@ FT = Float64
     Y, p, coords = initialize(pond_model)
     Y.surface_water.η .= FT(0.0)
 
-    pond_ode! = make_ode_function(pond_model)
+    exp_tendency! = make_exp_tendency(pond_model)
     t0 = FT(0)
     tf = FT(200)
     dt = FT(1)
@@ -44,7 +44,7 @@ FT = Float64
     dY = similar(Y)
     t = t0
     for step in 1:nsteps
-        pond_ode!(dY, Y, p, t)
+        exp_tendency!(dY, Y, p, t)
         @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
         t = t + dt
         if t % 40 == 0

--- a/test/Vegetation/canopy_model.jl
+++ b/test/Vegetation/canopy_model.jl
@@ -193,10 +193,10 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
               prognostic_types(getproperty(canopy, component))
     end
     Y.canopy.hydraulics[1] = plant_ν
-    ode! = make_ode_function(canopy)
+    exp_tendency! = make_exp_tendency(canopy)
     t0 = FT(0.0)
     dY = similar(Y)
-    ode!(dY, Y, p, t0)
+    exp_tendency!(dY, Y, p, t0)
     (evapotranspiration, shf, lhf) =
         canopy_surface_fluxes(canopy.atmos, canopy, Y, p, t0)
 

--- a/test/Vegetation/plant_hydraulics_test.jl
+++ b/test/Vegetation/plant_hydraulics_test.jl
@@ -182,7 +182,7 @@ domains = [
             radiation = radiation,
         )
         # Set system to hydrostatic equilibrium state by setting fluxes to zero, and setting LHS of both ODEs to 0
-        function initial_rhs!(F, Y)
+        function initial_compute_exp_tendency!(F, Y)
             T0A = FT(1e-8) * area_index[:leaf]
             for i in 1:(n_leaf + n_stem)
                 if i == 1
@@ -228,7 +228,11 @@ domains = [
             end
         end
 
-        soln = nlsolve(initial_rhs!, Vector(-0.03:0.01:0.07); ftol = 1e-11)
+        soln = nlsolve(
+            initial_compute_exp_tendency!,
+            Vector(-0.03:0.01:0.07);
+            ftol = 1e-11,
+        )
 
         S_l =
             inverse_water_retention_curve.(
@@ -250,8 +254,8 @@ domains = [
             p.canopy.hydraulics.fa[i] .= NaN
             dY.canopy.hydraulics.ϑ_l[i] .= NaN
         end
-        canopy_rhs! = make_rhs(model)
-        canopy_rhs!(dY, Y, p, 0.0)
+        canopy_compute_exp_tendency! = make_compute_exp_tendency(model)
+        canopy_compute_exp_tendency!(dY, Y, p, 0.0)
 
         m = similar(dY.canopy.hydraulics.ϑ_l[1])
         m .= FT(0)
@@ -271,8 +275,9 @@ domains = [
             p.canopy.hydraulics.fa[i] .= NaN
             standalone_dY.canopy.hydraulics.ϑ_l[i] .= NaN
         end
-        standalone_rhs! = make_rhs(model.hydraulics, nothing)
-        standalone_rhs!(standalone_dY, Y, p, 0.0)
+        standalone_compute_exp_tendency! =
+            make_compute_exp_tendency(model.hydraulics, nothing)
+        standalone_compute_exp_tendency!(standalone_dY, Y, p, 0.0)
 
         m = similar(dY.canopy.hydraulics.ϑ_l[1])
         m .= FT(0)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Part of SDI #135 
Replaces some functions to setup infrastructure for mixed implicit/explicit timestepping schemes:
- `make_ode_function` -> `make_exp_tendency, make_imp_tendency`
- `ode_function` -> `exp_tendency!, imp_tendency!`
- `make_rhs` -> `make_compute_exp_tendency, make_compute_imp_tendency`
- `rhs!` -> `compute_exp_tendency!, compute_imp_tendency!`

For now, the implicit functions aren't used (even for the Richards model). This will be addressed soon in another PR.

This PR also adds two new subtypes of the `AbstractModel` type, `AbstractImExType` and `AbstractExpType`. The former will be used for models which will be treated implicitly, and the former is for models which will be treated explicitly. These types are used for dispatch in functions that behave differently if the model is stepped implicitly or explicitly, such as `make_imp_tendency`.

## Content
- [x] Add `AbstractImExModel`, `AbstractExpModel` types
- [x] Add default functions for AbstractLandModel, AbstractModel, AbstractImExModel, AbstractCanopyComponent types
- [x] Replace all `make_rhs, rhs!` functions and calls with `make_compute_exp_tendency, compute_exp_tendency!`
- [x] Replace all `make_ode_function, ode_function!` functions and calls with `make_exp_tendency, exp_tendency!`
- [x] Update docs and tutorials to explain new interface
- [x] Test that the default functions  for abstract types return `nothing`

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
