### PR TITLE
Making canopy rhs and update aux more efficent and fix bugs!

### DIFF
--- a/docs/src/APIs/canopy/PlantHydraulics.md
+++ b/docs/src/APIs/canopy/PlantHydraulics.md
@@ -16,7 +16,7 @@ ClimaLSM.PlantHydraulics.effective_saturation
 ClimaLSM.PlantHydraulics.augmented_liquid_fraction
 ClimaLSM.PlantHydraulics.water_retention_curve
 ClimaLSM.PlantHydraulics.inverse_water_retention_curve
-ClimaLSM.PlantHydraulics.flux_out_roots
+ClimaLSM.PlantHydraulics.root_flux_per_ground_area!
 ClimaLSM.PlantHydraulics.flux
 ```
 

--- a/experiments/LSM/ozark/ozark.jl
+++ b/experiments/LSM/ozark/ozark.jl
@@ -242,7 +242,7 @@ Plots.plot!(
     xtickfontsize = 5,
     ytickfontsize = 5,
     xlim = [minimum(hours), maximum(hours)],
-    ylim = [0.2, 0.5],
+    ylim = [θ_r, soil_ν],
     xlabel = "Hours",
     ylabel = "SWC [m/m]",
 )

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -269,7 +269,7 @@ using .Snow
 include("Vegetation/Canopy.jl")
 using .Canopy
 using .Canopy.PlantHydraulics
-import .Canopy.PlantHydraulics: flux_out_roots
+import .Canopy.PlantHydraulics: root_flux_per_ground_area!
 ### Concrete types of AbstractLandModels
 ### and associated methods
 include("./soil_energy_hydrology_biogeochemistry.jl")

--- a/src/SharedUtilities/drivers.jl
+++ b/src/SharedUtilities/drivers.jl
@@ -16,7 +16,8 @@ export AbstractAtmosphericDrivers,
     net_radiation,
     surface_fluxes_at_a_point,
     liquid_precipitation,
-    snow_precipitation
+    snow_precipitation,
+    vapor_pressure_deficit
 
 """
      AbstractAtmosphericDrivers{FT <: AbstractFloat}
@@ -428,3 +429,24 @@ compute surface fluxes and radiative fluxes at the surface using
 the functions in this file.
 """
 function surface_height(model::AbstractModel, Y, p) end
+
+"""
+    vapor_pressure_deficit(T_air, P_air, q_air, thermo_params)
+
+Computes the vapor pressure deficit for air with temperature T_air,
+pressure P_air, and specific humidity q_air, using thermo_params,
+a Thermodynamics.jl param set.
+"""
+function vapor_pressure_deficit(T_air, P_air, q_air, thermo_params)
+    es = Thermodynamics.saturation_vapor_pressure(
+        thermo_params,
+        T_air,
+        Thermodynamics.Liquid(),
+    )
+    ea = Thermodynamics.partial_pressure_vapor(
+        thermo_params,
+        P_air,
+        Thermodynamics.PhasePartition(q_air),
+    )
+    return es - ea
+end

--- a/src/Vegetation/canopy_parameterizations.jl
+++ b/src/Vegetation/canopy_parameterizations.jl
@@ -327,8 +327,7 @@ function upscale_leaf_conductance(
     R::FT,
     P::FT,
 ) where {FT}
-    canopy_conductance = gs * LAI
-    canopy_conductance = canopy_conductance * (R * T) / P # convert to m s-1
+    canopy_conductance = gs * LAI * (R * T) / P # convert to m s-1
     return canopy_conductance
 end
 
@@ -410,19 +409,29 @@ function compute_Vcmax(
     R::FT,
     ΔHVcmax::FT,
 ) where {FT}
-    Vcmax = Vcmax25 * arrhenius_function(T, To, R, ΔHVcmax)#*exp(ep5*(Ta-To))/(R*Ta)
+    Vcmax = Vcmax25 * arrhenius_function(T, To, R, ΔHVcmax)
     return Vcmax
 end
 
 # 3. Stomatal conductance model
 """
-    medlyn_term(g1::FT, VPD::FT) where {FT}
+    medlyn_term(g1::FT, T_air::FT, P_air::FT, q_air::FT, thermo_params) where {FT}
 
 Computes the Medlyn term, equal to `1+g1/sqrt(VPD)`,
+by first computing the `VPD`,
 where `VPD` is the vapor pressure deficit in the atmosphere
 (Pa), and `g_1` is a constant with units of `sqrt(Pa)`.
+
+`thermo_params` is the Thermodynamics.jl parameter set.
 """
-function medlyn_term(g1::FT, VPD::FT) where {FT}
+function medlyn_term(
+    g1::FT,
+    T_air::FT,
+    P_air::FT,
+    q_air::FT,
+    thermo_params,
+) where {FT}
+    VPD = ClimaLSM.vapor_pressure_deficit(T_air, P_air, q_air, thermo_params)
     return 1 + g1 / sqrt(VPD)
 end
 

--- a/src/Vegetation/radiation.jl
+++ b/src/Vegetation/radiation.jl
@@ -43,5 +43,25 @@ struct BeerLambertModel{FT} <: AbstractRadiationModel{FT}
 end
 
 ClimaLSM.name(model::AbstractRadiationModel) = :radiative_transfer
-ClimaLSM.auxiliary_vars(model::BeerLambertModel) = (:apar,)
-ClimaLSM.auxiliary_types(model::BeerLambertModel{FT}) where {FT} = (FT,)
+ClimaLSM.auxiliary_vars(model::BeerLambertModel) = (:apar, :par)
+ClimaLSM.auxiliary_types(model::BeerLambertModel{FT}) where {FT} = (FT, FT)
+
+"""
+    compute_PAR(
+        model::BeerLambertModel,
+        solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+        t,
+    )
+
+Returns the estimated PAR (W/m^2) given the input solar radiation
+for the Beer-Lambert model.
+
+The estimated PAR is half of the incident shortwave radiation.
+"""
+function compute_PAR(
+    model::BeerLambertModel,
+    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+    t,
+)
+    return solar_radiation.SW_d(t) / 2
+end

--- a/test/Bucket/albedo_map_bucket.jl
+++ b/test/Bucket/albedo_map_bucket.jl
@@ -131,4 +131,5 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
             end
         end
     end
+    rm(regrid_dirpath, recursive = true)
 end

--- a/test/Vegetation/plant_hydraulics_test.jl
+++ b/test/Vegetation/plant_hydraulics_test.jl
@@ -252,8 +252,8 @@ domains = [
             p.canopy.hydraulics.fa[i] .= NaN
             dY.canopy.hydraulics.ϑ_l[i] .= NaN
         end
-        canopy_compute_exp_tendency! = make_compute_exp_tendency(model)
-        canopy_compute_exp_tendency!(dY, Y, p, 0.0)
+        canopy_exp_tendency! = make_exp_tendency(model)
+        canopy_exp_tendency!(dY, Y, p, 0.0)
 
         m = similar(dY.canopy.hydraulics.ϑ_l[1])
         m .= FT(0)
@@ -273,9 +273,11 @@ domains = [
             p.canopy.hydraulics.fa[i] .= NaN
             standalone_dY.canopy.hydraulics.ϑ_l[i] .= NaN
         end
-        standalone_compute_exp_tendency! =
+        update_aux! = make_update_aux(model)
+        standalone_exp_tendency! =
             make_compute_exp_tendency(model.hydraulics, nothing)
-        standalone_compute_exp_tendency!(standalone_dY, Y, p, 0.0)
+        update_aux!(p, Y, 0.0)
+        standalone_exp_tendency!(standalone_dY, Y, p, 0.0)
 
         m = similar(dY.canopy.hydraulics.ϑ_l[1])
         m .= FT(0)


### PR DESCRIPTION
## Purpose 
Reduce allocations in canopy update aux and the rhs function
Update plant hydraulics aux state in canopy update aux instead of in plant hydraulics RHS - this simplifies the plant hydraulics RHS, in an effort to debug: #180 
Fix a bug in p.canopy.conductance.transpiration that reduces it by a factor of LAI 
Fix a bug in the flux into the roots which multiplied it by an extra factor of RAI
Renamed some functions to be more clear what we are computing (per ground area vs per emitting area)

## Content
Using Julia1.8, with the model in test/Vegetation/canopy_model.jl
on main:
julia> @ btime exp_tendency!(dY,Y,p,t0) # updates aux + rhs
  89.083 μs (1456 allocations: 44.78 KiB)
julia>  @ btime update_aux!(p,Y,t0)
  9.958 μs (91 allocations: 3.45 KiB)
julia> @ btime exp_rhs!(dY,Y,p,t0)
  77.208 μs (1366 allocations: 41.36 KiB)

on this branch:
  8.208 μs (130 allocations: 7.31 KiB)
  4.613 μs (14 allocations: 1.30 KiB)
  3.531 μs (117 allocations: 6.08 KiB)

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
