### PR TITLE
Misc Bug fixes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,10 @@ steps:
   - label: "init environment :computer:"
     key: "init_cpu_env"
     command:
+
+      - echo "--- Configure MPI"
+      - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
+      
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project -e 'using Pkg; Pkg.precompile()'"
       - "julia --project -e 'using Pkg; Pkg.status()'"

--- a/experiments/LSM/ozark/ozark_domain.jl
+++ b/experiments/LSM/ozark/ozark_domain.jl
@@ -3,7 +3,8 @@
 nelements = 10
 zmin = FT(-2)
 zmax = FT(0)
-
+land_domain =
+    LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelements)
 
 # Number of stem and leaf compartments. Leaf compartments are stacked on top of stem compartments
 n_stem = Int64(1)

--- a/experiments/LSM/ozark/ozark_met_drivers_FLUXNET.jl
+++ b/experiments/LSM/ozark/ozark_met_drivers_FLUXNET.jl
@@ -40,7 +40,7 @@ column_names = driver_data[1, :]
 TA = driver_data[2:end, column_names .== "TA_F"] .+ 273.15; # convert C to K
 VPD = driver_data[2:end, column_names .== "VPD_F"] .* 100; # convert hPa to Pa
 PA = driver_data[2:end, column_names .== "PA_F"] .* 1000; # convert kPa to Pa
-P = driver_data[2:end, column_names .== "P_F"] ./ (1000 * 3600); # convert mm/HR to m/s
+P = driver_data[2:end, column_names .== "P_F"] ./ (1000 * 1800); # convert mm/HH to m/s
 WS = driver_data[2:end, column_names .== "WS_F"]; # already m/s
 LW_IN = driver_data[2:end, column_names .== "LW_IN_F"]
 SW_IN = driver_data[2:end, column_names .== "SW_IN_F"]

--- a/experiments/LSM/ozark/ozark_parameters.jl
+++ b/experiments/LSM/ozark/ozark_parameters.jl
@@ -1,5 +1,5 @@
 # Soil parameters
-soil_ν = FT(0.45) # m3/m3, from Wang et al. 2021 https://doi.org/10.5194/gmd-14-6741-2021
+soil_ν = FT(0.55) # m3/m3
 soil_K_sat = FT(4e-7) # m/s, matches Natan
 soil_S_s = FT(1e-3) # 1/m, guess
 soil_vg_n = FT(2.6257) # unitless, from Wang et al. 2021 https://doi.org/10.5194/gmd-14-6741-2021
@@ -24,7 +24,7 @@ oi = FT(0.209)
 θj = FT(0.9)
 f = FT(0.015)
 sc = FT(5e-6)
-ψc = FT(-2e6)
+pc = FT(-2e5)
 Vcmax25 = FT(5e-5)
 Γstar25 = FT(4.275e-5)
 Kc25 = FT(4.049e-4)

--- a/experiments/LSM/ozark/ozark_simulation.jl
+++ b/experiments/LSM/ozark/ozark_simulation.jl
@@ -1,6 +1,6 @@
 t0 = FT(0)
-N_days = 30
+N_days = 365
 tf = t0 + FT(3600 * 24 * N_days)
 dt = FT(30);
-halfhourly = Array(t0:(1800):(t0 + N_days * 3600 * 24))
-timestepper = RK4()
+hourly = Array(t0:(3600):(t0 + N_days * 3600 * 24))
+timestepper = Euler()

--- a/experiments/Manifest.toml
+++ b/experiments/Manifest.toml
@@ -154,9 +154,9 @@ version = "0.1.30"
 
 [[deps.CUDA]]
 deps = ["AbstractFFTs", "Adapt", "BFloat16s", "CEnum", "CUDA_Driver_jll", "CUDA_Runtime_Discovery", "CUDA_Runtime_jll", "CompilerSupportLibraries_jll", "ExprTools", "GPUArrays", "GPUCompiler", "KernelAbstractions", "LLVM", "LazyArtifacts", "Libdl", "LinearAlgebra", "Logging", "Preferences", "Printf", "Random", "Random123", "RandomNumbers", "Reexport", "Requires", "SparseArrays", "SpecialFunctions", "UnsafeAtomicsLLVM"]
-git-tree-sha1 = "280893f920654ebfaaaa1999fbd975689051f890"
+git-tree-sha1 = "beb01266a709235d8d9be1382d695a25f0b75bd3"
 uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
-version = "4.2.0"
+version = "4.3.0"
 
 [[deps.CUDA_Driver_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
@@ -202,9 +202,9 @@ version = "0.4.2"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
-git-tree-sha1 = "e8cfd4aeb2099d55331677f37f2447cffa4bf0f4"
+git-tree-sha1 = "9ef8838ca6cab5c79c090854c7159f3aee09d433"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.10.34"
+version = "0.10.36"
 
 [[deps.ClimaCoreTempestRemap]]
 deps = ["ClimaComms", "ClimaCore", "Dates", "LinearAlgebra", "NCDatasets", "PkgVersion", "TempestRemap_jll", "Test"]
@@ -214,7 +214,7 @@ version = "0.3.8"
 
 [[deps.ClimaLSM]]
 deps = ["ArtifactWrappers", "CLIMAParameters", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "Dates", "DocStringExtensions", "Insolation", "IntervalSets", "JLD2", "LinearAlgebra", "NCDatasets", "StaticArrays", "SurfaceFluxes", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "020d1ebe2a058d8d6e97ac5c3b493d43a96db79a"
+path = ".."
 uuid = "7884a58f-fab6-4fd0-82bb-ecfedb2d8430"
 version = "0.2.5"
 
@@ -394,9 +394,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "5eeb2bd01e5065090ad591a205d8cad432ae6cb6"
+git-tree-sha1 = "aa8ae1e8e8d4b5ef38a8fbc028fc75f3c5cad73d"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.93"
+version = "0.25.94"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -582,21 +582,21 @@ version = "0.1.4"
 
 [[deps.GPUCompiler]]
 deps = ["ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Scratch", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "5737dc242dadd392d934ee330c69ceff47f0259c"
+git-tree-sha1 = "11b2d77f29a85f3649c273a38f6618121c6b1c51"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "0.19.4"
+version = "0.20.2"
 
 [[deps.GR]]
 deps = ["Artifacts", "Base64", "DelimitedFiles", "Downloads", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Preferences", "Printf", "Random", "Serialization", "Sockets", "TOML", "Tar", "Test", "UUIDs", "p7zip_jll"]
-git-tree-sha1 = "d014972cd6f5afb1f8cd7adf000b7a966d62c304"
+git-tree-sha1 = "8b8a2fd4536ece6e554168c21860b6820a8a83db"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.72.5"
+version = "0.72.7"
 
 [[deps.GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "f670f269909a9114df1380cc0fcaa316fff655fb"
+git-tree-sha1 = "19fad9cd9ae44847fe842558a744748084a722d1"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.72.5+0"
+version = "0.72.7+0"
 
 [[deps.GaussQuadrature]]
 deps = ["SpecialFunctions"]
@@ -646,9 +646,9 @@ version = "1.0.2"
 
 [[deps.HDF5]]
 deps = ["Compat", "HDF5_jll", "Libdl", "Mmap", "Random", "Requires", "UUIDs"]
-git-tree-sha1 = "3dab31542b3da9f25a6a1d11159d4af8fdce7d67"
+git-tree-sha1 = "c73fdc3d9da7700691848b78c61841274076932a"
 uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-version = "0.16.14"
+version = "0.16.15"
 
 [[deps.HDF5_jll]]
 deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "OpenSSL_jll", "Pkg", "Zlib_jll"]

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -3,7 +3,11 @@ using UnPack
 using DocStringExtensions
 
 using ClimaCore
-import ClimaCore: Fields
+import ClimaCore: Fields, Spaces
+# Temporary fix 
+import ClimaComms
+ClimaCore.Spaces.PointSpace(x) =
+    ClimaCore.Spaces.PointSpace(ClimaComms.SingletonCommsContext(), x)
 
 include("Parameters.jl")
 import .Parameters as LSMP

--- a/src/SharedUtilities/drivers.jl
+++ b/src/SharedUtilities/drivers.jl
@@ -62,6 +62,8 @@ struct PrescribedAtmosphere{FT, LP, SP, TA, UA, QA, RA, CA} <:
     c_co2::CA
     "Reference height (m), relative to surface elevation"
     h::FT
+    "Minimum wind speed (gustiness; m/s)"
+    gustiness::FT
     function PrescribedAtmosphere(
         liquid_precip,
         snow_precip,
@@ -69,11 +71,12 @@ struct PrescribedAtmosphere{FT, LP, SP, TA, UA, QA, RA, CA} <:
         u,
         q,
         P,
-        h;
+        h::FT;
+        gustiness = FT(1),
         c_co2 = nothing,
-    )
+    ) where {FT}
         args = (liquid_precip, snow_precip, T, u, q, P, c_co2)
-        return new{typeof(h), typeof.(args)...}(args..., h)
+        return new{typeof(h), typeof.(args)...}(args..., h, gustiness)
     end
 
 end
@@ -216,6 +219,7 @@ function surface_fluxes_at_a_point(
         z0m = z_0m,
         z0b = z_0b,
         beta = β_sfc,
+        gustiness = atmos.gustiness,
     )
     surface_flux_params = LSMP.surface_fluxes_parameters(earth_param_set)
     conditions = SurfaceFluxes.surface_conditions(
@@ -232,6 +236,7 @@ function surface_fluxes_at_a_point(
         shf = conditions.shf,
         Ch = conditions.Ch,
         vapor_flux = vapor_flux,
+        r_ae = 1 / (conditions.Ch * SurfaceFluxes.windspeed(sc)),
     )
 end
 

--- a/src/Soil/boundary_conditions.jl
+++ b/src/Soil/boundary_conditions.jl
@@ -116,7 +116,7 @@ function soil_boundary_fluxes(
     S_c::FT = (1 + ((vg_n - 1) / vg_n)^(1 - 2 * vg_n))^(-vg_m)
     dsl = dry_soil_layer_thickness.(S_l_sfc, S_c, d_ds)
     r_soil = @. dsl / (_D_vapor * τ_a) # [s\m]
-    r_ae = @. 1 / (conditions.Ch * abs(bc.atmos.u(t))) # [s/m]
+    r_ae = conditions.r_ae
     net_water_flux = @. bc.atmos.liquid_precip(t) +
        conditions.vapor_flux * r_ae / (r_soil + r_ae)
     net_energy_flux =

--- a/src/Vegetation/canopy_parameterizations.jl
+++ b/src/Vegetation/canopy_parameterizations.jl
@@ -245,20 +245,20 @@ function net_photosynthesis(Ac::FT, Aj::FT, Rd::FT, β::FT) where {FT}
 end
 
 """
-    moisture_stress(ψl::FT,
+    moisture_stress(pl::FT,
                     sc::FT,
-                    ψc::FT) where {FT}
+                    pc::FT) where {FT}
 
 Computes the moisture stress factor (`β`), which is unitless,
  as a function of
-a constant (`sc`), a constant (`ψc`), and 
-the leaf water potential (`ψl`). 
+a constant (`sc`, 1/Pa), a reference pressure (`pc`, Pa), and 
+the leaf water pressure (`pl`, Pa) . 
 
 See Eqn 12.57 of G. Bonan's textbook, 
 Climate Change and Terrestrial Ecosystem Modeling (2019).
 """
-function moisture_stress(ψl::FT, sc::FT, ψc::FT) where {FT}
-    β = (1 + exp(sc * ψc)) / (1 + exp(sc * (ψc - ψl)))
+function moisture_stress(pl::FT, sc::FT, pc::FT) where {FT}
+    β = (1 + exp(sc * pc)) / (1 + exp(sc * (pc - pl)))
     return β
 end
 

--- a/src/Vegetation/photosynthesis.jl
+++ b/src/Vegetation/photosynthesis.jl
@@ -55,10 +55,10 @@ struct FarquharParameters{FT <: AbstractFloat}
     θj::FT
     "Constant factor appearing the dark respiration term, equal to 0.015."
     f::FT
-    "Fitting constant to compute the moisture stress factor (Pa^{-1})"
+    "Sensitivity to low water pressure, in the moisture stress factor, (Pa^{-1}) [Tuzet et al. (2003)]"
     sc::FT
-    "Fitting constant to compute the moisture stress factor (Pa)"
-    ψc::FT
+    "Reference water pressure for the moisture stress factor (Pa) [Tuzet et al. (2003)]"
+    pc::FT
 end
 
 """
@@ -68,7 +68,7 @@ end
         θj = FT(0.9), # unitless
         f = FT(0.015), # unitless
         sc = FT(5e-6),# Pa
-        ψc = FT(-2e6), # Pa
+        pc = FT(-2e6), # Pa
         Vcmax25 = FT(5e-5), # converted from 50 μmol/mol CO2/m^2/s to mol/m^2/s
         Γstar25 = FT(4.275e-5),  # converted from 42.75 μmol/mol to mol/mol
         Kc25 = FT(4.049e-4), # converted from 404.9 μmol/mol to mol/mol
@@ -91,7 +91,7 @@ function FarquharParameters{FT}(
     θj = FT(0.9),
     f = FT(0.015),
     sc = FT(5e-6),
-    ψc = FT(-2e6),
+    pc = FT(-2e6),
     Vcmax25 = FT(5e-5),
     Γstar25 = FT(4.275e-5),
     Kc25 = FT(4.049e-4),
@@ -122,7 +122,7 @@ function FarquharParameters{FT}(
         θj,
         f,
         sc,
-        ψc,
+        pc,
     )
 end
 
@@ -172,8 +172,6 @@ function compute_photosynthesis(
         θj,
         ϕ,
         mechanism,
-        sc,
-        ψc,
         oi,
         Kc25,
         Ko25,

--- a/test/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/Vegetation/test_bigleaf_parameterizations.jl
@@ -1,9 +1,5 @@
 using Test
 import CLIMAParameters as CP
-
-if !("." in LOAD_PATH)
-    push!(LOAD_PATH, ".")
-end
 using ClimaLSM.Canopy
 
 import ClimaLSM
@@ -31,7 +27,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     P = FT(101250) #Pa
     q = FT(0.02)
     VPD = ClimaLSM.vapor_pressure_deficit(T, P, q, thermo_params)#Pa
-    ψ_l = FT(-2e6) # Pa
+    p_l = FT(-2e6) # Pa
     ca = FT(4.11e-4) # mol/mol
     R = FT(LSMP.gas_constant(earth_param_set))
     θs = FT.(Array(0:0.1:(π / 2)))
@@ -113,10 +109,10 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
     Aj = light_assimilation.(Ref(photosynthesisparams.mechanism), J, ci, Γstar)
     @test all(@.(Aj == J * (ci - Γstar) / (4 * (ci + 2 * Γstar))))
-    β = moisture_stress(ψ_l, photosynthesisparams.sc, photosynthesisparams.ψc)
+    β = moisture_stress(p_l, photosynthesisparams.sc, photosynthesisparams.pc)
     @test β ==
-          (1 + exp(photosynthesisparams.sc * photosynthesisparams.ψc)) /
-          (1 + exp(photosynthesisparams.sc * (ψ_l - photosynthesisparams.ψc)))
+          (1 + exp(photosynthesisparams.sc * photosynthesisparams.pc)) /
+          (1 + exp(photosynthesisparams.sc * (p_l - photosynthesisparams.pc)))
     #    C4 tests
     @test rubisco_assimilation(
         C4(),


### PR DESCRIPTION
## Purpose 
This PR fixes a number of issues:
- Adds extension of PointSpace method that was deprecated in ClimaCore 10.35
- converts precip for the ozark test site into m/s correctly (from m/half hour)
- uses the LSM single column domain rather than a separate point and column domain for soil and canopy in the ozark test.
- converts plant potential psi from meters to Pa, and changes the name of the parameter from psi_c to P_c to indicate it is a pressure
- when windspeed is below the gustiness[m/s] in SurfaceFluxes, it uses the gustiness as the windspeed. Correct our comptutation of r_ae to use this (prevents a divide by zero when the windspeed -> 0). Allow gustiness to be set by us.
- adds additional debugging plots to the ozark test file (moisture stress factor, cumul precip and T)

co-authored with @AlexisRenchon 
(there will be a follow up PR to do the correct interpolation from centers to faces for unequal sized plant compartments.)

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

- [X] I have read and checked the items on the review checklist.
