### PR TITLE
Add some aqua tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,34 @@
+using Test
+using ClimaLSM
+using Aqua
+
+@testset "Aqua tests (performance)" begin
+    # This tests that we don't accidentally run into
+    # https://github.com/JuliaLang/julia/issues/29393
+    ua = Aqua.detect_unbound_args_recursively(ClimaLSM)
+    @test length(ua) ≤ 1
+
+    # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/1750
+    # Test that we're not introducing method ambiguities across deps
+    ambs = Aqua.detect_ambiguities(ClimaLSM; recursive = true)
+    pkg_match(pkgname, pkdir::Nothing) = false
+    pkg_match(pkgname, pkdir::AbstractString) = occursin(pkgname, pkdir)
+    filter!(x -> pkg_match("ClimaLSM", pkgdir(last(x).module)), ambs)
+
+    # Uncomment for debugging:
+    # for method_ambiguity in ambs
+    #     @show method_ambiguity
+    # end
+    @test length(ambs) ≤ 2
+end
+
+@testset "Aqua tests (additional)" begin
+    # Aqua.test_undefined_exports(ClimaLSM) # failing
+    # Aqua.test_stale_deps(ClimaLSM) # failing
+    # Aqua.test_deps_compat(ClimaLSM) # failing
+    Aqua.test_project_extras(ClimaLSM)
+    Aqua.test_project_toml_formatting(ClimaLSM)
+    # Aqua.test_piracy(ClimaLSM) # failing
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+include("aqua.jl")
 include("./Snow/parameterizations.jl")
 include("./implicit_timestepping/richards_model.jl")
 include("./Vegetation/test_bigleaf_parameterizations.jl")


### PR DESCRIPTION
This PR adds some aqua tests. @juliasloan25, can you follow through on fixing the following?

 - Unbound argument methods
 - `test_stale_deps`
 - `test_undefined_exports`
 - `test_deps_compat`

If you can fix the ambiguities, great, if not, don't worry, they're not always trivial, and sometimes it's just a julia issue.