### PR TITLE
Zero lai

### DIFF
--- a/src/soil_plant_hydrology_model.jl
+++ b/src/soil_plant_hydrology_model.jl
@@ -133,7 +133,10 @@ function make_interactions_update_aux(
         z = ClimaCore.Fields.coordinate_field(land.soil.domain.space).z
         (; area_index, conductivity_model) = land.canopy.hydraulics.parameters
         @. p.root_extraction =
-            area_index[:root] *
+            (
+                area_index[:root] +
+                area_index[land.canopy.hydraulics.compartment_labels[1]]
+            ) / 2 *
             PlantHydraulics.flux(
                 z,
                 land.canopy.hydraulics.compartment_midpoints[1],

--- a/test/Vegetation/canopy_model.jl
+++ b/test/Vegetation/canopy_model.jl
@@ -104,7 +104,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
     # Plant Hydraulics
     RAI = FT(1)
-    SAI = FT(1)
+    SAI = FT(0)
     area_index = (root = RAI, stem = SAI, leaf = LAI)
     K_sat_plant = FT(1.8e-8) # m/s
     ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value


### PR DESCRIPTION
## Purpose 
In the current codebase, setting the area indices of the plant to zero would result in a 0/0, because, for example, we have:
` d theta_leaf/dt = [stem_flux *LAI - canopy_transpiration]/ (LAI x Delta z)`, where canopy_transpiration involves a multiplication by LAI as well. 

Because we cannot have a changing number of prognostic variables across the domain, even when there is no vegetation present, we need to have a canopy model with some prognostic variables, parameters, etc. To turn off the canopy, setting LAI = SAI = RAI = 0 will imply zero fluxes and zero root extraction, and no change in the initial conditions of the plant prognostic variables. 

Therefore, update the codebase so that when LAI=SAI=RAI = 0, `d theta/ dt = 0` and there is no divide by zero.

Once we get closer to global runs, we should do some refactoring as it makes sense to make it so you dont need to define all these parameters where there is no vegetation. See Issue #250.

## Content
1. Change "LAI/(LAI x dz)" terms to "LAI/max(LAI x dz, eps(FT))". When LAI = 0, this gives zero flux and does not divide by zero.
2. Add consistency checks to the PlantHydraulics constructor:
- if LAI == 0, all area indices should be zero (no plant present)
- if LAI is nonzero, RAI must be nonzero (a plant cannot exist without roots)
- if n_stem == 0, the stem area index must be zero for consistency.
3. Adds unit tests to make sure consistency checks pass and that when LAI =RAI = SAI = 0, the root extraction and transpiration are both zero.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
