### PR TITLE
Prototype branch: LAI as a function of time

### DIFF
--- a/experiments/integrated/ozark/hydrology_only/ozark.jl
+++ b/experiments/integrated/ozark/hydrology_only/ozark.jl
@@ -102,7 +102,7 @@ photosynthesis_args = (;
     )
 )
 # Set up plant hydraulics
-area_index = (root = RAI, stem = SAI, leaf = LAI)
+area_index = (root = RAI, stem = SAI, leaf = max_LAI) # misleading placeholder - LAI value will be updated each timestep
 
 function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
     return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m

--- a/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
+++ b/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
@@ -91,6 +91,21 @@ atmos_h = FT(32)
 precipitation_function(t::FT) where {FT} = p_spline(t) < 0.0 ? p_spline(t) : 0.0 # m/s
 snow_precip(t) = eltype(t)(0) # this is likely not correct
 
+# LAI data from compartment_midpoints#
+lai_af = ArtifactFile(
+    url = "https://caltech.box.com/shared/static/yfqj0yqkx8yps7ydltsaixuy99083pon.csv",
+    filename = "Ozark_MODIS_LAI_2005.csv",
+)
+lai_dataset = ArtifactWrapper(@__DIR__, "modis_data", ArtifactFile[lai_af]);
+lai_dataset_path = get_data_folder(lai_dataset);
+lai_raw_data = joinpath(lai_dataset_path, "Ozark_MODIS_LAI_2005.csv");
+LAI_data = readdlm(lai_raw_data, ',') #m2.m-2
+LAI_column_names = LAI_data[1, :]
+LAI_data = LAI_data[2:end, LAI_column_names .== "lai_mean"] #m2.m-2
+# This has the same timestamsp as the driver data, so it's ok to use the time column from that file here
+LAI = Spline1D(seconds, LAI_data[:])
+
+
 
 # Construct the drivers
 atmos = ClimaLSM.PrescribedAtmosphere(

--- a/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
+++ b/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
@@ -10,22 +10,7 @@ function replace_missing_with_mean!(field, flag)
     return field
 end
 
-# Fluxnet Ozark (CO2 and H2O fluxes and met drivers)
-# 2005 data extracted as follows:
-#af = ArtifactFile(
-#    url = "https://caltech.box.com/shared/static/cy4jlul43kx72r2pqthvm4isjwkatgxy.csv",
-#    filename = "AMF_US-MOz_FLUXNET_FULLSET_HH_2004-2019_3-5.csv",
-#)
-#dataset = ArtifactWrapper(@__DIR__, "ameriflux_data_all_years", ArtifactFile[af]);
-#dataset_path = get_data_folder(dataset);
-#data = joinpath(dataset_path, "AMF_US-MOz_FLUXNET_FULLSET_HH_2004-2019_3-5.csv")
-#driver_data = readdlm(data, ',')
-#mask = Dates.year.(LOCAL_DATETIME) .== 2005
-#data_from_2005 = vcat(driver_data[[1],:], driver_data[2:end, :][mask, :])
-#open("AMF_US-MOz_FLUXNET_FULLSET_HH_2005.csv"), "w") do io
-#             writedlm(io, data_from_2005, ',')
-#         end
-
+# Fluxnet Ozark (CO2 and H2O fluxes and met drivers) from 2005
 af = ArtifactFile(
     url = "https://caltech.box.com/shared/static/1uwg8rjg2wx7y0vp8j9kv2d44y3fajyk.csv",
     filename = "AMF_US-MOz_FLUXNET_FULLSET_HH_2005.csv",
@@ -91,7 +76,7 @@ atmos_h = FT(32)
 precipitation_function(t::FT) where {FT} = p_spline(t) < 0.0 ? p_spline(t) : 0.0 # m/s
 snow_precip(t) = eltype(t)(0) # this is likely not correct
 
-# LAI data from compartment_midpoints#
+# LAI data
 lai_af = ArtifactFile(
     url = "https://caltech.box.com/shared/static/yfqj0yqkx8yps7ydltsaixuy99083pon.csv",
     filename = "Ozark_MODIS_LAI_2005.csv",
@@ -102,7 +87,7 @@ lai_raw_data = joinpath(lai_dataset_path, "Ozark_MODIS_LAI_2005.csv");
 LAI_data = readdlm(lai_raw_data, ',') #m2.m-2
 LAI_column_names = LAI_data[1, :]
 LAI_data = LAI_data[2:end, LAI_column_names .== "lai_mean"] #m2.m-2
-# This has the same timestamsp as the driver data, so it's ok to use the time column from that file here
+# This has the same timestamp as the driver data, so it's ok to use the time column from that file here
 LAI = Spline1D(seconds, LAI_data[:])
 
 

--- a/experiments/integrated/ozark/ozark_parameters.jl
+++ b/experiments/integrated/ozark/ozark_parameters.jl
@@ -59,7 +59,7 @@ To = FT(298.15)
 
 # Plant Hydraulics and general plant parameters
 SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?
-LAI = FT(4.2) # m2/m2, from Wang et al.
+max_LAI = FT(4.2) # m2/m2, from Wang et al.
 f_root_to_shoot = FT(3.5)
 RAI = (SAI + LAI) * f_root_to_shoot # CLM
 K_sat_plant = 5e-9 # m/s # seems much too small?

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -143,8 +143,8 @@ function CanopyModel{FT}(;
     #        AssertionError(
     #            "The leaf area index must be the same between the plant hydraulics and shared canopy parameters.",
     #        ),
-   #     )
-   # end
+    #     )
+    # end
     args = (
         radiative_transfer,
         photosynthesis,
@@ -383,7 +383,8 @@ function ClimaLSM.make_update_aux(
         n_leaf = hydraulics.n_leaf
         (; retention_model, conductivity_model, S_s, ν, area_index) =
             hydraulics.parameters
-        area_index = (root = area_index[:root], stem = area_index[:stem], leaf = LAI)
+        area_index =
+            (root = area_index[:root], stem = area_index[:stem], leaf = LAI)
         @inbounds @. ψ[1] = PlantHydraulics.water_retention_curve(
             retention_model,
             PlantHydraulics.effective_saturation(ν, ϑ_l[1]),
@@ -510,13 +511,7 @@ function canopy_surface_fluxes(
     leaf_conductance = p.canopy.conductance.gs
     LAI = model.parameters.LAI(t)
     canopy_conductance =
-        upscale_leaf_conductance.(
-            leaf_conductance,
-            LAI,
-            T,
-            R,
-            P,
-        )
+        upscale_leaf_conductance.(leaf_conductance, LAI, T, R, P)
     r_sfc = @. 1 / (canopy_conductance) # [s/m]
     r_ae = conditions.r_ae # [s/m]
     r_eff = r_ae .+ r_sfc

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -204,7 +204,7 @@ function PlantHydraulicsModel{FT}(;
 ) where {FT}
     args = (parameters, root_extraction, transpiration)
     area_index = parameters.area_index
-    lai_consistency_check(n_stem, n_leaf, area_index)
+    #lai_consistency_check(n_stem, n_leaf, area_index)
     @assert (n_leaf + n_stem) == length(compartment_midpoints)
     @assert (n_leaf + n_stem) + 1 == length(compartment_surfaces)
     for i in 1:length(compartment_midpoints)

--- a/src/standalone/Vegetation/component_models.jl
+++ b/src/standalone/Vegetation/component_models.jl
@@ -21,20 +21,20 @@ the canopy component parameterizations.
 abstract type AbstractCanopyComponent{FT <: AbstractFloat} end
 
 """
-    ClimaLSM.auxiliary_types(::AbstractCanopyComponent)
+    ClimaLSM.auxiliary_types(::AbstractCanopyComponent, canopy)
 
 Returns the auxiliary types of the canopy component
 passed in as an argument.
 """
-ClimaLSM.auxiliary_types(::AbstractCanopyComponent) = ()
+ClimaLSM.auxiliary_types(::AbstractCanopyComponent, canopy) = ()
 
 """
-    ClimaLSM.prognostic_types(::AbstractCanopyComponent)
+    ClimaLSM.prognostic_types(::AbstractCanopyComponent, canopy)
 
 Returns the prognostic types of the canopy component
 passed in as an argument.
 """
-ClimaLSM.prognostic_types(::AbstractCanopyComponent) = ()
+ClimaLSM.prognostic_types(::AbstractCanopyComponent, canopy) = ()
 
 """
     ClimaLSM.prognostic_vars(::AbstractCanopyComponent)
@@ -51,51 +51,6 @@ Returns the auxiliary types of the canopy component
 passed in as an argument.
 """
 ClimaLSM.auxiliary_vars(::AbstractCanopyComponent) = ()
-
-"""
-    initialize_prognostic(
-        component::AbstractCanopyComponent,
-        state,
-    )
-
-Creates and returns a ClimaCore.Fields.FieldVector
-with the prognostic variables of the canopy component
- `component`, stored using the name of the component.
-
-The input `state` is usually a ClimaCore Field object.
-"""
-function initialize_prognostic(component::AbstractCanopyComponent, state)
-    ClimaLSM.initialize_vars(
-        prognostic_vars(component),
-        prognostic_types(component),
-        state,
-        name(component),
-    )
-end
-
-"""
-    initialize_auxiliary(
-        component::AbstractCanopyComponent,
-        state,
-    )
-
-Creates and returns a ClimaCore.Fields.FieldVector
-with the auxiliary variables of the canopy component
- `component`, stored using the name of the component.
-
-The input `state` is usually a ClimaCore Field object.
-"""
-function initialize_auxiliary(
-    component::AbstractCanopyComponent{FT},
-    state,
-) where {FT}
-    ClimaLSM.initialize_vars(
-        auxiliary_vars(component),
-        auxiliary_types(component),
-        state,
-        name(component),
-    )
-end
 
 """
      ClimaLSM.make_compute_exp_tendency(component::AbstractCanopyComponent, canopy)

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -132,7 +132,7 @@ end
 
 ClimaLSM.name(model::AbstractPhotosynthesisModel) = :photosynthesis
 ClimaLSM.auxiliary_vars(model::FarquharModel) = (:An, :GPP)
-ClimaLSM.auxiliary_types(model::FarquharModel{FT}) where {FT} = (FT, FT)
+ClimaLSM.auxiliary_types(model::FarquharModel{FT},_) where {FT} = (FT, FT)
 
 """
     compute_photosynthesis(

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -44,7 +44,7 @@ end
 
 ClimaLSM.name(model::AbstractRadiationModel) = :radiative_transfer
 ClimaLSM.auxiliary_vars(model::BeerLambertModel) = (:apar, :par)
-ClimaLSM.auxiliary_types(model::BeerLambertModel{FT}) where {FT} = (FT, FT)
+ClimaLSM.auxiliary_types(model::BeerLambertModel{FT},_) where {FT} = (FT, FT)
 
 """
     compute_PAR(

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -44,5 +44,5 @@ end
 ClimaLSM.name(model::AbstractStomatalConductanceModel) = :conductance
 ClimaLSM.auxiliary_vars(model::MedlynConductanceModel) =
     (:medlyn_term, :gs, :transpiration)
-ClimaLSM.auxiliary_types(model::MedlynConductanceModel{FT}) where {FT} =
+ClimaLSM.auxiliary_types(model::MedlynConductanceModel{FT},_) where {FT} =
     (FT, FT, FT)

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -26,7 +26,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
                     for n_l in n_leaf
                         area_index = (root = R, stem = S, leaf = L)
                         if n_l == 0
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                            @test_throws AssertionError ClimaLSM.Canopy.lai_consistency_check(
                                 n_s,
                                 n_l,
                                 area_index,
@@ -34,7 +34,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
                         end
 
                         if (L > eps(FT) || S > eps(FT)) && R < eps(FT)
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                            @test_throws AssertionError ClimaLSM.Canopy.lai_consistency_check(
                                 n_s,
                                 n_l,
                                 area_index,
@@ -42,7 +42,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
                         end
 
                         if S > FT(0) && n_s == 0
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                            @test_throws AssertionError ClimaLSM.Canopy.lai_consistency_check(
                                 n_s,
                                 n_l,
                                 area_index,
@@ -50,7 +50,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
                         end
 
                         if S < eps(FT) && n_s > 0
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                            @test_throws AssertionError ClimaLSM.Canopy.lai_consistency_check(
                                 n_s,
                                 n_l,
                                 area_index,


### PR DESCRIPTION
## Purpose 
- Allow for LAI to be a function of time - and SAI/RAI? -> add LAI to the aux state.
- This PR is meant for site level runs, for example, at the ozark site, where we have LAI data throughout the year. But make this flexible enough to also work in 2d: LAI (lat, long, t).
- remove duplicate definitions of LAI in plant hydraulics parameters and in shared canopy parameters


## To-do
Currently, for met data, we fit spline functions to the data to get e.g. precip(t), radiation(t), and we can also do the same for lai(t). We then store the spline functions in structs and pass to the model. 

Im not sure how well this will work as a function of space (fitting splines as a function of lat/long/t). I think what Julia is working on is the better alternative: we have the parameters that vary in time and space as auxiliary variables, and update them via "update aux" each step when we read from the file and interpolate to the simulation time. 

This is described in https://github.com/CliMA/ClimaLSM.jl/issues/126.

I think we can already plan for Julia's work by making LAI a function of aux and updating it via "update aux", even if for now, in update aux we just call the spline function.




## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
