### PR TITLE
Root depths parameter usage

### DIFF
--- a/docs/tutorials/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/Canopy/canopy_tutorial.jl
@@ -212,12 +212,12 @@ plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
 root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0)
 
 ψ_soil0 = FT(0.0)
-root_extraction = PrescribedSoilPressure{FT}((t::FT) -> ψ_soil0)
+soil_potential = t -> eltype(t)(ψ_soil0)
+root_extraction = PrescribedSoilPressure{FT}(root_depths, soil_potential)
 
 plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
     parameters = plant_hydraulics_ps,
     root_extraction = root_extraction,
-    root_depths = root_depths,
     n_stem = n_stem,
     n_leaf = n_leaf,
     compartment_surfaces = compartment_surfaces,

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -109,9 +109,6 @@ function SoilCanopyModel{FT}(;
     )
     sources = (RootExtraction{FT}(), Soil.PhaseChange{FT}(Δz))
     root_extraction = PrognosticSoilPressure{FT}()
-    root_depths = sort(
-        unique(parent(ClimaLSM.Domains.coordinates(soil_args.domain).z)[:]),
-    )
     # add heat BC
     top_bc = ClimaLSM.Soil.AtmosDrivenFluxBC(atmos, CanopyRadiativeFluxes{FT}())
     zero_flux = FluxBC((p, t) -> eltype(t)(0.0))
@@ -140,7 +137,6 @@ function SoilCanopyModel{FT}(;
         hydraulics = canopy_component_types.hydraulics(;
             root_extraction = root_extraction,
             transpiration = transpiration,
-            root_depths = root_depths,
             canopy_component_args.hydraulics...,
         ),
         atmos = atmos,

--- a/src/integrated/soil_plant_hydrology_model.jl
+++ b/src/integrated/soil_plant_hydrology_model.jl
@@ -57,9 +57,6 @@ function SoilPlantHydrologyModel{FT}(;
     # These should always be set by the constructor.
     sources = (RootExtraction{FT}(),)
     root_extraction = PrognosticSoilPressure{FT}()
-    root_depths = sort(
-        unique(parent(ClimaLSM.Domains.coordinates(soil_args.domain).z)[:]),
-    )
 
     boundary_conditions = (;
         top = (water = FluxBC((p, t) -> eltype(t)(precipitation(t))),),
@@ -91,7 +88,6 @@ function SoilPlantHydrologyModel{FT}(;
         hydraulics = canopy_component_types.hydraulics(;
             root_extraction = root_extraction,
             transpiration = transpiration,
-            root_depths = root_depths,
             canopy_component_args.hydraulics...,
         ),
         atmos = atmos,

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -148,12 +148,12 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         )
 
     ψ_soil0 = FT(0.0)
-    root_extraction = PrescribedSoilPressure{FT}((t::FT) -> ψ_soil0)
+    root_extraction =
+        PrescribedSoilPressure{FT}(root_depths, (t::FT) -> ψ_soil0)
 
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,
         root_extraction = root_extraction,
-        root_depths = root_depths,
         n_stem = n_stem,
         n_leaf = n_leaf,
         compartment_surfaces = compartment_faces,

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -233,13 +233,13 @@ end
         ψ_soil0 = FT(0.0)
         transpiration =
             PrescribedTranspiration{FT}((t::FT) -> leaf_transpiration(t))
-        root_extraction = PrescribedSoilPressure{FT}((t::FT) -> ψ_soil0)
+        root_extraction =
+            PrescribedSoilPressure{FT}(root_depths, (t::FT) -> ψ_soil0)
 
         plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
             parameters = param_set,
             root_extraction = root_extraction,
             transpiration = transpiration,
-            root_depths = root_depths,
             n_stem = n_stem,
             n_leaf = n_leaf,
             compartment_surfaces = compartment_surfaces,
@@ -489,13 +489,13 @@ end
 
     ψ_soil0 = FT(0.0)
     transpiration = DiagnosticTranspiration{FT}()
-    root_extraction = PrescribedSoilPressure{FT}((t::FT) -> ψ_soil0)
+    root_extraction =
+        PrescribedSoilPressure{FT}(root_depths, (t::FT) -> ψ_soil0)
 
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,
         root_extraction = root_extraction,
         transpiration = transpiration,
-        root_depths = root_depths,
         n_stem = n_stem,
         n_leaf = n_leaf,
         compartment_surfaces = compartment_surfaces,


### PR DESCRIPTION
## Purpose 
When we run the canopy model in standalone mode, we require the rooting depths, but when run with the soil model, the root depths are the same as the soil layers. In the current code, the root_depths field (a vector of rooting depths) is required to make the model, so we need to define it when running an integrated soil+canopy model even though it is never used.

This PR changes it so that the `root_depths` field is only supplied when running in standalone mode with a PrescribedSoilPressure. When run with a soil model, the root depths never need to be specified.


## Content
Move root_depths to the PrescribedSoilPressure struct and out of the PlantHydraulics struct.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
