### PR TITLE
added source term for energy due to root extraction

### DIFF
--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -165,12 +165,12 @@ Y, p, cds = initialize(land)
 exp_tendency! = make_exp_tendency(land)
 
 #Initial conditions
-Y.soil.ϑ_l = SWC[Int(round(t0 / 1800))] # Get soil water content at t0
+Y.soil.ϑ_l = SWC[1 + Int(round(t0 / 1800))] # Get soil water content at t0
 # recalling that the data is in intervals of 1800 seconds. Both the data
 # and simulation are reference to 2005-01-01-00 (LOCAL)
 # or 2005-01-01-06 (UTC)
 Y.soil.θ_i = FT(0.0)
-T_0 = TS[Int(round(t0 / 1800))] # Get soil temperature at t0
+T_0 = TS[1 + Int(round(t0 / 1800))] # Get soil temperature at t0
 ρc_s =
     volumetric_heat_capacity.(Y.soil.ϑ_l, Y.soil.θ_i, Ref(land.soil.parameters))
 Y.soil.ρe_int =
@@ -662,7 +662,6 @@ Plots.plot!(
 Plots.plot!(plt2, seconds ./ 3600 ./ 24, TS, label = "", color = "red")
 
 
-
 plt3 = Plots.plot()
 Plots.plot!(
     plt3,
@@ -702,6 +701,7 @@ Plots.plot!(
     color = "red",
     legend = :bottomright,
 )
+
 Plots.plot!(plt3, legend = :bottomleft)
 Plots.plot(plt3, plt2, layout = (2, 1))
 Plots.savefig(joinpath(savedir, "soil_temperature.png"))

--- a/src/integrated/soil_plant_hydrology_model.jl
+++ b/src/integrated/soil_plant_hydrology_model.jl
@@ -218,7 +218,7 @@ struct RootExtraction{FT} <: Soil.AbstractSoilSource{FT} end
                      src::RootExtraction,
                      Y::ClimaCore.Fields.FieldVector,
                      p::ClimaCore.Fields.FieldVector
-                     params)
+                     model::RichardsModel)
 
 An extension of the `ClimaLSM.source!` function,
  which computes source terms for the 
@@ -230,7 +230,7 @@ function ClimaLSM.source!(
     src::RootExtraction,
     Y::ClimaCore.Fields.FieldVector,
     p::ClimaCore.Fields.FieldVector,
-    _...,
+    model::RichardsModel,
 )
     @. dY.soil.ϑ_l += -1 * p.root_extraction
     # if flow is negative, towards soil -> soil water increases, add in sign here.

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -166,7 +166,7 @@ function ClimaLSM.make_compute_exp_tendency(model::Soil.RichardsModel)
 
         # Source terms
         for src in model.sources
-            ClimaLSM.source!(dY, src, Y, p, model.parameters)
+            ClimaLSM.source!(dY, src, Y, p, model)
         end
     end
     return compute_exp_tendency!


### PR DESCRIPTION
## Purpose 
We forgot to add in the source/sink term for energy due to root extraction. This just required small changes to arguments to ClimaLSM.source! and a new method. The term is in Equation 2.18 of the land model design doc: \tilde{I}_l*R_r.

Along the way: make energyhydrology parameters broadcastable and update usage of Ref accordingly. a future PR will do this for all relevant structs - see issue https://github.com/CliMA/ClimaLSM.jl/issues/209

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
