### PR TITLE
Add Harvard and Niwot Ridge experiments

### DIFF
--- a/experiments/integrated/harvard/harvard.jl
+++ b/experiments/integrated/harvard/harvard.jl
@@ -1,3 +1,4 @@
+# External imports
 using DiffEqCallbacks
 import OrdinaryDiffEq as ODE
 import ClimaTimeSteppers as CTS
@@ -8,6 +9,7 @@ using Statistics
 using Dates
 using Insolation
 
+#Import CliMA packages
 using ClimaLSM
 using ClimaLSM.Domains: LSMSingleColumnDomain
 using ClimaLSM.Soil
@@ -16,23 +18,35 @@ using ClimaLSM.Canopy.PlantHydraulics
 import ClimaLSM
 import ClimaLSM.Parameters as LSMP
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
+
+# Choose floating point precision
 const FT = Float64
+
 earth_param_set = create_lsm_parameters(FT)
 climalsm_dir = pkgdir(ClimaLSM)
+
 # This reads in the data from the flux tower site and creates
 # the atmospheric and radiative driver structs for the model
 include(
     joinpath(
         climalsm_dir,
-        "experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl",
+        "experiments/integrated/harvard/harvard_met_drivers_FLUXNET.jl",
     ),
 )
-include(joinpath(climalsm_dir, "experiments/integrated/ozark/ozark_domain.jl"))
 include(
-    joinpath(climalsm_dir, "experiments/integrated/ozark/ozark_parameters.jl"),
+    joinpath(climalsm_dir, "experiments/integrated/harvard/harvard_domain.jl"),
 )
 include(
-    joinpath(climalsm_dir, "experiments/integrated/ozark/ozark_simulation.jl"),
+    joinpath(
+        climalsm_dir,
+        "experiments/integrated/harvard/harvard_parameters.jl",
+    ),
+)
+include(
+    joinpath(
+        climalsm_dir,
+        "experiments/integrated/harvard/harvard_simulation.jl",
+    ),
 )
 
 # Now we set up the model. For the soil model, we pick
@@ -169,13 +183,9 @@ land = SoilCanopyModel{FT}(;
 Y, p, cds = initialize(land)
 exp_tendency! = make_exp_tendency(land)
 
-#Initial conditions
-Y.soil.ϑ_l = SWC[1 + Int(round(t0 / 1800))] # Get soil water content at t0
-# recalling that the data is in intervals of 1800 seconds. Both the data
-# and simulation are reference to 2005-01-01-00 (LOCAL)
-# or 2005-01-01-06 (UTC)
+Y.soil.ϑ_l = 0.3
 Y.soil.θ_i = FT(0.0)
-T_0 = TS[1 + Int(round(t0 / 1800))] # Get soil temperature at t0
+T_0 = TA[Int(round(t0 / 3600))] # Get soil temperature at t0
 ρc_s =
     volumetric_heat_capacity.(Y.soil.ϑ_l, Y.soil.θ_i, Ref(land.soil.parameters))
 Y.soil.ρe_int =
@@ -207,7 +217,7 @@ set_initial_aux_state!(p, Y, t0);
 # Simulation
 sv = (;
     t = Array{FT}(undef, length(saveat)),
-    saveval = Array{NamedTuple}(undef, length(saveat)),
+    saveval = Array{ClimaCore.Fields.FieldVector}(undef, length(saveat)),
 )
 cb = ClimaLSM.NonInterpSavingCallback(sv, saveat)
 
@@ -224,7 +234,7 @@ sol = ODE.solve(
 
 # Plotting
 daily = sol.t ./ 3600 ./ 24
-savedir = joinpath(climalsm_dir, "experiments/integrated/ozark/")
+savedir = joinpath(climalsm_dir, "experiments/integrated/harvard/")
 
 # GPP
 model_GPP = [
@@ -315,8 +325,6 @@ Plots.plot!(
 )
 Plots.plot(plt1, plt2, layout = (2, 1))
 Plots.savefig(joinpath(savedir, "VPD.png"))
-
-
 
 T =
     [
@@ -449,7 +457,7 @@ plot!(
     label = "Ice, 5cm",
 )
 
-Plots.plot!(plt1, seconds ./ 3600 ./ 24, SWC, label = "Data")
+# Plots.plot!(plt1, seconds ./ 3600 ./ 24, SWC, label = "Data")
 plt2 = Plots.plot(
     seconds ./ 3600 ./ 24,
     P .* (-1e3 * 24 * 3600),
@@ -474,13 +482,7 @@ Plots.plot!(
     label = "Data",
     margins = 10Plots.mm,
 )
-Plots.plot!(
-    plt1,
-    seconds ./ 3600 ./ 24,
-    FT.(H_CORR),
-    label = "Data Corr",
-    margins = 10Plots.mm,
-)
+
 Plots.plot!(
     plt1,
     daily,
@@ -499,13 +501,7 @@ Plots.plot!(
     label = "",
     margins = 10Plots.mm,
 )
-Plots.plot!(
-    plt2,
-    seconds ./ 3600 ./ 24,
-    FT.(H_CORR),
-    label = "",
-    margins = 10Plots.mm,
-)
+
 Plots.plot!(
     plt2,
     daily,
@@ -543,122 +539,6 @@ Plots.plot!(
 
 Plots.plot!(ylabel = "∫ Water fluxes dt", xlabel = "Days", margins = 10Plots.mm,)
 Plots.savefig(joinpath(savedir, "cumul_p_et.png"))
-
-
-# Leaf water potential data from Pallardy et al (2018)
-# Predawn Leaf Water Potential of Oak-Hickory Forest at Missouri Ozark (MOFLUX) Site: 2004-2020
-# https://doi.org/10.3334/CDIAC/ORNLSFA.004
-lwp_filename = "MOFLUX_PredawnLeafWaterPotential_2020_20210125.csv"
-lwp_artifact = ArtifactFile(
-    url = "https://caltech.box.com/shared/static/d2nbhezw1q99vslnh5qfwnqrnp3p4edo.csv",
-    filename = lwp_filename,
-)
-lwp_dataset = ArtifactWrapper(
-    @__DIR__,
-    "lwp_pallardy_etal2018",
-    ArtifactFile[lwp_artifact],
-);
-
-lwp_path = joinpath(get_data_folder(lwp_dataset), lwp_filename)
-lwp_data = readdlm(lwp_path, ',', skipstart = 1)
-# We are using 2005 data in this test, so restrict to this year
-YEAR = lwp_data[:, 1]
-DOY = lwp_data[YEAR .== 2005, 2]
-# Our t0 = Dec 31, midnight, 2005. Predawn = guess of 0600 hours
-seconds_since_t0 = FT.(DOY) * 24 .* 3600 .+ (6 * 3600)
-lwp_measured = lwp_data[YEAR .== 2005, 7] .* 1e6 # MPa to Pa
-
-
-root_stem_flux = [
-    sum(sv.saveval[k].root_extraction) .* (1e3 * 3600 * 24) for
-    k in 1:length(sol.t)
-]
-
-stem_leaf_flux = [
-    parent(sv.saveval[k].canopy.hydraulics.fa)[1] .* (1e3 * 3600 * 24) for
-    k in 1:length(sol.t)
-]
-leaf_air_flux = [
-    parent(sv.saveval[k].canopy.hydraulics.fa)[2] .* (1e3 * 3600 * 24) for
-    k in 1:length(sol.t)
-]
-lwp = [
-    parent(sv.saveval[k].canopy.hydraulics.ψ)[2] * 9800 for k in 1:length(sol.t)
-]
-swp = [
-    parent(sv.saveval[k].canopy.hydraulics.ψ)[1] * 9800 for k in 1:length(sol.t)
-]
-ψ_soil = [
-    sum(
-        parent(sv.saveval[k].soil.ψ) .*
-        root_distribution.(parent(cds.subsurface.z)),
-    ) / sum(root_distribution.(parent(cds.subsurface.z))) * 9800 for
-    k in 1:length(sol.t)
-]
-
-plt1 = Plots.plot(size = (1500, 400))
-Plots.plot!(
-    plt1,
-    daily,
-    lwp,
-    label = "Model, Leaf",
-    title = "Water potentials",
-    xlim = [minimum(daily), maximum(daily)],
-)
-Plots.plot!(plt1, daily, swp, label = "Model, Stem")
-Plots.plot!(plt1, daily, ψ_soil, label = "Model, Mean soil")
-Plots.scatter!(
-    plt1,
-    seconds_since_t0 ./ 24 ./ 3600,
-    lwp_measured,
-    label = "Data; all species",
-    legend = :bottomleft,
-)
-
-plt2 = Plots.plot(size = (1500, 400))
-Plots.plot!(
-    plt2,
-    daily,
-    lwp,
-    label = "",
-    xlim = [minimum(daily), minimum(daily) + 30],
-    xlabel = "Day of year",
-    ylim = [-2e6, 0],
-    margin = 10Plots.mm,
-)
-
-Plots.plot!(plt2, daily, swp, label = "")
-Plots.plot!(plt2, daily, ψ_soil, label = "")
-Plots.plot!(plt2, seconds_since_t0 ./ 24 ./ 3600, lwp_measured, label = "")
-
-Plots.plot(plt1, plt2, layout = (2, 1))
-Plots.savefig(joinpath(savedir, "leaf_water_potential.png"))
-
-plt2 = Plots.plot(
-    daily,
-    leaf_air_flux,
-    label = "Leaf-air flux",
-    xlim = [minimum(daily), maximum(daily)],
-    title = "Within plant fluxes[mm/day]",
-    size = (1500, 400),
-)
-Plots.plot!(plt2, daily, stem_leaf_flux, label = "Stem-leaf flux")
-Plots.plot!(plt2, daily, root_stem_flux, label = "Soil-root-stem flux")
-
-plt1 = Plots.plot(
-    daily,
-    leaf_air_flux,
-    label = "",
-    xlabel = "Day of year",
-    margin = 10Plots.mm,
-    xlim = [minimum(daily), minimum(daily) + 30],
-    ylim = [-5, 7.5],
-    size = (1500, 400),
-)
-Plots.plot!(plt1, daily, stem_leaf_flux, label = "")
-Plots.plot!(plt1, daily, root_stem_flux, label = "")
-Plots.plot(plt2, plt1, layout = (2, 1))
-Plots.savefig(joinpath(savedir, "water_fluxes.png"))
 
 # Current resolution is 3.333 cm per layer, our nodes are at the center of the
 # layers. The second layer is ~ 5cm
@@ -709,7 +589,7 @@ Plots.plot!(
     plt3,
     seconds ./ 3600 ./ 24,
     TS,
-    label = "T_soil (data)",
+    label = "T_soil at 15 cm (data)",
     color = "red",
     legend = :bottomright,
 )

--- a/experiments/integrated/harvard/harvard_domain.jl
+++ b/experiments/integrated/harvard/harvard_domain.jl
@@ -1,0 +1,15 @@
+# Domain setup
+# For soil column
+nelements = 10
+zmin = FT(-2)
+zmax = FT(0)
+land_domain =
+    LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelements)
+
+# Number of stem and leaf compartments. Leaf compartments are stacked on top of stem compartments
+n_stem = Int64(1)
+n_leaf = Int64(1)
+h_stem = FT(9) # m
+h_leaf = FT(9.5) # m
+compartment_midpoints = [h_stem / 2, h_stem + h_leaf / 2]
+compartment_surfaces = [zmax, h_stem, h_stem + h_leaf]

--- a/experiments/integrated/harvard/harvard_met_drivers_FLUXNET.jl
+++ b/experiments/integrated/harvard/harvard_met_drivers_FLUXNET.jl
@@ -1,0 +1,123 @@
+using ArtifactWrappers
+using DelimitedFiles
+using Dierckx
+using Thermodynamics
+using Dates
+
+function replace_missing_with_mean!(field, flag)
+    good_indices = (flag .== 0) .|| (flag .== 1)
+    fill_value = mean(field[good_indices])
+    field[.~good_indices] .= fill_value
+    return field
+end
+
+# Fluxnet Harvard Forest US-Ha1 (CO2 and H2O fluxes and met drivers)
+
+# Save the data file as an artifact
+af = ArtifactFile(
+    url = "https://caltech.box.com/shared/static/xixaod6511cutz51ag81k1mtvy05hbol.csv",
+    filename = "combined_US-Ha1-2010.csv",
+)
+dataset = ArtifactWrapper(@__DIR__, "ameriflux_data_Ha1", ArtifactFile[af]);
+dataset_path = get_data_folder(dataset);
+data = joinpath(dataset_path, "combined_US-Ha1-2010.csv");
+driver_data = readdlm(data, ',')
+
+# Read the data in each column. For the Harvard site, we have hourly data
+column_names = driver_data[1, :]
+TA = driver_data[2:end, column_names .== "TA_F"] .+ 273.15; # convert C to K
+VPD = driver_data[2:end, column_names .== "VPD_F"] .* 100; # convert hPa to Pa
+PA = driver_data[2:end, column_names .== "PA_F"] .* 1000; # convert kPa to Pa
+P = driver_data[2:end, column_names .== "P_F"] ./ (1000 * 3600); # convert mm/HH to m/s
+WS = driver_data[2:end, column_names .== "WS_F"]; # already m/s
+LW_IN = driver_data[2:end, column_names .== "LW_IN_F"]
+SW_IN = driver_data[2:end, column_names .== "SW_IN_F"]
+CO2_F = driver_data[2:end, column_names .== "CO2_F_MDS_QC"]
+CO2 = driver_data[2:end, column_names .== "CO2_F_MDS"] .* 1e-6; # convert \mumol to mol
+replace_missing_with_mean!(CO2, CO2_F)
+# TODO: Find SWC data somewhere
+TS_F = driver_data[2:end, column_names .== "TS_F_MDS_2_QC"] # Most likely 5cm depth TODO: (switched to 2, check for dependencies)
+TS = driver_data[2:end, column_names .== "TS_F_MDS_2"] .+ 273.15;# convert C to K
+replace_missing_with_mean!(TS, TS_F)
+LE = driver_data[2:end, column_names .== "LE_F_MDS"]
+GPP = driver_data[2:end, column_names .== "GPP_DT_VUT_REF"] .* 1e-6 # to convert from micromol to mol.
+H = driver_data[2:end, column_names .== "H_F_MDS"]
+LAI_data = driver_data[2:end, column_names .== "value_mean"]
+
+# Get the data timestamps both in local and UTC times
+LOCAL_DATETIME = DateTime.(string.(driver_data[2:end, 1]), "yyyymmddHHMM")
+UTC_DATETIME = LOCAL_DATETIME .+ Dates.Hour(5)
+thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
+esat =
+    Thermodynamics.saturation_vapor_pressure.(
+        Ref(thermo_params),
+        TA,
+        Ref(Thermodynamics.Liquid()),
+    )
+
+# Compute atmospheric pressures
+e = @. esat - VPD
+q = @. 0.622 * e ./ (PA - 0.378 * e)
+
+#Make a bunch of splines
+seconds = FT.(0:3600:((length(UTC_DATETIME) - 1) * 3600));
+p_spline = Spline1D(seconds, -P[:]) # m/s
+atmos_q = Spline1D(seconds, q[:])
+atmos_T = Spline1D(seconds, TA[:])
+atmos_p = Spline1D(seconds, PA[:])
+atmos_co2 = Spline1D(seconds, CO2[:])
+atmos_u = Spline1D(seconds, WS[:])
+LW_IN_spline = Spline1D(seconds, LW_IN[:])
+SW_IN_spline = Spline1D(seconds, SW_IN[:])
+atmos_h = FT(32)
+precipitation_function(t::FT) where {FT} = p_spline(t) < 0.0 ? p_spline(t) : 0.0 # m/s
+snow_precip(t) = eltype(t)(0) # this is likely not correct
+LAIspline = Spline1D(seconds, LAI_data[:])
+LAIfunction = (t) -> eltype(t)(LAIspline(t))
+
+
+# Construct the drivers
+atmos = ClimaLSM.PrescribedAtmosphere(
+    precipitation_function,
+    snow_precip,
+    atmos_T,
+    atmos_u,
+    atmos_q,
+    atmos_p,
+    atmos_h;
+    c_co2 = atmos_co2,
+)
+
+# Site latitude and longitude data
+lat = FT(42.5378) # degree
+long = FT(-72.1715) # degree
+
+# Find the function for solar zenith angle vs. time for this site
+function zenith_angle(
+    t::FT,
+    orbital_data;
+    latitude = lat,
+    longitude = long,
+    insol_params = earth_param_set.insol_params,
+) where {FT}
+    # This should be time in UTC
+    dt = DateTime("2005-01-01-05", "yyyy-mm-dd-HH") + Dates.Second(round(t))
+    FT(
+        instantaneous_zenith_angle(
+            dt,
+            orbital_data,
+            longitude,
+            latitude,
+            insol_params,
+        )[1],
+    )
+end
+
+# Prescribed radiation function for this site
+radiation = ClimaLSM.PrescribedRadiativeFluxes(
+    FT,
+    SW_IN_spline,
+    LW_IN_spline;
+    θs = zenith_angle,
+    orbital_data = Insolation.OrbitalData(),
+)

--- a/experiments/integrated/harvard/harvard_parameters.jl
+++ b/experiments/integrated/harvard/harvard_parameters.jl
@@ -1,0 +1,87 @@
+# Soil parameters
+soil_ν = FT(0.386) # m3/m3; from GLDAS
+soil_K_sat = FT(2.9e-7) # m/s, Gupta et al. 2021 (predicted)
+soil_S_s = FT(1e-3) # 1/m, guess
+soil_vg_n = FT(1.448) # unitless
+soil_vg_α = FT(0.027) # inverse meters; VG params from Tiejun Wang et al 2015
+θ_r = FT(0.067) # m3/m3, Guess
+
+# Soil heat transfer parameters; not needed for hydrology only test
+# Site soil composition fractions
+ν_ss_quartz = FT(0.384) # Richardson, Petrenko, Friedland 2017
+ν_ss_om = FT(0.36) # https://harvardforest1.fas.harvard.edu/exist/apps/datasets/showData.html?id=hf143
+ν_ss_gravel = FT(0.0); # Assumption
+
+# Material thermal properties
+κ_quartz = FT(7.7) # W/m/K
+κ_minerals = FT(2.5) # W/m/K
+κ_om = FT(0.25) # W/m/K
+κ_liq = FT(0.57) # W/m/K
+κ_ice = FT(2.29) # W/m/K
+κ_air = FT(0.025); #W/m/K
+ρp = FT(2700); # kg/m^3
+κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+κ_dry = Soil.κ_dry(ρp, soil_ν, κ_solid, κ_air)
+κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, soil_ν, κ_ice)
+κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, soil_ν, κ_liq);
+ρc_ds = FT((1 - soil_ν) * 4e6); # J/m^3/K
+z_0m_soil = FT(0.1)
+z_0b_soil = FT(0.1)
+soil_ϵ = FT(0.98)
+soil_α_PAR = FT(0.3) # Estimate
+soil_α_NIR = FT(0.5) # Estimate
+
+# Two Stream Model Parameters
+Ω = FT(0.7) # MODIS
+ld = FT(0.5)
+α_PAR_leaf = FT(0.07) # CLM
+λ_γ_PAR = FT(5e-7)
+λ_γ_NIR = FT(1.65e-6)
+τ_PAR_leaf = FT(0.05) # CLM
+α_NIR_leaf = FT(0.35) # CLM
+τ_NIR_leaf = FT(0.1) # CLM
+n_layers = UInt64(20)
+diff_perc = FT(0.2) # Estimate
+
+# Conductance Model
+g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
+Drel = FT(1.6)
+g0 = FT(1e-4)
+
+#Photosynthesis model
+oi = FT(0.209)
+ϕ = FT(0.6)
+θj = FT(0.9)
+f = FT(0.015)
+sc = FT(2e-6) # Bonan's book: range of 2-5e-6
+pc = FT(-2e6) # Bonan's book: -2e6
+Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
+Γstar25 = FT(4.275e-5)
+Kc25 = FT(4.049e-4)
+Ko25 = FT(0.2874)
+To = FT(298.15)
+ΔHkc = FT(79430)
+ΔHko = FT(36380)
+ΔHVcmax = FT(58520)
+ΔHΓstar = FT(37830)
+ΔHJmax = FT(43540)
+ΔHRd = FT(46390)
+
+# Plant Hydraulics and general plant parameters
+SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?
+f_root_to_shoot = FT(3.5)
+maxLAI = FT(3.5)
+RAI = (SAI + maxLAI) * f_root_to_shoot # CLM
+K_sat_plant = 5e-9 # m/s # seems much too small?
+ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
+Weibull_param = FT(4) # unitless, Holtzman's original c param value
+a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+conductivity_model =
+    PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+capacity = FT(30) # kg/m^2
+plant_ν = capacity / (maxLAI / 2 * h_leaf + SAI * h_stem) / FT(1000)
+plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+rooting_depth = FT(0.5) # from Natan
+z0_m = FT(2)
+z0_b = FT(0.2)

--- a/experiments/integrated/harvard/harvard_simulation.jl
+++ b/experiments/integrated/harvard/harvard_simulation.jl
@@ -1,0 +1,9 @@
+t0 = FT(120 * 3600 * 24)# start mid year
+N_days = 120
+tf = t0 + FT(3600 * 24 * N_days)
+dt = FT(60)
+n = 60
+saveat = Array(t0:(n * dt):tf)
+timestepper = CTS.RK4()
+# Set up timestepper
+ode_algo = CTS.ExplicitAlgorithm(timestepper)

--- a/experiments/integrated/niwot/niwot_domain.jl
+++ b/experiments/integrated/niwot/niwot_domain.jl
@@ -1,0 +1,15 @@
+# Domain setup
+# For soil column
+nelements = 10
+zmin = FT(-2)
+zmax = FT(0)
+land_domain =
+    LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelements)
+
+# Number of stem and leaf compartments. Leaf compartments are stacked on top of stem compartments
+n_stem = Int64(1)
+n_leaf = Int64(1)
+h_stem = FT(9) # m; typical aspen height
+h_leaf = FT(9.5) # m; typical aspen height 
+compartment_midpoints = [h_stem / 2, h_stem + h_leaf / 2]
+compartment_surfaces = [zmax, h_stem, h_stem + h_leaf]

--- a/experiments/integrated/niwot/niwot_met_drivers_FLUXNET.jl
+++ b/experiments/integrated/niwot/niwot_met_drivers_FLUXNET.jl
@@ -1,0 +1,140 @@
+using ArtifactWrappers
+using DelimitedFiles
+using Dierckx
+using Thermodynamics
+using Dates
+function replace_missing_with_mean!(field, flag)
+    good_indices = (flag .== 0) .|| (flag .== 1)
+    fill_value = mean(field[good_indices])
+    field[.~good_indices] .= fill_value
+    return field
+end
+
+# Fluxnet Ozark (CO2 and H2O fluxes and met drivers)
+# 2005 data extracted as follows:
+#af = ArtifactFile(
+#    url = "https://caltech.box.com/shared/static/cy4jlul43kx72r2pqthvm4isjwkatgxy.csv",
+#    filename = "AMF_US-MOz_FLUXNET_FULLSET_HH_2004-2019_3-5.csv",
+#)
+#dataset = ArtifactWrapper(@__DIR__, "ameriflux_data_all_years", ArtifactFile[af]);
+#dataset_path = get_data_folder(dataset);
+#data = joinpath(dataset_path, "AMF_US-MOz_FLUXNET_FULLSET_HH_2004-2019_3-5.csv")
+#driver_data = readdlm(data, ',')
+#mask = Dates.year.(LOCAL_DATETIME) .== 2005
+#data_from_2005 = vcat(driver_data[[1],:], driver_data[2:end, :][mask, :])
+#open("AMF_US-MOz_FLUXNET_FULLSET_HH_2005.csv"), "w") do io
+#             writedlm(io, data_from_2005, ',')
+#         end
+
+af = ArtifactFile(
+    url = "https://caltech.box.com/shared/static/r6gvldgabk3mvtx53gevnlaq1ztsk41i.csv",
+    filename = "combined_US-NR1-2010.csv",
+)
+dataset = ArtifactWrapper(@__DIR__, "ameriflux_data", ArtifactFile[af]);
+dataset_path = get_data_folder(dataset);
+data = joinpath(dataset_path, "combined_US-NR1-2010.csv");
+driver_data = readdlm(data, ',')
+
+
+column_names = driver_data[1, :]
+TA = driver_data[2:end, column_names .== "TA_F"] .+ 273.15; # convert C to K
+VPD = driver_data[2:end, column_names .== "VPD_F"] .* 100; # convert hPa to Pa
+PA = driver_data[2:end, column_names .== "PA_F"] .* 1000; # convert kPa to Pa
+P = driver_data[2:end, column_names .== "P_F"] ./ (1000 * 1800); # convert mm/HH to m/s
+WS = driver_data[2:end, column_names .== "WS_F"]; # already m/s
+LW_IN = driver_data[2:end, column_names .== "LW_IN_F"]
+SW_IN = driver_data[2:end, column_names .== "SW_IN_F"]
+CO2_F = driver_data[2:end, column_names .== "CO2_F_MDS_QC"]
+CO2 = driver_data[2:end, column_names .== "CO2_F_MDS"] .* 1e-6; # convert \mumol to mol
+replace_missing_with_mean!(CO2, CO2_F)
+SWC_F = driver_data[2:end, column_names .== "SWC_F_MDS_1_QC"] # Most likely 5cm depth
+SWC = driver_data[2:end, column_names .== "SWC_F_MDS_1"] ./ 100; # to convert from % to m^3/m^3
+replace_missing_with_mean!(SWC, SWC_F)
+TS_F = driver_data[2:end, column_names .== "TS_F_MDS_1_QC"] # Most likely 5cm depth
+TS = driver_data[2:end, column_names .== "TS_F_MDS_1"] .+ 273.15;# convert C to K
+replace_missing_with_mean!(TS, TS_F)
+GPP = driver_data[2:end, column_names .== "GPP_DT_VUT_REF"] .* 1e-6 # to convert from micromol to mol.
+LE = driver_data[2:end, column_names .== "LE_CORR"]
+H_CORR = driver_data[2:end, column_names .== "H_CORR"]
+H = driver_data[2:end, column_names .== "H_F_MDS"]
+H_F = driver_data[2:end, column_names .== "H_F_MDS_QC"]
+replace_missing_with_mean!(H, H_F)
+G = driver_data[2:end, column_names .== "G_F_MDS"]
+G_F = driver_data[2:end, column_names .== "G_F_MDS_QC"]
+replace_missing_with_mean!(G, G_F)
+LAI_data = driver_data[2:end, column_names .== "value_mean"]
+
+LW_OUT = driver_data[2:end, column_names .== "LW_OUT"]# This has missing data
+SW_OUT = driver_data[2:end, column_names .== "SW_OUT"]# This has missing data
+LOCAL_DATETIME = DateTime.(string.(driver_data[2:end, 1]), "yyyymmddHHMM")
+UTC_DATETIME = LOCAL_DATETIME .+ Dates.Hour(7)
+thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
+esat =
+    Thermodynamics.saturation_vapor_pressure.(
+        Ref(thermo_params),
+        TA,
+        Ref(Thermodynamics.Liquid()),
+    )
+e = @. esat - VPD
+q = @. 0.622 * e ./ (PA - 0.378 * e)
+
+#Make a bunch of splines
+seconds = FT.(0:1800:((length(UTC_DATETIME) - 1) * 1800));
+p_spline = Spline1D(seconds, -P[:]) # m/s
+atmos_q = Spline1D(seconds, q[:])
+atmos_T = Spline1D(seconds, TA[:])
+atmos_p = Spline1D(seconds, PA[:])
+atmos_co2 = Spline1D(seconds, CO2[:])
+atmos_u = Spline1D(seconds, WS[:])
+LW_IN_spline = Spline1D(seconds, LW_IN[:])
+SW_IN_spline = Spline1D(seconds, SW_IN[:])
+atmos_h = FT(32)
+precipitation_function(t::FT) where {FT} = p_spline(t) < 0.0 ? p_spline(t) : 0.0 # m/s
+snow_precip(t) = eltype(t)(0) # this is likely not correct
+LAIspline = Spline1D(seconds, LAI_data[:])
+LAIfunction = (t) -> eltype(t)(LAIspline(t))
+
+
+# Construct the drivers
+atmos = ClimaLSM.PrescribedAtmosphere(
+    precipitation_function,
+    snow_precip,
+    atmos_T,
+    atmos_u,
+    atmos_q,
+    atmos_p,
+    atmos_h;
+    c_co2 = atmos_co2,
+)
+
+lat = FT(40.0329) # degree
+long = FT(-105.5464) # degree
+
+function zenith_angle(
+    t::FT,
+    orbital_data;
+    latitude = lat,
+    longitude = long,
+    insol_params = earth_param_set.insol_params,
+) where {FT}
+    # This should be time in UTC
+    dt = DateTime("2005-01-01-07", "yyyy-mm-dd-HH") + Dates.Second(round(t))
+    FT(
+        instantaneous_zenith_angle(
+            dt,
+            orbital_data,
+            longitude,
+            latitude,
+            insol_params,
+        )[1],
+    )
+end
+
+
+radiation = ClimaLSM.PrescribedRadiativeFluxes(
+    FT,
+    SW_IN_spline,
+    LW_IN_spline;
+    θs = zenith_angle,
+    orbital_data = Insolation.OrbitalData(),
+)

--- a/experiments/integrated/niwot/niwot_parameters.jl
+++ b/experiments/integrated/niwot/niwot_parameters.jl
@@ -1,0 +1,87 @@
+# Soil parameters
+soil_ν = FT(0.437) # m3/m3 from GLDAS dataset
+soil_K_sat = FT(5e-7) # m/s, Reference value for skeletal sandy loam
+soil_S_s = FT(1e-3) # 1/m, guess
+soil_vg_n = FT(1.3774) # unitless from Wosten et al 1999 for soil type
+soil_vg_α = FT(0.0383) # inverse meters from Wosten et al 1999 for soil type
+θ_r = FT(0.067) # m3/m3, Guess
+
+# Soil heat transfer parameters; not needed for hydrology only test
+# Site soil composition fractions
+ν_ss_quartz = FT(0.286) # Fields and Dethier 2018
+ν_ss_om = FT(0.236) # Fields and Dethier 2018
+ν_ss_gravel = FT(0.0); # Assumption
+
+# Material thermal properties
+κ_quartz = FT(7.7) # W/m/K
+κ_minerals = FT(2.5) # W/m/K
+κ_om = FT(0.25) # W/m/K
+κ_liq = FT(0.57) # W/m/K
+κ_ice = FT(2.29) # W/m/K
+κ_air = FT(0.025); #W/m/K
+ρp = FT(2700); # kg/m^3
+κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+κ_dry = Soil.κ_dry(ρp, soil_ν, κ_solid, κ_air)
+κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, soil_ν, κ_ice)
+κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, soil_ν, κ_liq);
+ρc_ds = FT((1 - soil_ν) * 4e6); # J/m^3/K
+z_0m_soil = FT(0.1)
+z_0b_soil = FT(0.1)
+soil_ϵ = FT(0.98)
+soil_α_PAR = FT(0.3) # Estimate
+soil_α_NIR = FT(0.5) # Estimate
+
+# Two Stream Model Parameters
+Ω = FT(0.69)
+ld = FT(0.5)
+α_PAR_leaf = FT(0.1)
+λ_γ_PAR = FT(5e-7)
+λ_γ_NIR = FT(1.65e-6)
+τ_PAR_leaf = FT(0.05)
+α_NIR_leaf = FT(0.45)
+τ_NIR_leaf = FT(0.25)
+n_layers = UInt64(20)
+diff_perc = FT(0.2) # Estimate
+
+# Conductance Model
+g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
+Drel = FT(1.6)
+g0 = FT(1e-4)
+
+#Photosynthesis model
+oi = FT(0.209)
+ϕ = FT(0.6)
+θj = FT(0.9)
+f = FT(0.015)
+sc = FT(2e-6) # Bonan's book: range of 2-5e-6
+pc = FT(-2e6) # Bonan's book: -2e6
+Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
+Γstar25 = FT(4.275e-5)
+Kc25 = FT(4.049e-4)
+Ko25 = FT(0.2874)
+To = FT(298.15)
+ΔHkc = FT(79430)
+ΔHko = FT(36380)
+ΔHVcmax = FT(58520)
+ΔHΓstar = FT(37830)
+ΔHJmax = FT(43540)
+ΔHRd = FT(46390)
+
+# Plant Hydraulics and general plant parameters
+SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?
+maxLAI = FT(4.2) # m2/m2, from Wang et al.
+f_root_to_shoot = FT(3.5)
+RAI = (SAI + maxLAI) * f_root_to_shoot # CLM
+K_sat_plant = 5e-9 # m/s # seems much too small?
+ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
+Weibull_param = FT(4) # unitless, Holtzman's original c param value
+a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+conductivity_model =
+    PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+capacity = FT(30) # kg/m^2
+plant_ν = capacity / (maxLAI * h_leaf + SAI * h_stem) / FT(1000)
+plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+rooting_depth = FT(0.5) # from Natan
+z0_m = FT(2)
+z0_b = FT(0.2)

--- a/experiments/integrated/niwot/niwot_simulation.jl
+++ b/experiments/integrated/niwot/niwot_simulation.jl
@@ -1,0 +1,9 @@
+t0 = FT(120 * 3600 * 24)# start mid year
+N_days = 120
+tf = t0 + FT(3600 * 24 * N_days)
+dt = FT(60)
+n = 60
+saveat = Array(t0:(n * dt):tf)
+timestepper = CTS.RK4()
+# Set up timestepper
+ode_algo = CTS.ExplicitAlgorithm(timestepper)

--- a/experiments/integrated/ozark/hydrology_only/ozark.jl
+++ b/experiments/integrated/ozark/hydrology_only/ozark.jl
@@ -56,6 +56,7 @@ soil_model_type = Soil.RichardsModel{FT}
 # Component Types
 canopy_component_types = (;
     radiative_transfer = Canopy.BeerLambertModel{FT},
+    #radiative_transfer = Canopy.TwoStreamModel{FT},
     photosynthesis = Canopy.FarquharModel{FT},
     conductance = Canopy.MedlynConductanceModel{FT},
     hydraulics = Canopy.PlantHydraulicsModel{FT},
@@ -72,6 +73,18 @@ radiative_transfer_args = (;
         λ_γ_NIR = λ_γ_NIR,
     )
 )
+#= radiative_transfer_args = (;
+    parameters = TwoStreamParameters{FT}(;
+        ld = ld,
+        ρ_leaf = ρ_leaf,
+        τ = FT(0.3),
+        a_soil = FT(0.2),
+        Ω = Ω,
+        λ_γ = λ_γ,
+        n_layers = UInt64(20),
+        diff_perc = FT(0.5)
+    )
+) =#
 # Set up conductance
 conductance_args = (;
     parameters = MedlynConductanceParameters{FT}(;


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Add experiments paralleling the Ozark experiment using data from the FluxNet sites at Harvard Forest and Niwot Ridge.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [ ] Refine experiment parameters as much as possible
- [ ] Update the new experiments to use the soil_driver structure recently merged
- [ ] Add time varying LAI to the new experiments


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
 - 2 experiments added in the directories experiments/integrated/harvard and experiments/integrated/niwot
- Currently, the plots of the model and the data together do not agree well with each other, similar to how the GPP plot for Ozark experiment does not agree well. I have been looking for a reason why this is but haven't been able to find anything which resolves the difference.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
