### PR TITLE
drive ozark with observed LAI(t)

### DIFF
--- a/docs/tutorials/Canopy/soil_canopy_tutorial.jl
+++ b/docs/tutorials/Canopy/soil_canopy_tutorial.jl
@@ -58,6 +58,19 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"));
 const FT = Float64;
 earth_param_set = create_lsm_parameters(FT);
 
+# - We will be using prescribed atmospheric and radiative drivers from the 
+#   US-MOz tower, which we read in here. We are using prescribed
+#   atmospheric and radiative flux conditions, but it is also possible to couple
+#   the simulation with atmospheric and radiative flux models. We also
+# read in the observed LAI and let that vary in time in a prescribed manner.
+
+include(
+    joinpath(
+        pkgdir(ClimaLSM),
+        "experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl",
+    ),
+);
+
 # # Setup the Coupled Canopy and Soil Physics Model
 
 # We want to simulate the canopy-soil system together, so the model type 
@@ -215,11 +228,11 @@ photosynthesis_args = (;
 );
 
 f_root_to_shoot = FT(3.5)
-SAI = FT(1.0)
-LAI = FT(4.2)
-LAIfunction = (t) -> eltype(t)(LAI)
+SAI = FT(0.00242)
+maxLAI = FT(4.2)
 K_sat_plant = 1.8e-8
-RAI = (SAI + LAI) * f_root_to_shoot
+RAI = (SAI + maxLAI) * f_root_to_shoot;
+# Note: LAIfunction was determined from data in the script we included above.
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 function root_distribution(z::T; rooting_depth = FT(1.0)) where {T}
     return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m

--- a/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
+++ b/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
@@ -135,3 +135,19 @@ radiation = ClimaLSM.PrescribedRadiativeFluxes(
     θs = zenith_angle,
     orbital_data = Insolation.OrbitalData(),
 )
+
+
+# LAI data
+lai_af = ArtifactFile(
+    url = "https://caltech.box.com/shared/static/yfqj0yqkx8yps7ydltsaixuy99083pon.csv",
+    filename = "Ozark_MODIS_LAI_2005.csv",
+)
+lai_dataset = ArtifactWrapper(@__DIR__, "modis_data", ArtifactFile[lai_af]);
+lai_dataset_path = get_data_folder(lai_dataset);
+lai_raw_data = joinpath(lai_dataset_path, "Ozark_MODIS_LAI_2005.csv");
+LAI_data = readdlm(lai_raw_data, ',') #m2.m-2
+LAI_column_names = LAI_data[1, :]
+LAI_data = LAI_data[2:end, LAI_column_names .== "lai_mean"] #m2.m-2
+# This has the same timestamp as the driver data, so it's ok to use the time column from that file here
+LAIspline = Spline1D(seconds, LAI_data[:])
+LAIfunction = (t) -> eltype(t)(LAIspline(t))

--- a/experiments/integrated/ozark/ozark_parameters.jl
+++ b/experiments/integrated/ozark/ozark_parameters.jl
@@ -59,10 +59,9 @@ To = FT(298.15)
 
 # Plant Hydraulics and general plant parameters
 SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?
-LAI = FT(4.2) # m2/m2, from Wang et al.
-LAIfunction = (t) -> eltype(t)(LAI)
+maxLAI = FT(4.2) # m2/m2, from Wang et al.
 f_root_to_shoot = FT(3.5)
-RAI = (SAI + LAI) * f_root_to_shoot # CLM
+RAI = (SAI + maxLAI) * f_root_to_shoot # CLM
 K_sat_plant = 5e-9 # m/s # seems much too small?
 ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
 Weibull_param = FT(4) # unitless, Holtzman's original c param value
@@ -70,8 +69,8 @@ a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of el
 conductivity_model =
     PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
 retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-capacity = FT(30) # kg/m^2
-plant_ν = capacity / (LAI * h_leaf + SAI * h_stem) / FT(1000)
+capacity = FT(15) # kg/m^2
+plant_ν = capacity / (maxLAI / 2 * h_leaf + SAI * h_stem) / FT(1000)
 plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
 rooting_depth = FT(0.5) # from Natan
 z0_m = FT(2)

--- a/experiments/integrated/ozark/ozark_simulation.jl
+++ b/experiments/integrated/ozark/ozark_simulation.jl
@@ -1,8 +1,8 @@
-t0 = FT(150 * 3600 * 24)# start mid year
-N_days = 100
+t0 = FT(50 * 3600 * 24)# start mid year
+N_days = 275
 tf = t0 + FT(3600 * 24 * N_days)
-dt = FT(30)
-n = 120
+dt = FT(60)
+n = 60
 saveat = Array(t0:(n * dt):tf)
 timestepper = CTS.RK4()
 # Set up timestepper


### PR DESCRIPTION
## Purpose 
Read in LAI(t) from MODIS data and drive ozark simulation with a prescribed LAI(t), but fixed RAI and SAI.


## To-do
review


## Content
Update experiment and tutorial with correct LAI(t).

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
