### PR TITLE
Create prescribed and prognostic soil drivers for the canopy model

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ tutorials = [
         ],
         "Canopy modeling" => [
             "Standalone Canopy" => "Canopy/canopy_tutorial.jl",
-            "Coupled Canopy and Soil Hydrology" => "Canopy/soil_plant_hydrology_tutorial.jl",
+            "Coupled Canopy and Soil" => "Canopy/soil_canopy_tutorial.jl",
         ],
         "Bucket LSM" =>
             ["Bucket/bucket_tutorial.jl", "Bucket/coupled_bucket.jl"],

--- a/docs/src/APIs/canopy/Canopy.md
+++ b/docs/src/APIs/canopy/Canopy.md
@@ -16,3 +16,11 @@ ClimaLSM.Canopy.SharedCanopyParameters
 ClimaLSM.Canopy.DiagnosticTranspiration
 ClimaLSM.Canopy.canopy_surface_fluxes
 ```
+
+## Canopy Model Soil Drivers
+
+```@docs
+ClimaLSM.Canopy.AbstractSoilDriver
+ClimaLSM.Canopy.PrescribedSoil
+ClimaLSM.Canopy.PrognosticSoil
+```

--- a/docs/tutorials/Canopy/soil_canopy_tutorial.jl
+++ b/docs/tutorials/Canopy/soil_canopy_tutorial.jl
@@ -6,8 +6,8 @@
 # standalone mode using prescribed values for the inputs of soil hydraulics 
 # into the canopy hydraulics model. However, ClimaLSM has the built-in capacity 
 # to couple the canopy model with a soil physics model and timestep the two 
-# simulations together to model a canopy-soil hydrology system. This tutorial 
-# demonstrates how to setup and run a coupled hydrology simulation, again using 
+# simulations together to model a canopy-soil system. This tutorial 
+# demonstrates how to setup and run a coupled simulation, again using 
 # initial conditions, atmospheric and radiative flux conditions, and canopy 
 # properties observed at the US-MOz flux tower, a flux tower located within an 
 # oak-hickory forest in Ozark, Missouri, USA. See [Wang et al. 2021]
@@ -15,17 +15,18 @@
 # parameters.
 
 
-# In ClimaLSM, the coupling of the canopy and Richard's models is done by 
-# pairing the root extraction of the canopy hydraulics model, which acts as a 
-# boundary flux for the plant system, with a source term for root extraction in 
-# the Richard's model, so that the flux of water from the soil into the roots is 
+# In ClimaLSM, the coupling of the canopy and soil models is done by 
+# pairing the inputs and outputs which between the two models so that they match. 
+# For example, the root extraction of the canopy hydraulics model, which acts as a 
+# boundary flux for the plant system, is paired with a source term for root extraction in 
+# the soil model, so that the flux of water from the soil into the roots is 
 # equal and factored into both models. This pairing is done automatically in the 
 # constructor for a 
-# [`SoilPlantHydrologyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/ClimaLSM/#LSM-Model-Types-and-methods)
+# [`SoilCanopyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/ClimaLSM/#LSM-Model-Types-and-methods)
 # so that a 
 # user needs only specify the necessary arguments for each of the component 
 # models, and the two models will automatically be paired into a coupled 
-# hydrology model.
+# simulation.
 
 # # Preliminary Setup
 
@@ -60,7 +61,7 @@ earth_param_set = create_lsm_parameters(FT);
 # # Setup the Coupled Canopy and Soil Physics Model
 
 # We want to simulate the canopy-soil system together, so the model type 
-# [`SoilPlantHydrologyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/ClimaLSM/#LSM-Model-Types-and-methods)
+# [`SoilCanopyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/ClimaLSM/#LSM-Model-Types-and-methods)
 # is chosen.
 # From the linked documentation, we see that we need to provide the soil model 
 # type and arguments as well as the canopy model component types, component
@@ -75,31 +76,79 @@ zmax = FT(0)
 land_domain =
     LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelements);
 
-# For our soil model, we will choose a 
-# [`RichardsModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Soil/#Soil-Models-2) 
+# For our soil model, we will choose the
+# [`EnergyHydrology`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Soil/#Soil-Models-2) 
 # and set up all the necessary arguments. See the 
-# [tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/Soil/richards_equation/)
-# on Richard's Model for a more detailed explanation of the soil model.
+# [tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/Soil/soil_energy_hydrology/)
+# on the model for a more detailed explanation of the soil model.
 
+# We will be using prescribed atmospheric and radiative drivers from the 
+# US-MOz tower. We are using prescribed
+# atmospheric and radiative flux conditions, but it is also possible to couple
+# the simulation with atmospheric and radiative flux models.
 
-soil_ν = FT(0.55)
-soil_K_sat = FT(4e-7)
-soil_S_s = FT(1e-3)
-soil_vg_n = FT(2.6257)
-soil_vg_α = FT(1.368)
-θ_r = FT(0.067)
+include(
+    joinpath(
+        pkgdir(ClimaLSM),
+        "experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl",
+    ),
+);
+
+# Define the parameters for the soil model and provide them to the model 
+# parameters struct:
+
+# Soil parameters
+soil_ν = FT(0.5) # m3/m3
+soil_K_sat = FT(4e-7) # m/s
+soil_S_s = FT(1e-3) # 1/m
+soil_vg_n = FT(2.05) # unitless
+soil_vg_α = FT(0.04) # inverse meters
+θ_r = FT(0.067); # m3/m3
+
+# Soil heat transfer parameters
+ν_ss_quartz = FT(0.1)
+ν_ss_om = FT(0.1)
+ν_ss_gravel = FT(0.0);
+κ_quartz = FT(7.7) # W/m/K
+κ_minerals = FT(2.5) # W/m/K
+κ_om = FT(0.25) # W/m/K
+κ_liq = FT(0.57) # W/m/K
+κ_ice = FT(2.29) # W/m/K
+κ_air = FT(0.025); #W/m/K
+ρp = FT(2700); # kg/m^3
+κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+κ_dry = Soil.κ_dry(ρp, soil_ν, κ_solid, κ_air)
+κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, soil_ν, κ_ice)
+κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, soil_ν, κ_liq);
+ρc_ds = FT((1 - soil_ν) * 4e6); # J/m^3/K
+z_0m_soil = FT(0.1)
+z_0b_soil = FT(0.1)
+soil_ϵ = FT(0.98)
+soil_α = FT(0.25);
 
 soil_domain = land_domain.subsurface
-soil_ps = Soil.RichardsParameters{FT, vanGenuchten{FT}}(
-    soil_ν,
-    vanGenuchten(; α = soil_vg_α, n = soil_vg_n),
-    soil_K_sat,
-    soil_S_s,
-    θ_r,
-)
+soil_ps = Soil.EnergyHydrologyParameters{FT}(;
+    κ_dry = κ_dry,
+    κ_sat_frozen = κ_sat_frozen,
+    κ_sat_unfrozen = κ_sat_unfrozen,
+    ρc_ds = ρc_ds,
+    ν = soil_ν,
+    ν_ss_om = ν_ss_om,
+    ν_ss_quartz = ν_ss_quartz,
+    ν_ss_gravel = ν_ss_gravel,
+    hydrology_cm = vanGenuchten(; α = soil_vg_α, n = soil_vg_n),
+    K_sat = soil_K_sat,
+    S_s = soil_S_s,
+    θ_r = θ_r,
+    earth_param_set = earth_param_set,
+    z_0m = z_0m_soil,
+    z_0b = z_0b_soil,
+    emissivity = soil_ϵ,
+    albedo = soil_α,
+);
 
 soil_args = (domain = soil_domain, parameters = soil_ps)
-soil_model_type = Soil.RichardsModel{FT};
+soil_model_type = Soil.EnergyHydrology{FT}
 
 # Next we need to set up the [`CanopyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/canopy/Canopy/#Canopy-Model-Structs).
 # For more details on the specifics of this model see the previous tutorial.
@@ -113,7 +162,7 @@ soil_model_type = Soil.RichardsModel{FT};
 # this must be done internally from the constructor.
 
 canopy_component_types = (;
-    radiative_transfer = Canopy.BeerLambertModel{FT},
+    radiative_transfer = Canopy.TwoStreamModel{FT},
     photosynthesis = Canopy.FarquharModel{FT},
     conductance = Canopy.MedlynConductanceModel{FT},
     hydraulics = Canopy.PlantHydraulicsModel{FT},
@@ -123,11 +172,14 @@ canopy_component_types = (;
 # and photosynthesis models as was done in the previous tutorial.
 
 radiative_transfer_args = (;
-    parameters = BeerLambertParameters{FT}(;
-        Ω = FT(0.69),
+    parameters = TwoStreamParameters{FT}(;
         ld = FT(0.5),
         ρ_leaf = FT(0.1),
+        τ = FT(0.1),
+        Ω = FT(0.69),
         λ_γ = FT(5e-7),
+        n_layers = UInt64(20),
+        diff_perc = FT(0.5),
     )
 )
 
@@ -162,12 +214,8 @@ photosynthesis_args = (;
     )
 );
 
-# For the plant hydraulics model, we now will not provide prescribed root 
-# extraction since the soil pressure will now be simulated by the soil physics 
-# model.
-
 f_root_to_shoot = FT(3.5)
-SAI = FT(0.00242)
+SAI = FT(1.0)
 LAI = FT(4.2)
 LAIfunction = (t) -> eltype(t)(LAI)
 K_sat_plant = 1.8e-8
@@ -235,30 +283,14 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
 
 canopy_model_args = (; parameters = shared_params, domain = land_domain.surface);
 
-# - We will be using prescribed atmospheric and radiative drivers from the 
-#   US-MOz tower, which we read in here. We are using prescribed
-#   atmospheric and radiative flux conditions, but it is also possible to couple
-#   the simulation with atmospheric and radiative flux models.
-
-include(
-    joinpath(
-        pkgdir(ClimaLSM),
-        "experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl",
-    ),
-);
-
-# We may now instantiate the integrated plant hydraulics and soil model. The 
-# Default diagnostics is transpiration. Here we will work with prescribed 
+# We may now instantiate the integrated plant and soil model. In this example, 
+# we will compute transpiration diagnostically, and work with prescribed 
 # atmospheric and radiative flux conditions from the observations at the Ozark 
 # site as was done in the previous tutorial.
 
-land_input = (
-    transpiration = DiagnosticTranspiration{Float64}(),
-    atmos = atmos,
-    radiation = radiation,
-)
+land_input = (atmos = atmos, radiation = radiation)
 
-land = SoilPlantHydrologyModel{FT}(;
+land = SoilCanopyModel{FT}(;
     land_args = land_input,
     soil_model_type = soil_model_type,
     soil_args = soil_args,
@@ -272,14 +304,23 @@ land = SoilPlantHydrologyModel{FT}(;
 # stepping is done implicitly, while the canopy model may be explicitly stepped, 
 # so we use an IMEX (implicit-explicit) scheme for the combined model.
 
-Y, p, coords = initialize(land)
-exp_tendency! = make_exp_tendency(land)
-imp_tendency! = make_imp_tendency(land);
+Y, p, coords = initialize(land);
+exp_tendency! = make_exp_tendency(land);
 
 # We need to provide initial conditions for the soil and canopy hydraulics 
 # models:
-
 Y.soil.ϑ_l = FT(0.4)
+Y.soil.θ_i = FT(0.0)
+T_0 = FT(288.7)
+ρc_s =
+    volumetric_heat_capacity.(Y.soil.ϑ_l, Y.soil.θ_i, Ref(land.soil.parameters))
+Y.soil.ρe_int =
+    volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T_0,
+        Ref(land.soil.parameters),
+    )
 ψ_stem_0 = FT(-1e5 / 9800)
 ψ_leaf_0 = FT(-2e5 / 9800)
 
@@ -302,34 +343,18 @@ t0 = FT(0)
 set_initial_aux_state! = make_set_initial_aux_state(land)
 set_initial_aux_state!(p, Y, t0);
 
-# Select the timestepper and solvers needed for the specific problem, and setup
-# the jacobian for the soil model. For more details on the soil jacobian setup 
-# see the tutorial on using a Richard's Model. Specify the time range and dt
+# Select the timestepper and solvers needed for the specific problem. Specify the time range and dt
 # value over which to perform the simulation.
 
-update_jacobian! = make_update_jacobian(land.soil)
-
-N_days = 365
+t0 = FT(150 * 3600 * 24)# start mid year
+N_days = 100
 tf = t0 + FT(3600 * 24 * N_days)
-dt = FT(225)
-n = 16
+dt = FT(30)
+n = 120
 saveat = Array(t0:(n * dt):tf)
-timestepper = CTS.ARS222()
-norm_condition = CTS.MaximumError(FT(1e-8))
-conv_checker = CTS.ConvergenceChecker(; norm_condition)
-max_iterations = 20
 
-ode_algo = CTS.IMEXAlgorithm(
-    timestepper,
-    CTS.NewtonsMethod(
-        max_iters = max_iterations,
-        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
-        convergence_checker = conv_checker,
-    ),
-)
-
-W = RichardsTridiagonalW(Y)
-jac_kwargs = (; jac_prototype = W, Wfact = update_jacobian!);
+timestepper = CTS.RK4()
+ode_algo = CTS.ExplicitAlgorithm(timestepper);
 
 # And now perform the simulation as always.
 
@@ -339,16 +364,8 @@ sv = (;
 )
 cb = ClimaLSM.NonInterpSavingCallback(sv, saveat)
 
-prob = ODE.ODEProblem(
-    CTS.ClimaODEFunction(
-        T_exp! = exp_tendency!,
-        T_imp! = ODE.ODEFunction(imp_tendency!; jac_kwargs...),
-        dss! = ClimaLSM.dss!,
-    ),
-    Y,
-    (t0, tf),
-    p,
-)
+prob =
+    ODE.ODEProblem(CTS.ClimaODEFunction(T_exp! = exp_tendency!), Y, (t0, tf), p);
 sol = ODE.solve(
     prob,
     ode_algo;

--- a/experiments/integrated/ozark/hydrology_only/ozark.jl
+++ b/experiments/integrated/ozark/hydrology_only/ozark.jl
@@ -146,7 +146,8 @@ canopy_model_args = (; parameters = shared_params, domain = land_domain.surface)
 # debugging purposes), you would pass it as another element
 # of this tuple. The default if it is not passed is
 # a diagnostic (big leaf-computed) transpiration.
-land_input = (atmos = atmos, radiation = radiation)
+soil_driver = PrognosticSoil(; soil_α = FT(0.2))
+land_input = (atmos = atmos, soil_driver = soil_driver, radiation = radiation)
 land = SoilPlantHydrologyModel{FT}(;
     land_args = land_input,
     soil_model_type = soil_model_type,

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -64,7 +64,7 @@ soil_model_type = Soil.EnergyHydrology{FT}
 # Now we set up the canopy model, which we set up by component:
 # Component Types
 canopy_component_types = (;
-    radiative_transfer = Canopy.BeerLambertModel{FT},
+    radiative_transfer = Canopy.TwoStreamModel{FT},
     photosynthesis = Canopy.FarquharModel{FT},
     conductance = Canopy.MedlynConductanceModel{FT},
     hydraulics = Canopy.PlantHydraulicsModel{FT},
@@ -72,11 +72,14 @@ canopy_component_types = (;
 # Individual Component arguments
 # Set up radiative transfer
 radiative_transfer_args = (;
-    parameters = BeerLambertParameters{FT}(;
+    parameters = TwoStreamParameters{FT}(;
         Ω = Ω,
         ld = ld,
         ρ_leaf = ρ_leaf,
         λ_γ = λ_γ,
+        τ = FT(0.1),
+        n_layers = UInt64(20),
+        diff_perc = FT(0.5),
     )
 )
 # Set up conductance

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -1,3 +1,4 @@
+using ..ClimaLSM.Canopy
 export plant_absorbed_ppfd,
     extinction_coeff,
     arrhenius_function,
@@ -23,11 +24,12 @@ export plant_absorbed_ppfd,
 # 1. Radiative transfer
 
 """
-    plant_absorbed_ppfd(RT::BeerLambertModel,
+    plant_absorbed_ppfd(RT::BeerLambertModel{FT},
                         PAR::FT,
                         LAI::FT,
                         K::FT,
-                        θs::FT,
+                        _,
+                        _,
     )
 
 Computes the absorbed photosynthetically active radiation in terms 
@@ -42,11 +44,12 @@ BeerLambertModel, along with the PAR, LAI, extinction coefficient K, and solar
 zenith anlgle.
 """
 function plant_absorbed_ppfd(
-    RT::BeerLambertModel,
+    RT::BeerLambertModel{FT},
     PAR::FT,
     LAI::FT,
     K::FT,
-    θs::FT,
+    _,
+    _,
 ) where {FT}
     RTP = RT.parameters
     APAR = PAR * (1 - RTP.ρ_leaf) * (1 - exp(-K * LAI * RTP.Ω))
@@ -54,7 +57,7 @@ function plant_absorbed_ppfd(
 end
 
 """
-    plant_absorbed_ppfd(RT::TwoStreamModel,
+    plant_absorbed_ppfd(RT::TwoStreamModel{FT},
                         PAR::FT,
                         LAI::FT,
                         K::FT,
@@ -66,18 +69,20 @@ of mol photons per m^2 per second (`APAR`).
 
 This applies the two-stream radiative transfer solution which takes into account
 the impacts of scattering within the canopy. The function takes in all 
-paramters from the parameter struct of a TwoStreamModel, along with the PAR, 
-LAI, extinction coefficient K, and solar zenith anlgle.
+parameters from the parameter struct of a TwoStreamModel, along with the 
+incident PAR, LAI, extinction coefficient K, soil albedo from the 
+canopy soil_driver, and solar zenith angle.
 """
 function plant_absorbed_ppfd(
-    RT::TwoStreamModel,
+    RT::TwoStreamModel{FT},
     PAR::FT,
     LAI::FT,
     K::FT,
     θs::FT,
+    a_soil::FT,
 ) where {FT}
 
-    (; ld, ρ_leaf, τ, a_soil, Ω, n_layers, diff_perc) = RT.parameters
+    (; ld, ρ_leaf, τ, Ω, n_layers, diff_perc) = RT.parameters
 
     # Compute μ̄, the average inverse diffuse optical length per LAI
     μ̄ = 1 / (2 * ld)

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -1,3 +1,5 @@
+using ..ClimaLSM.Canopy: AbstractSoilDriver
+
 export BeerLambertParameters,
     BeerLambertModel, TwoStreamParameters, TwoStreamModel
 
@@ -59,8 +61,6 @@ struct TwoStreamParameters{FT <: AbstractFloat}
     ρ_leaf::FT
     "leaf element transmittance"
     τ::FT
-    "Soil albedo"
-    a_soil::FT
     "Clumping index following Braghiere (2021) (unitless)"
     Ω::FT
     "Typical wavelength per PAR photon (m)"
@@ -76,7 +76,6 @@ end
         ld = FT(0.5),
         ρ_leaf = FT(0.3),
         τ = FT(0.2),
-        a_soil = FT(0.1),
         Ω = FT(1),
         λ_γ = FT(5e-7),
         n_layers = UInt64(20),
@@ -89,22 +88,12 @@ function TwoStreamParameters{FT}(;
     ld = FT(0.5),
     ρ_leaf = FT(0.3),
     τ = FT(0.2),
-    a_soil = FT(0.1),
     Ω = FT(1),
     λ_γ = FT(5e-7),
     n_layers = UInt64(20),
     diff_perc = FT(0),
 ) where {FT}
-    return TwoStreamParameters{FT}(
-        ld,
-        ρ_leaf,
-        τ,
-        a_soil,
-        Ω,
-        λ_γ,
-        n_layers,
-        diff_perc,
-    )
+    return TwoStreamParameters{FT}(ld, ρ_leaf, τ, Ω, λ_γ, n_layers, diff_perc)
 end
 
 struct TwoStreamModel{FT} <: AbstractRadiationModel{FT}

--- a/src/standalone/Vegetation/soil_drivers.jl
+++ b/src/standalone/Vegetation/soil_drivers.jl
@@ -1,0 +1,70 @@
+export AbstractSoilDriver, PrescribedSoil, PrognosticSoil
+
+"""
+An abstract type of soil drivers of the canopy model.
+"""
+abstract type AbstractSoilDriver{FT <: AbstractFloat} end
+
+"""
+     PrescribedSoil{FT} <: AbstractSoilDriver{FT}
+
+A container for holding prescribed soil parameters needed by the canopy model
+when running the canopy in standalone mode, including the soil pressure and 
+albedo.
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedSoil{FT} <: AbstractSoilDriver{FT}
+    "The depth of the root tips, in meters"
+    root_depths::Vector{FT}
+    "Prescribed soil potential (m) as a function of time"
+    ψ_soil::Function
+    "Soil albedo"
+    soil_α::FT
+end
+
+"""
+     function PrescribedSoil{FT}(;
+         root_depths::Vector{FT},
+         ψ_soil::Function,
+         soil_α::FT
+     ) where {FT}
+
+An outer constructor for the PrescribedSoil soil driver allowing the user to 
+specify the soil parameters by keyword arguments.
+"""
+function PrescribedSoil(;
+    root_depths::Vector{FT} = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0),
+    ψ_soil::Function = t -> eltype(t)(FT(0.0)),
+    soil_α::FT = FT(0.2),
+) where {FT}
+    return PrescribedSoil{FT}(root_depths, ψ_soil, soil_α)
+end
+
+"""
+     PrognosticSoil{FT} <: AbstractSoilDriver{FT}
+
+Concrete type of AbstractSoilDriver used for dispatch in cases where both 
+a canopy model and soil model are run. Contains the soil albedo to be shared 
+between the canopy and soil models.
+
+When running the SoilCanopyModel, the soil model specifies the albedo. In this 
+case, the constructor for the model reads the albedo from the soil model and the
+user only specifies it once, for the soil model. When running the 
+SoilPlantHydrologyModel (which is intended for internal usage/testing primarily)
+the user must specify the albedo because the soil model in that case does not
+have an albedo.
+$(DocStringExtensions.FIELDS)
+"""
+struct PrognosticSoil{FT} <: AbstractSoilDriver{FT}
+    soil_α::FT
+end
+
+"""
+    function PrognosticSoil{FT}(; soil_α::FT) where {FT}
+
+An outer constructor for the PrognosticSoil soil driver allowing the user to
+specify the soil albedo by keyword argument.
+"""
+function PrognosticSoil(; soil_α::FT = FT(0.2)) where {FT}
+    return PrognosticSoil{FT}(soil_α)
+end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -148,12 +148,11 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         )
 
     ψ_soil0 = FT(0.0)
-    root_extraction =
-        PrescribedSoilPressure{FT}(root_depths, (t::FT) -> ψ_soil0)
+
+    soil_driver = PrescribedSoil(root_depths, (t::FT) -> ψ_soil0, FT(0.2))
 
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,
-        root_extraction = root_extraction,
         n_stem = n_stem,
         n_leaf = n_leaf,
         compartment_surfaces = compartment_faces,
@@ -166,6 +165,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         photosynthesis = photosynthesis_model,
         conductance = stomatal_model,
         hydraulics = plant_hydraulics,
+        soil_driver = soil_driver,
         atmos = atmos,
         radiation = radiation,
     )
@@ -324,13 +324,8 @@ end
             )
         )
 
-    ψ_soil0 = FT(0.0)
-    root_extraction =
-        PrescribedSoilPressure{FT}(root_depths, (t::FT) -> ψ_soil0)
-
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,
-        root_extraction = root_extraction,
         n_stem = n_stem,
         n_leaf = n_leaf,
         compartment_surfaces = compartment_faces,

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -229,12 +229,11 @@ end
     ψ_soil0 = FT(0.0)
     transpiration =
         PrescribedTranspiration{FT}((t::FT) -> leaf_transpiration(t))
-    root_extraction =
-        PrescribedSoilPressure{FT}(root_depths, (t::FT) -> ψ_soil0)
+
+    soil_driver = PrescribedSoil(root_depths, (t::FT) -> ψ_soil0, FT(0.2))
 
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,
-        root_extraction = root_extraction,
         transpiration = transpiration,
         n_stem = n_stem,
         n_leaf = n_leaf,
@@ -249,6 +248,7 @@ end
             photosynthesis = photosynthesis_model,
             conductance = stomatal_model,
             hydraulics = plant_hydraulics,
+            soil_driver = soil_driver,
             atmos = atmos,
             radiation = radiation,
         )
@@ -351,7 +351,7 @@ end
         end
         set_initial_aux_state!(p, Y, 0.0)
         standalone_exp_tendency! =
-            make_compute_exp_tendency(model.hydraulics, nothing)
+            make_compute_exp_tendency(model.hydraulics, model)
         standalone_exp_tendency!(standalone_dY, Y, p, 0.0)
 
         m = similar(dY.canopy.hydraulics.ϑ_l[1])
@@ -487,12 +487,10 @@ end
 
     ψ_soil0 = FT(0.0)
     transpiration = DiagnosticTranspiration{FT}()
-    root_extraction =
-        PrescribedSoilPressure{FT}(root_depths, (t::FT) -> ψ_soil0)
+    soil_driver = PrescribedSoil(root_depths, (t::FT) -> ψ_soil0, FT(0.2))
 
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,
-        root_extraction = root_extraction,
         transpiration = transpiration,
         n_stem = n_stem,
         n_leaf = n_leaf,
@@ -506,6 +504,7 @@ end
         photosynthesis = photosynthesis_model,
         conductance = stomatal_model,
         hydraulics = plant_hydraulics,
+        soil_driver = soil_driver,
         atmos = atmos,
         radiation = radiation,
     )

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -27,6 +27,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     T = FT(290) # K
     P = FT(101250) #Pa
     q = FT(0.02)
+    a_soil = FT(0.2)
     VPD = ClimaLSM.vapor_pressure_deficit(T, P, q, thermo_params)#Pa
     p_l = FT(-2e6) # Pa
     ca = FT(4.11e-4) # mol/mol
@@ -36,7 +37,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     PAR = SW(θs) ./ (energy_per_photon * N_a) # convert 500 W/m^2 to mol of photons per m^2/s
     K_c = extinction_coeff.(RTparams.ld, θs)
     @test all(K_c .≈ RTparams.ld ./ cos.(θs))
-    APAR = plant_absorbed_ppfd.(RT, PAR, LAI, K_c, θs)
+    APAR = plant_absorbed_ppfd.(RT, PAR, LAI, K_c, θs, a_soil)
     @test all(
         APAR .≈
         PAR .* (1 - RTparams.ρ_leaf) .* (1 .- exp.(-K_c .* LAI .* RTparams.Ω)),

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -55,7 +55,6 @@ py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
             ld = ld[i],
             ρ_leaf = ρ_leaf[i],
             τ = τ[i],
-            a_soil = a_soil[i],
             Ω = Ω,
             λ_γ = λ_γ,
             n_layers = n_layers[i],
@@ -67,7 +66,7 @@ py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
 
         # Compute the predicted FAPAR using the ClimaLSM TwoStream implementation
         K = extinction_coeff(ld[i], θs[i])
-        FAPAR = plant_absorbed_ppfd(RT, FT(1), LAI[i], K, θs[i])
+        FAPAR = plant_absorbed_ppfd(RT, FT(1), LAI[i], K, θs[i], a_soil[i])
 
         # Check that the predictions are app. equivalent to the Python model
         @test isapprox(py_FAPAR[i], FAPAR, atol = 0.005)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds soil drivers to the canopy model to prevent the requirement to specify soil albedo in multiple places when using a TwoStream radiative transfer model. Will resolve #271

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Creates the type `AbstractSoilDriver` with 3 different concrete types, and requires a soil driver of this type to be input into the canopy model
- There are now `PrescribedSoil` (fully prescribed by the user), `PrognosticSoil` (for use with SoilEnergyHydrology), and `PrognosticSoilHydrology` (Hydrology only is prognostic and user needs to specify albedo (for SoilPlantHydrologyModel)) which can be the `soil_driver` for the CanopyModel
- Integrated models edited to use these types
- Ozark experiment and canopy tutorials updated to use these types

There are a couple things we may want to think about still before merging
- `plant_absorbed_ppfd` is now a function of the canopy model since it requires the `soil_driver` from the canopy. If it isn't, then we need to supply the soil_driver to the TwoStream model only when soil is prescribed which seems confusing for a user. However, this would mean that `plant_absorbed_ppfd` should be moved out of the parameterizations file and the parameterizations tests need to change.
    - One alternative would be to use the canopy model similar to how we use the integrated CanopySoilModel... provide arguments for the component models to the constructor of the canopy model, then have the CanopyModel instantiate the component models and supply the soil driver to the ones that need it. This way the user would only have to input the soil driver once, but it would be supplied to the hydraulic model and radiative_transfer model where needed.
- Similarly as it stands now, we have to supply the soil_driver to the Hydraulics model only when running standalone or `SoilPlantHydrologyModel`, which seems confusing for a user

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
