### PR TITLE
Fix `interpol` bug

### DIFF
--- a/src/shared_utilities/FileReader.jl
+++ b/src/shared_utilities/FileReader.jl
@@ -369,7 +369,7 @@ a segment `Δt_t2t1 = (t2 - t1)`, of fields `f1` and `f2`, with `t2 > t1`.
 function interpol(f1::FT, f2::FT, Δt_tt1::FT, Δt_t2t1::FT) where {FT}
     interp_fraction = Δt_tt1 / Δt_t2t1
     @assert abs(interp_fraction) <= FT(1) "time interpolation weights must be <= 1, but `interp_fraction` = $interp_fraction"
-    return f1 * interp_fraction + f2 * (FT(1) - interp_fraction)
+    return f1 * (FT(1) - interp_fraction) + f2 * (interp_fraction)
 end
 
 """

--- a/test/shared_utilities/file_reader.jl
+++ b/test/shared_utilities/file_reader.jl
@@ -72,6 +72,27 @@ for FT in (Float64, Float32)
         end
     end
 
+    @testset "test interpol for FT=$FT" begin
+        # Setup
+        t1 = FT(0)
+        t2 = FT(10)
+
+        f1 = FT(-1)
+        f2 = FT(1)
+
+        # Case 1: t1 < t < t2
+        t = FT(5)
+        @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == 0
+
+        # Case 2: t1 = t < t2
+        t = FT(0)
+        @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == f1
+
+        # Case 3: t1 < t = t2
+        t = FT(10)
+        @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == f2
+    end
+
     @testset "test interpolate_data for FT=$FT" begin
         # test interpolate_data with interpolation (default)
         dummy_dates =


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We have a function `interpol` in the FileReader module that performs interpolation between two values. However, the logic is switched so the interpolation is incorrect. This PR fixes the logic and adds a test to verify correctness.


## Content
- [x] fix interpol logic
- [x] add test

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
