### PR TITLE
Update dss_helper to use pre-allocated buffer variables

### DIFF
--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -72,8 +72,11 @@ function dss_helper!(
         ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace,
         ClimaCore.Spaces.AbstractSpectralElementSpace,
     },
-)
-    Spaces.weighted_dss!(field)
+)       
+    field_buffer = Spaces.create_dss_buffer(field)
+    Spaces.weighted_dss_start!(field, field_buffer)
+    Spaces.weighted_dss_internal!(field, field_buffer)
+    Spaces.weighted_dss_ghost!(field, field_buffer)
 end
 
 """

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -72,7 +72,7 @@ function dss_helper!(
         ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace,
         ClimaCore.Spaces.AbstractSpectralElementSpace,
     },
-)       
+)
     field_buffer = Spaces.create_dss_buffer(field)
     Spaces.weighted_dss!(field, field_buffer)
 end

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -74,9 +74,7 @@ function dss_helper!(
     },
 )       
     field_buffer = Spaces.create_dss_buffer(field)
-    Spaces.weighted_dss_start!(field, field_buffer)
-    Spaces.weighted_dss_internal!(field, field_buffer)
-    Spaces.weighted_dss_ghost!(field, field_buffer)
+    Spaces.weighted_dss!(field, field_buffer)
 end
 
 """


### PR DESCRIPTION
TODO: Cache `field_buffer`
	modified:   src/shared_utilities/utils.jl

Use pre-allocated buffer variables in `dss_helper` function.

----
- [ ] I have read and checked the items on the review checklist.
