### PR TITLE
clean up name of function

### DIFF
--- a/docs/src/APIs/ClimaLSM.md
+++ b/docs/src/APIs/ClimaLSM.md
@@ -14,8 +14,8 @@ ClimaLSM.initialize_interactions
 ClimaLSM.land_components
 ClimaLSM.interaction_vars
 ClimaLSM.interaction_types
-ClimaLSM.interaction_domains
-ClimaLSM.domain
+ClimaLSM.interaction_domain_names
+ClimaLSM.domain_name
 ```
 
 ## Land Hydrology

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -57,7 +57,7 @@ function Domains.coordinates(model::AbstractLandModel)
         Domains.coordinates(getproperty(model, component))
     end
     domains_list = map(components) do (component)
-        domain(getproperty(model, component))
+        domain_name(getproperty(model, component))
     end
     coords = ClimaCore.Fields.FieldVector(;
         NamedTuple{Tuple(unique(domains_list))}(Tuple(unique(coords_list)))...,
@@ -73,7 +73,7 @@ function initialize_prognostic(
     Y_state_list = map(components) do (component)
         submodel = getproperty(model, component)
         zero_state =
-            map(_ -> zero(FT), getproperty(coords, domain(submodel)))
+            map(_ -> zero(FT), getproperty(coords, domain_name(submodel)))
         getproperty(initialize_prognostic(submodel, zero_state), component)
     end
     Y = ClimaCore.Fields.FieldVector(; NamedTuple{components}(Y_state_list)...)
@@ -88,7 +88,7 @@ function initialize_auxiliary(
     p_state_list = map(components) do (component)
         submodel = getproperty(model, component)
         zero_state =
-            map(_ -> zero(FT), getproperty(coords, domain(submodel)))
+            map(_ -> zero(FT), getproperty(coords, domain_name(submodel)))
         getproperty(initialize_auxiliary(submodel, zero_state), component)
     end
     p_interactions = initialize_interactions(model, coords)
@@ -112,7 +112,7 @@ This function should be called during `initialize_auxiliary` step.
 function initialize_interactions(land::AbstractLandModel, land_coords)
     vars = interaction_vars(land)
     types = interaction_types(land)
-    domains = interaction_domains(land)
+    domains = interaction_domain_names(land)
     interactions = map(zip(types, domains)) do (T, domain)
         zero_instance = zero(T)
         map(_ -> zero_instance, getproperty(land_coords, domain))
@@ -265,7 +265,7 @@ Returns the shared interaction variable types for the model in the form of a tup
 interaction_types(m::AbstractLandModel) = ()
 
 """
-   interaction_domains(m::AbstractLandModel)
+   interaction_domain_names(m::AbstractLandModel)
 
 Returns the interaction domain symbols in the form of a tuple e.g. :surface or :subsurface.
 
@@ -274,7 +274,7 @@ for multi-component models, not standalone components. Component-specific variab
 should be listed as prognostic or auxiliary variables which do not require this to
 initialize.
 """
-interaction_domains(m::AbstractLandModel) = ()
+interaction_domain_names(m::AbstractLandModel) = ()
 
 # Methods extended by the LSM models we support
 include("standalone/SurfaceWater/Pond.jl")

--- a/src/integrated/pond_soil_model.jl
+++ b/src/integrated/pond_soil_model.jl
@@ -80,7 +80,7 @@ interaction_vars(m::LandHydrology) = (:soil_infiltration,)
 
 interaction_types(m::LandHydrology{FT}) where {FT} = (FT,)
 
-interaction_domains(m::LandHydrology) = (:surface,)
+interaction_domain_names(m::LandHydrology) = (:surface,)
 
 #=
 If there is a pond present, flux BC should be -i_c

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -182,12 +182,12 @@ interaction_types(m::SoilCanopyModel{FT}) where {FT} =
     (FT, FT, FT, FT, FT, FT, FT, FT)
 
 """
-    interaction_domains(m::SoilCanopyModel)
+    interaction_domain_names(m::SoilCanopyModel)
 
-The domains of the additional auxiliary variables that are 
+The domain names of the additional auxiliary variables that are 
 included in the integrated Soil-Canopy model.
 """
-interaction_domains(m::SoilCanopyModel) = (
+interaction_domain_names(m::SoilCanopyModel) = (
     :subsurface,
     :surface,
     :surface,

--- a/src/integrated/soil_plant_hydrology_model.jl
+++ b/src/integrated/soil_plant_hydrology_model.jl
@@ -120,7 +120,7 @@ interaction_vars(m::SoilPlantHydrologyModel) = (:root_extraction,)
 
 interaction_types(m::SoilPlantHydrologyModel{FT}) where {FT} = (FT,)
 
-interaction_domains(m::SoilPlantHydrologyModel) = (:subsurface,)
+interaction_domain_names(m::SoilPlantHydrologyModel) = (:subsurface,)
 
 """
     make_interactions_update_aux(

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -16,7 +16,7 @@ export AbstractModel,
     auxiliary_types,
     make_set_initial_aux_state,
     name,
-    domain
+    domain_name
 
 import .Domains: coordinates
 ## Default methods for all models - to be in a seperate module at some point.
@@ -55,11 +55,11 @@ name(model::AbstractModel) =
     error("`name` not implemented for $(Base.typename(typeof(model)).wrapper)")
 
 """
-    domain(model::AbstractModel)
+    domain_name(model::AbstractModel)
 
-Returns a symbol indicating the model's domain, e.g. :surface or :subsurface. Only required for models that will be used as part of an LSM.
+Returns a symbol indicating the model's domain name, e.g. :surface or :subsurface. Only required for models that will be used as part of an LSM.
 """
-domain(model::AbstractModel) = error(
+domain_name(model::AbstractModel) = error(
     "`domain` not implemented for $(Base.typename(typeof(model)).wrapper)",
 )
 

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -14,6 +14,7 @@ import ClimaLSM:
     prognostic_vars,
     auxiliary_vars,
     name,
+    domain_name,
     prognostic_types,
     auxiliary_types,
     TopBoundary,
@@ -181,7 +182,7 @@ function SoilCO2Model{FT}(;
 end
 
 ClimaLSM.name(model::SoilCO2Model) = :soilco2
-ClimaLSM.domain(model::SoilCO2Model) = :subsurface
+ClimaLSM.domain_name(model::SoilCO2Model) = :subsurface
 
 
 ClimaLSM.prognostic_vars(::SoilCO2Model) = (:C,)

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -74,6 +74,7 @@ import ClimaLSM:
     prognostic_vars,
     auxiliary_vars,
     name,
+    domain_name,
     prognostic_types,
     auxiliary_types,
     AbstractSource,
@@ -119,7 +120,7 @@ and a fully integrated soil heat and water model, with phase change.
 abstract type AbstractSoilModel{FT} <: ClimaLSM.AbstractImExModel{FT} end
 
 ClimaLSM.name(::AbstractSoilModel) = :soil
-ClimaLSM.domain(::AbstractSoilModel) = :subsurface
+ClimaLSM.domain_name(::AbstractSoilModel) = :subsurface
 
 """
    horizontal_components!(dY::ClimaCore.Fields.FieldVector,

--- a/src/standalone/SurfaceWater/Pond.jl
+++ b/src/standalone/SurfaceWater/Pond.jl
@@ -62,7 +62,7 @@ end
 ClimaLSM.prognostic_vars(model::PondModel) = (:η,)
 ClimaLSM.prognostic_types(model::PondModel{FT}) where {FT} = (FT,)
 ClimaLSM.name(::AbstractSurfaceWaterModel) = :surface_water
-ClimaLSM.domain(::AbstractSurfaceWaterModel) = :surface
+ClimaLSM.domain_name(::AbstractSurfaceWaterModel) = :surface
 
 function ClimaLSM.make_compute_exp_tendency(model::PondModel)
     function compute_exp_tendency!(dY, Y, p, t)

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -9,7 +9,7 @@ import ..Parameters as LSMP
 import ClimaLSM:
     AbstractExpModel,
     name,
-    domain,
+    domain_name,
     prognostic_vars,
     prognostic_types,
     auxiliary_vars,
@@ -164,7 +164,7 @@ function CanopyModel{FT}(;
 end
 
 ClimaLSM.name(::CanopyModel) = :canopy
-ClimaLSM.domain(::CanopyModel) = :surface
+ClimaLSM.domain_name(::CanopyModel) = :surface
 
 
 """

--- a/test/integrated/lsms.jl
+++ b/test/integrated/lsms.jl
@@ -1,7 +1,7 @@
 using Test
 import ClimaLSM:
     name,
-    domain,
+    domain_name,
     prognostic_types,
     auxiliary_types,
     prognostic_vars,
@@ -18,7 +18,7 @@ using ClimaLSM
         domain::Any
     end
     ClimaLSM.name(::DummyModel1) = :m1
-    ClimaLSM.domain(::DummyModel1) = :surface
+    ClimaLSM.domain_name(::DummyModel1) = :surface
     ClimaLSM.auxiliary_vars(::DummyModel1) = (:a, :b)
     ClimaLSM.auxiliary_types(::DummyModel1{FT}) where {FT} = (FT, FT)
 
@@ -27,7 +27,7 @@ using ClimaLSM
     end
 
     ClimaLSM.name(::DummyModel2) = :m2
-    ClimaLSM.domain(::DummyModel2) = :surface
+    ClimaLSM.domain_name(::DummyModel2) = :surface
     ClimaLSM.auxiliary_vars(::DummyModel2) = (:c, :d)
     ClimaLSM.auxiliary_types(::DummyModel2{FT}) where {FT} = (FT, FT)
 

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -268,7 +268,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         Ref(Thermodynamics.Liquid()),
     )
     @test ρ_sfc == compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
-    @test ClimaLSM.domain(canopy) == :surface
+    @test ClimaLSM.domain_name(canopy) == :surface
 end
 
 


### PR DESCRIPTION
## Purpose 
We use the name `domain` for a number of things, the domain itself (ClimaLSM struct) but also as a function which returns the domain name (:surface, :subsurface). change the function to `domain_name` for clarity; likewise for `interaction_domain`


## To-do

## Content
Change `domain` function to `domain_name` and propagate; likewise for `interaction_domains`

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [ ] I have read and checked the items on the review checklist.
