### PR TITLE
BulkAlbedoTemporal - use ClimaCore space

### DIFF
--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -142,7 +142,7 @@ end
         regrid_dirpath::String,
         date_ref::Union{DateTime, DateTimeNoLeap},
         t_start::FT,
-        surface;
+        Space::ClimaCore.Spaces.AbstractSpace;
         input_file = Bucket.cesm2_albedo_dataset_path(),
         varname = "sw_alb"
     ) where {FT}
@@ -157,12 +157,12 @@ function BulkAlbedoTemporal{FT}(
     regrid_dirpath::String,
     date_ref::Union{DateTime, DateTimeNoLeap},
     t_start::FT,
-    surface;
+    space::ClimaCore.Spaces.AbstractSpace;
     input_file = Bucket.cesm2_albedo_dataset_path(),
     varname = "sw_alb",
 ) where {FT}
     # Verify inputs
-    if typeof(surface) <: ClimaLSM.Domains.Point
+    if typeof(space) <: ClimaCore.Spaces.PointSpace
         error("Using an albedo map requires a global run.")
     end
     NCDataset(input_file, "r") do ds
@@ -180,7 +180,7 @@ function BulkAlbedoTemporal{FT}(
         varname,
         date_ref,
         t_start,
-        surface.space,
+        space,
     )
     return BulkAlbedoTemporal{FT}(data_info)
 end

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -105,8 +105,7 @@ end
     regrid_dir_temporal = joinpath(pkgdir(ClimaLSM), "test", "temporal")
     t_start = FT(0)
     domain = create_domain_2d(FT)
-    surface = domain.surface
-    space = surface.space
+    space = domain.surface.space
 
     input_file = cesm2_albedo_dataset_path()
     date_ref = to_datetime(NCDataset(input_file, "r") do ds
@@ -114,7 +113,7 @@ end
     end)
 
     albedo =
-        BulkAlbedoTemporal{FT}(regrid_dir_temporal, date_ref, t_start, surface)
+        BulkAlbedoTemporal{FT}(regrid_dir_temporal, date_ref, t_start, space)
     p = (; bucket = (; α_sfc = Fields.zeros(space)))
     surface_coords = Fields.coordinate_field(space)
 
@@ -218,7 +217,7 @@ end
         regrid_dir_temporal,
         date_ref,
         t_start,
-        domain.surface,
+        space,
     )
 
     Y = (; bucket = (; W = Fields.zeros(space)))
@@ -374,7 +373,7 @@ end
     input_file = bareground_albedo_dataset_path()
     date_ref = Dates.DateTime(1900, 1, 1)
     t_start = FT(0)
-    surface = nothing
+    space = nothing
     err = nothing
 
     try
@@ -382,7 +381,7 @@ end
             regrid_dirpath,
             date_ref,
             t_start,
-            surface,
+            space,
             input_file = input_file,
         )
     catch err
@@ -429,13 +428,13 @@ end
     orbital_data = Insolation.OrbitalData()
 
     for bucket_domain in bucket_domains
-        surface = bucket_domain.surface
+        space = bucket_domain.surface.space
         if bucket_domain isa LSMSphericalShellDomain
             albedo_model = BulkAlbedoTemporal{FT}(
                 regrid_dirpath,
                 date_ref,
                 t_start,
-                surface,
+                space,
             )
             # Radiation
             SW_d = (t) -> eltype(t)(0.0)
@@ -532,7 +531,7 @@ end
                         regrid_dirpath,
                         date_ref,
                         t_start,
-                        surface,
+                        space,
                     )
                 catch err
                 end

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -213,12 +213,8 @@ end
     end)
     t_start = FT(0)
 
-    albedo = BulkAlbedoTemporal{FT}(
-        regrid_dir_temporal,
-        date_ref,
-        t_start,
-        space,
-    )
+    albedo =
+        BulkAlbedoTemporal{FT}(regrid_dir_temporal, date_ref, t_start, space)
 
     Y = (; bucket = (; W = Fields.zeros(space)))
     p = (; bucket = (; α_sfc = Fields.zeros(space)))
@@ -373,23 +369,25 @@ end
     input_file = bareground_albedo_dataset_path()
     date_ref = Dates.DateTime(1900, 1, 1)
     t_start = FT(0)
-    space = nothing
-    err = nothing
+    domain = create_domain_2d(FT)
+    space = domain.surface.space
 
-    try
-        BulkAlbedoTemporal{FT}(
-            regrid_dirpath,
-            date_ref,
-            t_start,
-            space,
-            input_file = input_file,
-        )
-    catch err
+    let err = nothing
+        try
+            BulkAlbedoTemporal{FT}(
+                regrid_dirpath,
+                date_ref,
+                t_start,
+                space,
+                input_file = input_file,
+            )
+        catch err
+        end
+
+        @test err isa Exception
+        @test sprint(showerror, err) ==
+              "Using a temporal albedo map requires data with time dimension."
     end
-
-    @test err isa Exception
-    @test sprint(showerror, err) ==
-          "Using a temporal albedo map requires data with time dimension."
 
 end
 
@@ -430,12 +428,8 @@ end
     for bucket_domain in bucket_domains
         space = bucket_domain.surface.space
         if bucket_domain isa LSMSphericalShellDomain
-            albedo_model = BulkAlbedoTemporal{FT}(
-                regrid_dirpath,
-                date_ref,
-                t_start,
-                space,
-            )
+            albedo_model =
+                BulkAlbedoTemporal{FT}(regrid_dirpath, date_ref, t_start, space)
             # Radiation
             SW_d = (t) -> eltype(t)(0.0)
             LW_d = (t) -> eltype(t)(5.67e-8 * 280.0^4.0)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Closes #299 (see for more info)

As of August 21, the coupler is able to use BulkAlbedoTemporal in coupled runs with this change (https://github.com/CliMA/ClimaCoupler.jl/pull/394).

After merging this PR, we need to make a patch release of ClimaLSM.jl (v0.3.1).

## To-do
- [x] change constructor argument from surface (type `ClimaLSM.Domains.AbstractDomain`) to space (type `ClimaCore.Spaces.AbstractSpace`)
- [x] update constructor usage in tests


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
