### PR TITLE
type restriction on t

### DIFF
--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -80,16 +80,12 @@ end
 
 
 """
-      dss!(Y::ClimaCore.Fields.FieldVector, p::NamedTuple, t::FT)
+      dss!(Y::ClimaCore.Fields.FieldVector, p::NamedTuple, t)
 
 Computes the weighted direct stiffness summation and updates `Y` in place.
 In the case of a column domain, no dss operations are performed.
 """
-function dss!(
-    Y::ClimaCore.Fields.FieldVector{FT},
-    p::NamedTuple,
-    t::FT,
-) where {FT}
+function dss!(Y::ClimaCore.Fields.FieldVector, p::NamedTuple, t)
     for key in propertynames(Y)
         property = getproperty(Y, key)
         dss_helper!(property, axes(property), p)


### PR DESCRIPTION
## Purpose 
See issue https://github.com/CliMA/ClimaCoupler.jl/issues/396


## To-do
Figure out if we need to remove all instances where we assume t is FT, with FT Float32 or Float64, because it will be Float64 when using ClimaTimesteppers.


## Content



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
