### PR TITLE
Domain stretching

### DIFF
--- a/docs/tutorials/Usage/domain_tutorial.jl
+++ b/docs/tutorials/Usage/domain_tutorial.jl
@@ -16,7 +16,7 @@ system of differential equations, where at each coordinate point a value of
 `ρ`, `T`, `P`, and `u⃗` are solved for at each step. The choice of domain is a question "only"
 of geometry: you may be interested in a large eddy simulation (using a box domain), or
 in a global model (where you would need a spherical shell domain
-representing the atmosphere or ocean from some depth to a given height).
+representing the atmosphere or ocean from some depth to z_sfc = 0).
 
 For land surface
 models, each variable is not defined everywhere in space. For example,
@@ -55,7 +55,7 @@ There is a single key method which take a ClimaLSM domain as an argument.
 - [` coordinates(domain)`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.coordinates): under the hood, this function  uses
 the function space (domain.space) to create the coordinate field. This returns the coordinates as a ClimaCore.Fields.Field object.
 Depending on the domain, the returned coordinate field will have elements of different names and types. For example,
-the SphericalShell domain has coordinates of latitude, longitude, and height, while a Plane domain has coordinates
+the SphericalShell domain has coordinates of latitude, longitude, and depth, while a Plane domain has coordinates
 of x and y, and a Point domain only has a coordinate z_sfc.
 
 

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -425,8 +425,7 @@ Plots.plot!(
 Plots.plot(plt1, plt2, layout = (2, 1))
 Plots.savefig(joinpath(savedir, "stomatal_conductance.png"))
 
-# Current resolution is 3.333 cm per layer, our nodes are at the center of the
-# layers. The second layer is ~ 5cm
+# Current resolution has the first layer at 0.1 cm, the second at 5cm.
 plt1 = Plots.plot(size = (1500, 800))
 Plots.plot!(
     plt1,

--- a/experiments/integrated/ozark/ozark_domain.jl
+++ b/experiments/integrated/ozark/ozark_domain.jl
@@ -1,10 +1,16 @@
 # Domain setup
 # For soil column
-nelements = 60
+nelements = 10
 zmin = FT(-2)
 zmax = FT(0)
-land_domain =
-    LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelements)
+dz_bottom = FT(0.5)
+dz_top = FT(0.025)
+
+land_domain = LSMSingleColumnDomain(;
+    zlim = (zmin, zmax),
+    nelements = nelements,
+    dz_tuple = (dz_bottom, dz_top),
+)
 
 # Number of stem and leaf compartments. Leaf compartments are stacked on top of stem compartments
 n_stem = Int64(1)

--- a/experiments/integrated/ozark/ozark_simulation.jl
+++ b/experiments/integrated/ozark/ozark_simulation.jl
@@ -1,8 +1,9 @@
 t0 = FT(120 * 3600 * 24)# start mid year
 N_days = 120
 tf = t0 + FT(3600 * 24 * N_days)
-dt = FT(60)
-n = 60
+dt = FT(240)
+# Number of timesteps between saving output
+n = 15
 saveat = Array(t0:(n * dt):tf)
 timestepper = CTS.RK4()
 # Set up timestepper

--- a/test/shared_utilities/utilities.jl
+++ b/test/shared_utilities/utilities.jl
@@ -199,7 +199,7 @@ end
         )
         domain2 = ClimaLSM.Domains.SphericalShell(;
             radius = FT(2),
-            height = FT(1.0),
+            depth = FT(1.0),
             nelements = (10, 5),
             npolynomial = 3,
         )

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -46,7 +46,7 @@ function create_domain_2d(FT)
     np = 2
     return LSMSphericalShellDomain(;
         radius = rad,
-        height = h,
+        depth = h,
         nelements = ne,
         npolynomial = np,
     )
@@ -277,7 +277,7 @@ end
         LSMSingleColumnDomain(; zlim = (-100.0, 0.0), nelements = 10),
         LSMSphericalShellDomain(;
             radius = FT(100.0),
-            height = FT(3.5),
+            depth = FT(3.5),
             nelements = (2, 10),
             npolynomial = 2,
         ),
@@ -418,7 +418,7 @@ end
         LSMSingleColumnDomain(; zlim = (-100.0, 0.0), nelements = 10),
         LSMSphericalShellDomain(;
             radius = FT(100.0),
-            height = FT(3.5),
+            depth = FT(3.5),
             nelements = (2, 10),
             npolynomial = 2,
         ),

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -50,7 +50,7 @@ bucket_domains = [
     ),
     LSMSphericalShellDomain(;
         radius = 100.0,
-        height = 3.5,
+        depth = 3.5,
         nelements = (1, 10),
         npolynomial = 1,
     ),

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -48,7 +48,7 @@ bucket_domains = [
     ),
     LSMSphericalShellDomain(;
         radius = 100.0,
-        height = 3.5,
+        depth = 3.5,
         nelements = (1, 10),
         npolynomial = 1,
     ),

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -17,7 +17,7 @@ FT = Float64
 
     domain = SphericalShell(;
         radius = FT(1.0),
-        height = FT(1.0),
+        depth = FT(1.0),
         nelements = (1, 2),
         npolynomial = 3,
     )

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -356,7 +356,7 @@ end
 
     soil_domain = SphericalShell(;
         radius = FT(100.0),
-        height = FT(1.0),
+        depth = FT(1.0),
         nelements = (1, 30),
         npolynomial = 3,
     )
@@ -404,13 +404,13 @@ end
 
     ## vertical change should be zero except at the boundary, where it should be ±30.
     @test (mean(unique(parent(ClimaCore.level(dY.soil.ϑ_l, 1)))) - 30.0) / ν <
-          1e-11
+          1e-10
     @test (mean(unique(parent(ClimaCore.level(dY.soil.ϑ_l, 30)))) + 30.0) / ν <
-          1e-11
+          1e-10
     @test mean([
         maximum(abs.(unique(parent(ClimaCore.level(dY.soil.ϑ_l, k))))) for
         k in 2:29
-    ]) / ν < 1e-11
+    ]) / ν < 1e-10
 
     exp_tendency!(dY, Y, p, t0)
     ClimaLSM.dss!(dY, p, t0)
@@ -419,7 +419,7 @@ end
     @test mean([
         maximum(abs.(unique(parent(ClimaCore.level(dY.soil.ϑ_l, k))))) for
         k in 1:30
-    ]) / ν < 1e-11
+    ]) / ν < 1e-10
 
 end
 
@@ -438,7 +438,7 @@ end
     )
     shell = ClimaLSM.Domains.SphericalShell(;
         radius = FT(1),
-        height = FT(1),
+        depth = FT(1),
         nelements = (2, 3),
         npolynomial = 1,
     )


### PR DESCRIPTION
## Purpose 
Allows for variable domain stretching (finer resolution at the top of the domain compared to the bottom).

Whenever we need dz in source code, we obtain it using the function `get_Δz`, which uses ClimaCore to extract the `dz` values. so we do not make the assumption of uniform spacing in src code. (we do in some tests, but that seems OK if those tests use uniform spacing.)
## To-do
Future PRs: fix piracy and add the aqua test back in:
#277 #311 

## Content

1. Adds domain stretching to all domains with a z coordinate.
2. Renames height to depth for the SphericalShell domain
3. uses the stretched domain in the ozark example
4. adds unit tests.

Note that the user passes the target (dz_bottom, dz_top) desired, as a Tuple, or `nothing`, if no stretching is needed. We then create the ClimaCore.Meshes.GeneralizedExponentialStretching object in the domain constructor appropriately. Instead, the user could pass the stretching object itself, and the default could be `ClimaCore.Meshes.Uniform`. In a way this is nicer (it's not prescribed that they use Uniform or GeneralizedExponentialStretching, gives them all the options that ClimaCore develops in the future, no `if` statement in the constructor), but I felt this might be more confusing than supplying the target layer widths at the top and bottom. Happy to change if anyone feels strongly!


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
