### PR TITLE
Remove PointSpace method

### DIFF
--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -4,10 +4,6 @@ using DocStringExtensions
 
 using ClimaCore
 import ClimaCore: Fields, Spaces
-# Temporary fix
-import ClimaComms
-ClimaCore.Spaces.PointSpace(x) =
-    ClimaCore.Spaces.PointSpace(ClimaComms.SingletonCommsContext(), x)
 
 include("shared_utilities/Parameters.jl")
 import .Parameters as LSMP

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -2,6 +2,7 @@
 ### the models.jl code as well. But LSM domains will live in ClimaLSM.
 module Domains
 using ClimaCore
+using ClimaComms
 using IntervalSets
 using DocStringExtensions
 
@@ -40,12 +41,25 @@ struct Point{FT, S} <: AbstractDomain{FT}
 end
 
 """
-    Point(;z_sfc::FT) where {FT}
+    Point(;z_sfc::FT,
+           comms = ClimaComms.SingletonCommsContext()
+          ) where {FT}
+
 Constructor for the `Point` domain using keyword arguments.
+
+All other ClimaLSM domains rely on default comms set internally
+by ClimaCore. However, the Point space is unique in this context,
+and does not have the same default defined in ClimaCore. 
+Because of this, we set the default here
+in ClimaLSM. In long term, we will repeat the same for all ClimaLSM domains
+and not rely on any internal defaults set in ClimaCore.
 """
-function Point(; z_sfc::FT) where {FT}
+function Point(;
+    z_sfc::FT,
+    comms = ClimaComms.SingletonCommsContext(),
+) where {FT}
     coord = ClimaCore.Geometry.ZPoint(z_sfc)
-    space = ClimaCore.Spaces.PointSpace(coord)
+    space = ClimaCore.Spaces.PointSpace(comms, coord)
     return Point{FT, typeof(space)}(z_sfc, space)
 end
 


### PR DESCRIPTION
## Purpose 
Remove PointSpace method which sets the default comms to the SingletonContext; instead define it with a default kwarg to out Point() constructor.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
