### PR TITLE
edited docs and experiments to use set_initial_aux_state

### DIFF
--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -286,7 +286,7 @@ Y.bucket.W .= FT(0.05);
 Y.bucket.Ws .= FT(0.0);
 Y.bucket.σS .= FT(0.08);
 
-# We also initialize the auxiliary state here:
+# We also set the initial conditions of the auxiliary state here:
 set_initial_aux_state! = make_set_initial_aux_state(model);
 set_initial_aux_state!(p, Y, t0);
 

--- a/docs/tutorials/Canopy/soil_canopy_tutorial.jl
+++ b/docs/tutorials/Canopy/soil_canopy_tutorial.jl
@@ -355,7 +355,7 @@ for i in 1:2
         augmented_liquid_fraction.(plant_ν, S_l_ini[i])
 end;
 
-# Now initialize the auxiliary variables for the combined soil and plant model.
+# Now set the initial conditions for the auxiliary variables for the combined soil and plant model.
 
 t0 = FT(0)
 set_initial_aux_state! = make_set_initial_aux_state(land)

--- a/docs/tutorials/Soil/freezing_front.jl
+++ b/docs/tutorials/Soil/freezing_front.jl
@@ -200,14 +200,18 @@ end
 
 init_soil!(Y, coords.z, soil.parameters);
 
-# Create the tendency function, and choose a timestep, integration timespan, etc:
-exp_tendency! = make_exp_tendency(soil)
+# We choose the initial and final simulation times:
 t0 = FT(0)
-dt = FT(60)
-tf = FT(3600 * 50)
+tf = FT(60 * 60 * 50);
 
-# Choose a timestepper and set up the ODE problem:
-timestepper = CTS.RK4();
+# We set the aux state corresponding to the initial conditions
+# of the state Y:
+set_initial_aux_state! = make_set_initial_aux_state(soil);
+set_initial_aux_state!(p, Y, t0);
+# Create the tendency function, and choose a timestep, and timestepper:
+exp_tendency! = make_exp_tendency(soil)
+dt = FT(60)
+timestepper = CTS.RK4()
 ode_algo = CTS.ExplicitAlgorithm(timestepper)
 prob = ODE.ODEProblem(
     CTS.ClimaODEFunction(T_exp! = exp_tendency!, dss! = ClimaLSM.dss!),

--- a/docs/tutorials/Soil/richards_equation.jl
+++ b/docs/tutorials/Soil/richards_equation.jl
@@ -153,11 +153,18 @@ coords |> propertynames
 # conditions.
 Y.soil.ϑ_l .= FT(0.494);
 
-# Next, we turn to timestepping. We choose the initial and final times, as well as a timestep.
+# We choose the initial and final simulation times:
+t0 = FT(0)
+tf = FT(60 * 60 * 24 * 36);
+
+# We set the aux state corresponding to the initial conditions
+# of the state Y:
+set_initial_aux_state! = make_set_initial_aux_state(soil);
+set_initial_aux_state!(p, Y, t0);
+
+# Next, we turn to timestepping. 
 # As usual, your timestep depends on the problem you are solving, the accuracy
 # of the solution required, and the timestepping algorithm you are using.
-t0 = FT(0)
-tf = FT(60 * 60 * 24 * 36)
 dt = FT(1e3);
 
 # Now, we choose the timestepping algorithm we want to use.

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -112,6 +112,7 @@ model = LandSoilBiogeochemistry{FT}(;
 )
 
 Y, p, coords = initialize(model)
+set_initial_aux_state! = make_set_initial_aux_state(model);
 
 function init_soil!(Y, z, params)
     ν = params.ν
@@ -136,9 +137,7 @@ z = coords.subsurface.z
 init_soil!(Y, z, model.soil.parameters)
 init_co2!(Y, z)
 t0 = FT(0.0)
-update_aux! = make_update_aux(model)
-update_aux!(p, Y, t0)
-
+set_initial_aux_state!(p, Y, t0);
 Soil_bio_exp_tendency! = make_exp_tendency(model)
 
 tf = FT(10000)

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -140,14 +140,17 @@ function init_soil!(Y, z, params)
         Soil.volumetric_internal_energy.(FT(0), ρc_s, T, Ref(params))
 end
 
-t = FT(0)
+init_soil!(Y, cds.z, soil.parameters)
+
 t0 = FT(0)
 tf = FT(24 * 3600 * 15)
+# We also set the initial conditions of the auxiliary state here:
+set_initial_aux_state! = make_set_initial_aux_state(soil);
+set_initial_aux_state!(p, Y, t0);
+
+# Timestepping:
 dt = FT(1)
-
-init_soil!(Y, cds.z, soil.parameters)
 soil_exp_tendency! = make_exp_tendency(soil)
-
 timestepper = CTS.RK4()
 ode_algo = CTS.ExplicitAlgorithm(timestepper)
 

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -44,6 +44,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         boundary_conditions = boundary_states,
         sources = sources,
     )
+    set_initial_aux_state! = make_set_initial_aux_state(soil)
 
     Y, p, coords = initialize(soil)
 
@@ -54,6 +55,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     update_jacobian! = ClimaLSM.make_update_jacobian(soil)
 
     t0 = FT(0)
+    set_initial_aux_state!(p, Y, t0)
     tf = FT(1e6)
     dt = FT(1e3)
 
@@ -138,6 +140,7 @@ end
     )
 
     Y, p, coords = initialize(soil)
+    set_initial_aux_state! = make_set_initial_aux_state(soil)
 
     # specify ICs
     Y.soil.ϑ_l .= FT(0.1)
@@ -146,6 +149,7 @@ end
     update_jacobian! = ClimaLSM.make_update_jacobian(soil)
 
     t0 = FT(0)
+    set_initial_aux_state!(p, Y, t0)
     tf = FT(60 * 60 * 0.8)
     dt = FT(1)
     # Note, we can use a bigger step and still conserve mass.

--- a/experiments/standalone/Soil/water_conservation.jl
+++ b/experiments/standalone/Soil/water_conservation.jl
@@ -86,6 +86,7 @@ soil = Soil.RichardsModel{FT}(;
 )
 
 exp_tendency! = make_exp_tendency(soil)
+set_initial_aux_state! = make_set_initial_aux_state(soil);
 imp_tendency! = make_imp_tendency(soil)
 update_jacobian! = make_update_jacobian(soil)
 
@@ -96,6 +97,7 @@ for i in eachindex(dts)
 
     Y, p, coords = initialize(soil)
     @. Y.soil.ϑ_l = FT(0.24)
+    set_initial_aux_state!(p, Y, FT(0.0))
 
     jac_kwargs =
         (; jac_prototype = RichardsTridiagonalW(Y), Wfact = update_jacobian!)
@@ -186,6 +188,7 @@ soil_dirichlet = Soil.RichardsModel{FT}(;
 )
 
 exp_tendency! = make_exp_tendency(soil_dirichlet)
+set_initial_aux_state! = make_set_initial_aux_state(soil_dirichlet);
 imp_tendency! = make_imp_tendency(soil_dirichlet)
 update_jacobian! = make_update_jacobian(soil_dirichlet)
 update_aux! = make_update_aux(soil_dirichlet)
@@ -197,6 +200,7 @@ for i in eachindex(dts)
 
     Y, p, coords = initialize(soil_dirichlet)
     @. Y.soil.ϑ_l = FT(0.24)
+    set_initial_aux_state!(p, Y, FT(0.0))
 
     jac_kwargs =
         (; jac_prototype = RichardsTridiagonalW(Y), Wfact = update_jacobian!)

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -89,6 +89,10 @@ using ClimaLSM.Pond
     exp_tendency! = make_exp_tendency(land)
     t = FT(0)
     dt = FT(1)
+    # set aux state values to those corresponding with Y(t=0)
+    set_initial_aux_state! = make_set_initial_aux_state(land)
+    set_initial_aux_state!(p, Y, t)
+    # integrate
     for step in 1:10
         exp_tendency!(dY, Y, p, t)
         t = t + dt

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -116,8 +116,8 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     init_soil!(Y, z, model.soil.parameters)
     init_co2!(Y, C)
     t0 = FT(0.0)
-    update_aux! = make_update_aux(model)
-    update_aux!(p, Y, t0)
+    set_initial_aux_state! = make_set_initial_aux_state(model)
+    set_initial_aux_state!(p, Y, t0)
 
     @test p.soil.T ≈ Soil.Biogeochemistry.soil_temperature(
         model.soilco2.driver.met,

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -50,6 +50,9 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
         Y, p, coords = initialize(soil)
         Y.soil.ϑ_l .= FT(0.24)
+        # We do not set the initial aux state here because
+        # we want to test that it is updated correctly in
+        # the jacobian correctly.
         W = RichardsTridiagonalW(Y)
         Wfact! = make_tendency_jacobian(soil)
         dtγ = FT(1.0)
@@ -151,6 +154,9 @@ end
 
         Y, p, coords = initialize(soil)
         Y.soil.ϑ_l .= FT(0.24)
+        # We do not set the initial aux state here because
+        # we want to test that it is updated correctly in
+        # the jacobian correctly.
         W = RichardsTridiagonalW(Y)
         Wfact! = make_tendency_jacobian(soil)
         dtγ = FT(1.0)

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -45,6 +45,9 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     dY = similar(Y)
     exp_tendency! = make_exp_tendency(model)
     t = FT(1)
+    Y.soilco2.C .= FT(4)
+    set_initial_aux_state! = make_set_initial_aux_state(model)
+    set_initial_aux_state!(p, Y, t)
     exp_tendency!(dY, Y, p, t)
     @test dY.soilco2.C ≈ p.soilco2.Sm
 end
@@ -84,6 +87,8 @@ end
     exp_tendency! = make_exp_tendency(model)
     t = FT(1)
     Y.soilco2.C .= FT(C)
+    set_initial_aux_state! = make_set_initial_aux_state(model)
+    set_initial_aux_state!(p, Y, t)
     exp_tendency!(dY, Y, p, t)
     @test sum(dY.soilco2.C) ≈ FT(0.0)
 end

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -131,8 +131,8 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
         t = FT(0)
         init_soil!(Y, coords.z, model.parameters)
-        update_aux! = ClimaLSM.make_update_aux(model)
-        update_aux!(p, Y, t)
+        set_initial_aux_state! = make_set_initial_aux_state(model)
+        set_initial_aux_state!(p, Y, t)
 
 
         face_space = ClimaLSM.Domains.obtain_face_space(model.domain.space)

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -76,6 +76,8 @@ FT = Float64
     dY = similar(Y)
 
     t0 = FT(0.0)
+    set_initial_aux_state! = make_set_initial_aux_state(soil)
+    set_initial_aux_state!(p, Y, t0)
     imp_tendency! = make_imp_tendency(soil)
     exp_tendency! = make_exp_tendency(soil)
     imp_tendency!(dY, Y, p, t0)
@@ -322,6 +324,8 @@ end
 
 
     t0 = FT(0.0)
+    set_initial_aux_state! = make_set_initial_aux_state(soil)
+    set_initial_aux_state!(p, Y, t0)
     imp_tendency! = make_imp_tendency(soil)
     exp_tendency! = make_exp_tendency(soil)
     dY = similar(Y)
@@ -397,6 +401,8 @@ end
     init_soil!(Y, coords.z, soil.parameters)
 
     t0 = FT(0)
+    set_initial_aux_state! = make_set_initial_aux_state(soil)
+    set_initial_aux_state!(p, Y, t0)
     imp_tendency! = make_imp_tendency(soil)
     exp_tendency! = make_exp_tendency(soil)
     dY = similar(Y)

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -171,6 +171,8 @@ end
     init_soil!(Y, coords.z, soil.parameters)
 
     t0 = FT(0)
+    set_initial_aux_state! = make_set_initial_aux_state(soil)
+    set_initial_aux_state!(p, Y, t0)
     dY = similar(Y)
 
     imp_tendency! = make_imp_tendency(soil)
@@ -263,6 +265,8 @@ end
 
     t0 = FT(0)
     init_soil_heat!(Y, coords.z, soil_heat_on.parameters)
+    set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
+    set_initial_aux_state!(p, Y, t0)
     exp_tendency! = make_exp_tendency(soil_heat_on)
     dY = similar(Y)
     exp_tendency!(dY, Y, p, t0)
@@ -320,6 +324,8 @@ end
 
     t0 = FT(0)
     init_soil_water!(Y, coords.z, soil_water_on.parameters)
+    set_initial_aux_state! = make_set_initial_aux_state(soil_water_on)
+    set_initial_aux_state!(p, Y, t0)
     exp_tendency! = make_exp_tendency(soil_water_on)
     dY = similar(Y)
     exp_tendency!(dY, Y, p, t0)
@@ -463,6 +469,8 @@ end
 
     t0 = FT(0)
     init_soil_off!(Y, coords.z, soil_both_off.parameters)
+    set_initial_aux_state! = make_set_initial_aux_state(soil_both_off)
+    set_initial_aux_state!(p, Y, t0)
     exp_tendency! = make_exp_tendency(soil_both_off)
     dY = similar(Y)
     exp_tendency!(dY, Y, p, t0)
@@ -512,6 +520,9 @@ end
 
     t0 = FT(0)
     init_soil_on!(Y, coords.z, soil_both_on.parameters)
+    set_initial_aux_state! = make_set_initial_aux_state(soil_both_on)
+    set_initial_aux_state!(p, Y, t0)
+
     exp_tendency! = make_exp_tendency(soil_both_on)
     dY = similar(Y)
     exp_tendency!(dY, Y, p, t0)
@@ -649,6 +660,8 @@ end
     end
 
     init_soil_heat!(Y, coords.z, soil_heat_on.parameters)
+    set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
+    set_initial_aux_state!(p, Y, FT(0.0))
     dY = similar(Y)
     dY .= FT(0.0)
     source!(dY, sources[1], Y, p, soil_heat_on)

--- a/test/standalone/SurfaceWater/pond_test.jl
+++ b/test/standalone/SurfaceWater/pond_test.jl
@@ -29,6 +29,9 @@ FT = Float64
     t0 = FT(0)
     tf = FT(200)
     dt = FT(1)
+    set_initial_aux_state! = make_set_initial_aux_state(pond_model)
+    set_initial_aux_state!(p, Y, t0)
+
 
     function expected_pond_height(t)
         if t < 20


### PR DESCRIPTION
## Purpose 
Make using `set_initial_aux_state!` the default in all docs, experiments, and relevant tests. Although this is not required for all models (the aux state is set via update aux in the first timestep before computing tendencies), it is required for parameters which are functions of space and stored in aux that are set 1x but never updated - i.e. for constant parameters.



## Content
after setting the IC for Y and setting t0, set the initial aux state.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
