### PR TITLE
Canopy temperature and emissivity

### DIFF
--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -16,6 +16,7 @@ apis = [
             "Plant Hydraulics" => "APIs/canopy/PlantHydraulics.md",
             "Canopy Photosynthesis" => "APIs/canopy/Photosynthesis.md",
             "Canopy RT" => "APIs/canopy/RadiativeTransfer.md",
+            "Canopy Energy" => "APIs/canopy/CanopyEnergy.md",
             "Canopy Stomatal Conductance" => "APIs/canopy/StomatalConductance.md",
         ],
         "Surface Water Models" => "APIs/SurfaceWater.md",

--- a/docs/src/APIs/canopy/CanopyEnergy.md
+++ b/docs/src/APIs/canopy/CanopyEnergy.md
@@ -1,0 +1,18 @@
+# Canopy Energy Model
+
+```@meta
+CurrentModule = ClimaLSM.Canopy
+```
+
+## Methods
+
+```@docs
+ClimaLSM.Canopy.canopy_temperature
+```
+
+## Types
+
+```@docs
+ClimaLSM.Canopy.AbstractCanopyEnergyModel
+ClimaLSM.Canopy.PrescribedCanopyTempModel
+```

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -339,8 +339,13 @@ Plots.savefig(joinpath(savedir, "water_conservation.png"))
 # Turbulent fluxes
 LHF = [parent(sv.saveval[k].soil_lhf)[1] for k in 2:length(sol.t)]
 SHF = [parent(sv.saveval[k].soil_shf)[1] for k in 2:length(sol.t)]
-# Radiation
-soil_Rn = [parent(sv.saveval[k].soil_Rn)[1] for k in 2:length(sol.t)]
+# Radiation is computed in LW and SW components
+# with positive numbers indicating the soil gaining energy.
+soil_Rn =
+    -1 .* [
+        parent(sv.saveval[k].soil_LW_n .+ sv.saveval[k].soil_SW_n)[1] for
+        k in 2:length(sol.t)
+    ]
 # Root sink term: a positive root extraction is a sink term for soil; add minus sign
 root_sink_energy = [
     sum(

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -82,6 +82,7 @@ radiative_transfer_args = (;
         α_NIR_leaf = α_NIR_leaf,
         τ_NIR_leaf = τ_NIR_leaf,
         n_layers = n_layers,
+        ϵ_canopy = ϵ_canopy,
     )
 )
 # Set up conductance
@@ -266,58 +267,62 @@ Plots.plot!(plt2, seconds ./ 3600 ./ 24, GPP .* 1e6, label = "", lalpha = 0.3)
 Plots.plot(plt1, plt2, layout = (2, 1))
 Plots.savefig(joinpath(savedir, "GPP.png"))
 
-# SW_IN
-
+# SW_OUT
+SW_out_model = [parent(sv.saveval[k].SW_out)[1] for k in 1:length(sv.saveval)]
 plt1 = Plots.plot(size = (1500, 400))
 Plots.plot!(
     plt1,
     seconds ./ 3600 ./ 24,
-    FT.(SW_IN),
+    FT.(SW_OUT),
     label = "Data",
-    title = " SWd (W/m^2)",
+    title = "Outgoing SW (W/m^2)",
     xlim = [minimum(daily), maximum(daily)],
 )
+
+Plots.plot!(plt1, daily, SW_out_model, label = "Model")
 
 plt2 = Plots.plot(size = (1500, 400))
 Plots.plot!(
     plt2,
     seconds ./ 3600 ./ 24,
-    FT.(SW_IN),
+    FT.(SW_OUT),
     label = "",
     xlim = [minimum(daily), minimum(daily) + 30],
     margin = 10Plots.mm,
     xlabel = "Day of year",
 )
+Plots.plot!(plt2, daily, SW_out_model, label = "Model")
 Plots.plot(plt1, plt2, layout = (2, 1))
+Plots.savefig(joinpath(savedir, "SW.png"))
 
-Plots.savefig(joinpath(savedir, "SW_IN.png"))
 
-# VPD
-
+# LW_OUT
+LW_out_model = [parent(sv.saveval[k].LW_out)[1] for k in 1:length(sv.saveval)]
 plt1 = Plots.plot(size = (1500, 400))
 Plots.plot!(
     plt1,
     seconds ./ 3600 ./ 24,
-    FT.(VPD),
+    FT.(LW_OUT),
     label = "Data",
-    title = "VPD (Pa)",
+    title = "Outgoing LW (W/m^2)",
     xlim = [minimum(daily), maximum(daily)],
 )
+
+Plots.plot!(plt1, daily, LW_out_model, label = "Model")
 
 plt2 = Plots.plot(size = (1500, 400))
 Plots.plot!(
     plt2,
     seconds ./ 3600 ./ 24,
-    FT.(VPD),
+    FT.(LW_OUT),
     label = "",
     xlim = [minimum(daily), minimum(daily) + 30],
-    ylim = [0, 2000],
     margin = 10Plots.mm,
     xlabel = "Day of year",
 )
+Plots.plot!(plt2, daily, LW_out_model, label = "Model")
 Plots.plot(plt1, plt2, layout = (2, 1))
-Plots.savefig(joinpath(savedir, "VPD.png"))
-
+Plots.savefig(joinpath(savedir, "LW.png"))
 
 
 T =

--- a/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
+++ b/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
@@ -10,6 +10,13 @@ function replace_missing_with_mean!(field, flag)
     return field
 end
 
+function replace_missing_with_mean_by_value!(field)
+    good_indices = .~(field .== -9999)
+    fill_value = mean(field[good_indices])
+    field[.~good_indices] .= fill_value
+    return field
+end
+
 # Fluxnet Ozark (CO2 and H2O fluxes and met drivers)
 # 2005 data extracted as follows:
 #af = ArtifactFile(
@@ -65,6 +72,9 @@ replace_missing_with_mean!(G, G_F)
 
 LW_OUT = driver_data[2:end, column_names .== "LW_OUT"]# This has missing data
 SW_OUT = driver_data[2:end, column_names .== "SW_OUT"]# This has missing data
+replace_missing_with_mean_by_value!(SW_OUT)
+replace_missing_with_mean_by_value!(LW_OUT)
+
 LOCAL_DATETIME = DateTime.(string.(driver_data[2:end, 1]), "yyyymmddHHMM")
 UTC_DATETIME = LOCAL_DATETIME .+ Dates.Hour(6)
 thermo_params = LSMP.thermodynamic_parameters(earth_param_set)

--- a/experiments/integrated/ozark/ozark_parameters.jl
+++ b/experiments/integrated/ozark/ozark_parameters.jl
@@ -25,8 +25,8 @@ soil_vg_α = FT(0.04) # inverse meters
 z_0m_soil = FT(0.1)
 z_0b_soil = FT(0.1)
 soil_ϵ = FT(0.98)
-soil_α_PAR = FT(0.3)
-soil_α_NIR = FT(0.5)
+soil_α_PAR = FT(0.2)
+soil_α_NIR = FT(0.2)
 
 # TwoStreamModel parameters
 Ω = FT(0.69)
@@ -39,6 +39,7 @@ ld = FT(0.5)
 τ_NIR_leaf = FT(0.25)
 n_layers = UInt64(20)
 diff_perc = FT(0.2)
+ϵ_canopy = FT(0.97)
 
 # Conductance Model
 g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.

--- a/experiments/integrated/ozark/ozark_simulation.jl
+++ b/experiments/integrated/ozark/ozark_simulation.jl
@@ -1,10 +1,11 @@
 t0 = FT(120 * 3600 * 24)# start mid year
 N_days = 120
+dt = FT(120)
 tf = t0 + FT(3600 * 24 * N_days)
-dt = FT(240)
 # Number of timesteps between saving output
-n = 15
-saveat = Array(t0:(n * dt):tf)
+n = 30
+t_spinup = t0 + FT(10 * 3600 * 24)
+saveat = Array(t_spinup:(n * dt):tf)
 timestepper = CTS.RK4()
 # Set up timestepper
 ode_algo = CTS.ExplicitAlgorithm(timestepper)

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -1,0 +1,29 @@
+export PrescribedCanopyTempModel, AbstractCanopyEnergyModel, canopy_temperature
+abstract type AbstractCanopyEnergyModel{FT} <: AbstractCanopyComponent{FT} end
+
+ClimaLSM.name(model::AbstractCanopyEnergyModel) = :energy
+
+"""
+    PrescribedCanopyTempModel{FT} <: AbstractCanopyEnergyModel{FT}
+
+A model for the energy of the canopy which assumes the canopy temperature
+is the same as the atmosphere temperature prescribed in the
+`PrescribedAtmos` struct. 
+
+No equation for the energy of the canopy is solved.
+"""
+struct PrescribedCanopyTempModel{FT} <: AbstractCanopyEnergyModel{FT} end
+
+ClimaLSM.auxiliary_vars(model::AbstractCanopyEnergyModel) = (:shf, :lhf)
+ClimaLSM.auxiliary_types(model::AbstractCanopyEnergyModel{FT}) where {FT} =
+    (FT, FT)
+
+"""
+    canopy_temperature(model::PrescribedCanopyTempModel, canopy, Y, p, t)
+
+Returns the canopy temperature under the `PrescribedCanopyTemp` model, 
+where the canopy temperature is assumed to be the same as the atmosphere
+temperature.
+"""
+canopy_temperature(model::PrescribedCanopyTempModel, canopy, Y, p, t) =
+    canopy.atmos.T(t)

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -18,6 +18,8 @@ struct BeerLambertParameters{FT <: AbstractFloat}
     α_PAR_leaf::FT
     "NIR leaf reflectance"
     α_NIR_leaf::FT
+    "Emissivity of the canopy"
+    ϵ_canopy::FT
     "Clumping index following Braghiere (2021) (unitless)"
     Ω::FT
     "Typical wavelength per PAR photon (m)"
@@ -31,17 +33,19 @@ end
         ld = FT(0.5),    
         α_PAR_leaf = FT(0.1),
         α_NIR_leaf = FT(0.4),
+        ϵ_canopy = FT(0.98),
         Ω = FT(1),
         λ_γ_PAR = FT(5e-7),
         λ_γ_NIR = FT(1.65e-6),
     ) where {FT}
 
 A constructor supplying default values for the BeerLambertParameters struct.
-    """
+        """
 function BeerLambertParameters{FT}(;
     ld = FT(0.5),
     α_PAR_leaf = FT(0.1),
     α_NIR_leaf = FT(0.4),
+    ϵ_canopy = FT(0.98),
     Ω = FT(1),
     λ_γ_PAR = FT(5e-7),
     λ_γ_NIR = FT(1.65e-6),
@@ -50,6 +54,7 @@ function BeerLambertParameters{FT}(;
         ld,
         α_PAR_leaf,
         α_NIR_leaf,
+        ϵ_canopy,
         Ω,
         λ_γ_PAR,
         λ_γ_NIR,
@@ -78,6 +83,8 @@ struct TwoStreamParameters{FT <: AbstractFloat}
     α_NIR_leaf::FT
     "NIR leaf element transmittance"
     τ_NIR_leaf::FT
+    "Emissivity of the canopy"
+    ϵ_canopy::FT
     "Clumping index following Braghiere (2021) (unitless)"
     Ω::FT
     "Typical wavelength per PAR photon (m)"
@@ -95,6 +102,7 @@ end
         τ_PAR_leaf = FT(0.2),
         α_NIR_leaf = FT(0.4),
         τ_NIR_leaf = FT(0.25),
+        ϵ_canopy = FT(0.98),
         Ω = FT(1),
         λ_γ_PAR = FT(5e-7),
         λ_γ_NIR = FT(1.65e-6),
@@ -103,13 +111,14 @@ end
     ) where {FT}
 
 A constructor supplying default values for the TwoStreamParameters struct.
-"""
+    """
 function TwoStreamParameters{FT}(;
     ld = FT(0.5),
     α_PAR_leaf = FT(0.3),
     τ_PAR_leaf = FT(0.2),
     α_NIR_leaf = FT(0.4),
     τ_NIR_leaf = FT(0.25),
+    ϵ_canopy = FT(0.98),
     Ω = FT(1),
     λ_γ_PAR = FT(5e-7),
     λ_γ_NIR = FT(1.65e-6),
@@ -121,6 +130,7 @@ function TwoStreamParameters{FT}(;
         τ_PAR_leaf,
         α_NIR_leaf,
         τ_NIR_leaf,
+        ϵ_canopy,
         Ω,
         λ_γ_PAR,
         λ_γ_NIR,
@@ -177,9 +187,17 @@ Base.broadcastable(RT::AbstractRadiationModel) = tuple(RT)
 
 ClimaLSM.name(model::AbstractRadiationModel) = :radiative_transfer
 ClimaLSM.auxiliary_vars(model::Union{BeerLambertModel, TwoStreamModel}) =
-    (:apar, :par, :anir, :nir)
+    (:apar, :par, :rpar, :tpar, :anir, :nir, :rnir, :tnir)
 ClimaLSM.auxiliary_types(
     model::Union{BeerLambertModel{FT}, TwoStreamModel{FT}},
-) where {FT} = (FT, FT, FT, FT)
-ClimaLSM.auxiliary_domain_names(::Union{BeerLambertModel, TwoStreamModel}) =
-    (:surface, :surface, :surface, :surface)
+) where {FT} = (FT, FT, FT, FT, FT, FT, FT, FT)
+ClimaLSM.auxiliary_domain_names(::Union{BeerLambertModel, TwoStreamModel}) = (
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+)

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -67,7 +67,7 @@ py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
 
         # Compute the predicted FAPAR using the ClimaLSM TwoStream implementation
         K = extinction_coeff(ld[i], θs[i])
-        FAPAR = plant_absorbed_pfd(
+        output = plant_absorbed_pfd(
             RT,
             FT(1),
             RT_params.α_PAR_leaf,
@@ -78,7 +78,7 @@ py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
             a_soil[i],
             PropDif[i],
         )
-
+        FAPAR = output.abs
         # Check that the predictions are app. equivalent to the Python model
         @test isapprox(py_FAPAR[i], FAPAR, atol = 0.005)
 


### PR DESCRIPTION
## Purpose 

We would like to implement an equation solving for T_canopy prognostically. This PR is a precursor to a PR adding in the energy balance equation. 

The purpose of this is to add canopy temperature and emissivity to the equations implemented for the soil/canopy model.  Any time a temperature is used now, it is labeled as T_air or T_canopy for clarity (along with P_air, q_air, etc).  At the same time, we have added emissivity to the canopy RT parameters and that is used now as well.

We have also introduced an Energy component to the canopy. The only supported energy model is one in which the canopy temperature is set to the air temperature.
Therefore, this PR formalizes what we were doing already but has made it more extensible. Future energy component models which compute T_canopy/q_canopy prognostically will need to set that variable correctly via a new method of `canopy_temperature`, etc.  But no code anywhere else would need to change (in terms of flux computations).

https://github.com/CliMA/ProjectManagement/issues/2

## To-do
Review use of T_air/P_air/q_air in update_aux! of Canopy.jl (in computing the Medlyn term, GPP, etc)
Review the equations for net radiative fluxes for the soil, canopy, and outgoing radiation in soil_canopy_model.jl


## Content
- add energy component to the CanopyModel
- sets the default energy component to the PrescribedCanopyTempModel
- creates a function `canopy_temperature` which returns the air temperature when used with a PrescribedCanopyTempModel
- explicitly uses T_canopy, T_air, e_canopy in equations for fluxes instead of implicitly assuming T_canopy=T_air and e_canopy = 1
- Adds e_canopy to the RT parameter struct.



Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
