### PR TITLE
Generalize variable domains

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -14,12 +14,10 @@ ClimaLSM.Domains.HybridBox
 ClimaLSM.Domains.Column
 ClimaLSM.Domains.Plane
 ClimaLSM.Domains.Point
-ClimaLSM.Domains.LSMSingleColumnDomain
-ClimaLSM.Domains.LSMMultiColumnDomain
-ClimaLSM.Domains.LSMSphericalShellDomain
 ClimaLSM.Domains.coordinates
 ClimaLSM.Domains.obtain_face_space
 ClimaLSM.Domains.obtain_surface_space
+ClimaLSM.Domains.obtain_surface_domain
 ClimaLSM.Domains.top_center_to_surface
 ```
 
@@ -37,8 +35,10 @@ ClimaLSM.make_update_aux
 ClimaLSM.make_set_initial_aux_state
 ClimaLSM.prognostic_vars
 ClimaLSM.prognostic_types
+ClimaLSM.prognostic_domain_names
 ClimaLSM.auxiliary_vars
 ClimaLSM.auxiliary_types
+ClimaLSM.auxiliary_domain_names
 ClimaLSM.initialize_prognostic
 ClimaLSM.initialize_auxiliary
 ClimaLSM.initialize

--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -137,7 +137,7 @@ using Insolation
 # will need access to.
 
 using ClimaLSM.Bucket: BucketModel, BucketModelParameters, BulkAlbedoFunction
-using ClimaLSM.Domains: coordinates, LSMSingleColumnDomain
+using ClimaLSM.Domains: coordinates, Column
 using ClimaLSM:
     initialize,
     make_update_aux,
@@ -205,11 +205,10 @@ bucket_parameters = BucketModelParameters(
 # resolution as the atmosphere, the bucket horizontal resolution would match the
 # horizontal resolution at the lowest level of the atmosphere model. In general, however, the two
 # resolutions do not need to match. Here we just set up something
-# simple - an LSMSingleColumnDomain, consisting of a single column.
+# simple - a Column.
 
 soil_depth = FT(3.5);
-bucket_domain =
-    LSMSingleColumnDomain(; zlim = (-soil_depth, 0.0), nelements = 10);
+bucket_domain = Column(; zlim = (-soil_depth, 0.0), nelements = 10);
 
 
 # The PrescribedAtmosphere and PrescribedRadiation need to take in a reference

--- a/docs/tutorials/Canopy/soil_canopy_tutorial.jl
+++ b/docs/tutorials/Canopy/soil_canopy_tutorial.jl
@@ -44,7 +44,7 @@ using ClimaCore
 import CLIMAParameters as CP
 import ClimaTimeSteppers as CTS
 using ClimaLSM
-using ClimaLSM.Domains: LSMSingleColumnDomain
+using ClimaLSM.Domains: Column, obtain_surface_domain
 using ClimaLSM.Soil
 using ClimaLSM.Canopy
 using ClimaLSM.Canopy.PlantHydraulics
@@ -86,8 +86,7 @@ include(
 nelements = 10
 zmin = FT(-2)
 zmax = FT(0)
-land_domain =
-    LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelements);
+land_domain = Column(; zlim = (zmin, zmax), nelements = nelements);
 
 # For our soil model, we will choose the
 # [`EnergyHydrology`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Soil/#Soil-Models-2) 
@@ -140,7 +139,7 @@ soil_ϵ = FT(0.98)
 soil_α_PAR = FT(0.2)
 soil_α_NIR = FT(0.4)
 
-soil_domain = land_domain.subsurface
+soil_domain = land_domain
 soil_ps = Soil.EnergyHydrologyParameters{FT}(;
     κ_dry = κ_dry,
     κ_sat_frozen = κ_sat_frozen,
@@ -297,8 +296,8 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     z0_b,
     earth_param_set,
 )
-
-canopy_model_args = (; parameters = shared_params, domain = land_domain.surface);
+canopy_domain = obtain_surface_domain(land_domain)
+canopy_model_args = (; parameters = shared_params, domain = canopy_domain);
 
 # We may now instantiate the integrated plant and soil model. In this example, 
 # we will compute transpiration diagnostically, and work with prescribed 

--- a/docs/tutorials/Soil/freezing_front.jl
+++ b/docs/tutorials/Soil/freezing_front.jl
@@ -198,7 +198,7 @@ function init_soil!(Ysoil, z, params)
         Soil.volumetric_internal_energy.(FT(0.0), ρc_s, T, Ref(params))
 end
 
-init_soil!(Y, coords.z, soil.parameters);
+init_soil!(Y, coords.subsurface.z, soil.parameters);
 
 # We choose the initial and final simulation times:
 t0 = FT(0)
@@ -242,7 +242,7 @@ mask_12h = hours .== 12
 mask_24h = hours .== 24
 mask_50h = hours .== 50;
 
-z = parent(coords.z)[:];
+z = parent(coords.subsurface.z)[:];
 plot1 = plot(
     ylabel = "Soil depth (m)",
     xlabel = "",

--- a/docs/tutorials/Soil/richards_equation.jl
+++ b/docs/tutorials/Soil/richards_equation.jl
@@ -217,7 +217,7 @@ sol = SciMLBase.solve(prob, ode_algo; dt = dt, adaptive = false);
 
 t = sol.t ./ (60 * 60 * 24);
 ϑ_l = [parent(sol.u[k].soil.ϑ_l) for k in 1:length(t)]
-z = parent(coords.z)
+z = parent(coords.subsurface.z)
 plot(
     ϑ_l[1],
     z,

--- a/docs/tutorials/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/Soil/soil_energy_hydrology.jl
@@ -241,7 +241,7 @@ function init_soil!(Y, z, params)
         Soil.volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T, Ref(params))
 end
 
-init_soil!(Y, coords.z, soil.parameters);
+init_soil!(Y, coords.subsurface.z, soil.parameters);
 
 # We choose the initial and final simulation times:
 t0 = FT(0)
@@ -281,7 +281,7 @@ cb = ClimaLSM.NonInterpSavingCallback(saved_values, saveat);
 sol = SciMLBase.solve(prob, ode_algo; dt = dt, saveat = saveat, callback = cb);
 
 # Extract output
-z = parent(coords.z)
+z = parent(coords.subsurface.z)
 t = parent(sol.t)
 ϑ_l = [parent(sol.u[k].soil.ϑ_l) for k in 1:length(t)]
 T = [parent(saved_values.saveval[k].soil.T) for k in 1:length(t)];

--- a/docs/tutorials/Usage/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/Usage/LSM_single_column_tutorial.jl
@@ -36,7 +36,7 @@
 
 # First, let's load the required modules:
 using ClimaLSM
-using ClimaLSM.Domains: LSMSingleColumnDomain, Column
+using ClimaLSM.Domains: Column, obtain_surface_domain
 using ClimaLSM.Soil
 using ClimaLSM.Pond
 
@@ -246,22 +246,21 @@ pond_ode! = make_exp_tendency(pond_model);
 # - boundary conditions,
 # - sources in the soil equation, if any.
 
-# First, let's make our LSM domain, which now contains
+# First, let's make our  domain, which now contains
 # information about the subsurface domain and the surface domain. For
 # a single column, this means specifying the boundaries of the soil domain
 # and the number of elements.
-lsm_domain = LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelems);
-# The surface domain is again just a `Point` with
+lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
+# The surface domain is just a `Point` with
 # `z_sfc = zmax`.
-lsm_domain.surface
-# The subsurface domain is a column from zmin to zmax:
-lsm_domain.subsurface
+surface_domain = obtain_surface_domain(lsm_domain)
+# The subsurface domain is the column itself.
 
 # Let's now collect the needed arguments for the soil and pond
 # models:
 
-soil_args = (parameters = soil_ps, domain = lsm_domain.subsurface, sources = ());
-surface_water_args = (domain = lsm_domain.surface,);
+soil_args = (parameters = soil_ps, domain = lsm_domain, sources = ());
+surface_water_args = (domain = surface_domain,);
 # Atmospheric drivers don't "belong" to either component alone:
 land_args = (precip = precipitation,);
 land = LandHydrology{FT}(;

--- a/docs/tutorials/Usage/domain_tutorial.jl
+++ b/docs/tutorials/Usage/domain_tutorial.jl
@@ -26,37 +26,30 @@ Once we have discretized the land surface region into
 a set of points, the numerical problem is to advance a system of ODEs, where
 at each coordinate point a different subset of (`θ`, `S`, ...) are solved for.
 
-In other words, different prognostic variables in land surface models exist
+In other words, different variables in land surface models exist
 in different, overlapping, domains. We need to decide on the geometry of interest (e.g. single column
 vs a global simulation), but we also need to specify where each variable of the model is defined.
 
-ClimaLSM Domains were designed with this in mind. Following other Clima models, the domains are defined
+ClimaLSM Domains were designed with this in mind. The domains are defined
 so that
 1. the user can easily switch geometries, e.g. single column to global model,
 2. individual component models can be run by themselves, using a single domain,
-3. different model component domains can be combined into a single land model domain, since different land model components can be combined to run as a single land surface model.
+3. the same domains can be used to set up multi-component models (LSMs),
+4. different variables can exist on different parts of the domain.
 
 
 ## What is a ClimaLSM Domain?
 A domain represents a region of space. In ClimaLSM, domains are simply
 structs containing parameters that define these regions - for example an
 x-range and y-range that define a plane. In addition, ClimaLSM domains store
-the ClimaCore function space on the
-physical domain. When solving partial differential equations, the spatial
+the ClimaCore function spaces for the
+physical domain as a NamedTuple. When solving partial differential equations, the spatial
 discretization is tied to a set of basis functions you wish to use to represent the prognostic
 variable as a function of space. The nodal points - the locations in space where the variable
 is solved for - are arranged in `space` in a manner which depends on these basis functions.
-
- Note that this is only needed for domains of variables satisfying PDEs,
-but it is defined for all domains[^1].
-
-There is a single key method which take a ClimaLSM domain as an argument.
-
-- [` coordinates(domain)`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.coordinates): under the hood, this function  uses
-the function space (domain.space) to create the coordinate field. This returns the coordinates as a ClimaCore.Fields.Field object.
-Depending on the domain, the returned coordinate field will have elements of different names and types. For example,
-the SphericalShell domain has coordinates of latitude, longitude, and depth, while a Plane domain has coordinates
-of x and y, and a Point domain only has a coordinate z_sfc.
+Note that these spaces are only mathematically needed when your variables satisfy PDEs[^1],
+but that they still exist when your variables do not, because we are using the same 
+underlying infrastructure in both cases.
 
 
 ## Domain types
@@ -69,38 +62,49 @@ A variety of concrete domain types are supported:
 - 2D: [`Domains.Plane`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.Plane), [`Domains.SphericalSurface`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.SphericalSurface)
 - 3D: [`Domains.HybridBox`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.HybridBox), [`Domains.SphericalShell`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.SphericalShell).
 
-Single component models (soil, snow, vegetation, canopy airspace...) will be solved on
-a single domain. Which domain is appropriate depends on the model equations (PDE vs ODE) and
-on the configuration of interest (single column or 3d).
+As discussed above, our modeling requires that variables of a model can be defined on different subsets of the domain. Because of that, we define the concept of a surface domain, and a subsurface domain. Not all domains have a surface and subsurface; some only have surface domains, as shown in the Table below.
 
-Furthermore, these individual model domains are composed when building a multi-component
-Land System Model. In this case, the full LSM domain is split into regions:
-the subsurface and the surface[^2]. Different land model components are associated
-with these different regions - e.g. the soil model is a subsurface model, while vegetation
-is a surface model. The above domain types are then paired based on the desired LSM
-domain being modeled:
 
-| LSM Domain | Surface Domain | Subsurface Domain |
+|  Domain | Surface Domain | Subsurface Domain |
 | :---         |     :---:      |          ---: |
-| [LSMSingleColumnDomain](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.LSMSingleColumnDomain)   | Point    | Column    |
-| LSMCartesianBoxDomain    | Plane[^3]       | HybridBox      |
-| LSMSphericalShellDomain    | SphericalSurface[^3]       | SphericalShell      |
+| Column | Point    | Column    |
+| HybridBox    | Plane      | HybridBox      |
+| SphericalShell    | SphericalSurface      | SphericalShell      |
+
+
+There is a single key method which take a ClimaLSM domain as an argument.
+
+- [` coordinates(domain)`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.Domains.coordinates): under the hood, this function  uses
+the NamedTuple of function spaces (domain.space) to create the coordinate field for the surface and subsurface domains (as applicable), stored in a NamedTuple.
+Depending on the domain, the returned coordinate field will have elements of different names and types. For example,
+the SphericalShell domain has subsurface coordinates of latitude, longitude, and depth, while the surface coordinates
+are latitude and longitude. A Plane domain has coordinates
+of x and y (surface only), and a Point domain only has a coordinate z_sfc (surface only). Column domains have a surface coordinate of z_sfc,
+and subsurface coordinates of z.
 
 It is important to note that the horizontal domain used for the surface and subsurface
-domains are identical in LSM simulations. This ensures that we can use the same indexing
-of surface and subsurface domains and variables to correctly compute and
-apply boundary fluxes between different component models. Otherwise we would need
+domains are identical in all simulations. This ensures that we can use the same indexing
+of surface and subsurface domains and variables. Otherwise we would need
 to develop additional infrastructure in order to, for example, select the correct subsurface
 column corresponding to a particular surface location.
 
 
-
 ## How variable initialization depends on domains
-When a developer creates a model, they need to specify the symbols used for the prognostic variables,
+Single component models (soil, snow, vegetation, canopy...) must have an associated domain in order
+to solve the their equations.  Which domain is appropriate depends on the model equations and
+on the configuration of interest (single column or global, etc.). For example, the soil model is a
+vertically resolved model, so only domains with a vertical extent (Column, HybridBox, or SphericalShell)
+make sense to use. A single layer snow model does not require vertical resolution - and so the domains
+that make sense to use are a Point, Plane, or SphericalSurface.
+
+When a developer first defines a model, they need to specify the symbols used for the prognostic variables,
 via [`prognostic_vars`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.prognostic_vars),
 and
 the types of those variables,
  via [`prognostic_types`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.prognostic_types).
+
+They additionally need to define which subset of the domain the variables are defined on, using 
+[`prognostic_domain_names`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.prognostic_domain_names).
 
 The [`initialize`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.initialize)
 function (which calls both
@@ -110,9 +114,14 @@ creates the prognostic state vector `Y` (a ClimaCore.Fields.FieldVector). Each f
 the field vector corresponds to a prognostic variable (identified with the symbol specified). If the prognostic type for that variable
 is a float, the field will be a field of float values (a scalar field)[^4].
 
-How do domains tie into this? The field of prognostic variables corresponds in a 1-1 fashion with the coordinate field created from the
-domain. That is, if you coordinate field has points (x,y) in [(1,1), (1,2); (2,1), (2,2)], your prognostic variable field (for variable `θ`,
-for example) will be [θ11, θ12; θ21, θ22]. Your variable always has the same spatial resolution as the domain does.
+How do domains tie into this? The field of a prognostic variable corresponds in a 1-1 fashion with the coordinate field of the subset of the domain associated with that variable via `prognostic_domain_name`.  For example, the bucket model has a vertically resolved temperature `T`, but the bucket water content 
+`W` is not vertically resolved. If your domain is a Column, the subsurface coordinates may be [-4.5,-3.5,-2.5,-1.5, -0.5], and 
+the surface coordinate would be [-0.0]. Your prognostic variable field for `T` will be [T[-4.5], T[-3.5]; T[-2.5], T[-1.5], T[-0.5]], and for `W`  it will be [W[0.0],]. Your variable always has the same spatial resolution as the associated subset of the domain. 
+
+This functionality is not required for every standalone component model. For example, a single layer snow model
+will only have variables on the surface of the domain (which in this case, would be the entire Point, Plane, or 
+SphericalShell domain). The user still must define the prognostic_domain_names method. This functionality is required
+for most multi-component models.
 
 
 ## Future work
@@ -134,7 +143,5 @@ we then use IMEX (mixed explicit/implicit) methods.
 
 [^2]: a suprasurface region may also be necessary - for example if the canopy airspace model involves PDEs.
 
-[^3]: We are not sure yet if the surface domain should be associated with a 2d space or if it should be a 3d space but with only one point in the vertical. Both would result in the same number of surface coordinate points, but they would have different underlying representations. The latter may be helpful because we can use the `column` function in the exact same way to extract the same column from the surface and subsurface domains.  In that case, the surface domain would be a HybdridBox (with one vertical element) instead of a Plane, and a SphericalShell (with one vertical element) instead of a Spherical Surface. Regardless, the two domains will share the same instance of the horizontal domain.
-
-[^4]: We also will support having an array-like type of variable (perhaps an NTuple; this is TBD).  This is to be used for the multi-layer canopy model.
+[^3]: We also will support having an array-like type of variable.
 =#

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -8,7 +8,7 @@ using Dates
 using Insolation
 
 using ClimaLSM
-using ClimaLSM.Domains: LSMSingleColumnDomain
+using ClimaLSM.Domains: Column
 using ClimaLSM.Soil
 using ClimaLSM.Canopy
 using ClimaLSM.Canopy.PlantHydraulics
@@ -39,7 +39,7 @@ include(
 
 # Now we set up the model. For the soil model, we pick
 # a model type and model args:
-soil_domain = land_domain.subsurface
+soil_domain = land_domain
 soil_ps = Soil.EnergyHydrologyParameters{FT}(;
     κ_dry = κ_dry,
     κ_sat_frozen = κ_sat_frozen,
@@ -155,7 +155,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     earth_param_set,
 )
 
-canopy_model_args = (; parameters = shared_params, domain = land_domain.surface)
+canopy_model_args = (; parameters = shared_params, domain = canopy_domain)
 
 # Integrated plant hydraulics and soil model
 land_input = (atmos = atmos, radiation = radiation)

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -8,7 +8,7 @@ using Dates
 using Insolation
 
 using ClimaLSM
-using ClimaLSM.Domains: LSMSingleColumnDomain
+using ClimaLSM.Domains: Column
 using ClimaLSM.Soil
 using ClimaLSM.Canopy
 using ClimaLSM.Canopy.PlantHydraulics
@@ -36,7 +36,7 @@ include(
 
 # Now we set up the model. For the soil model, we pick
 # a model type and model args:
-soil_domain = land_domain.subsurface
+soil_domain = land_domain
 soil_ps = Soil.EnergyHydrologyParameters{FT}(;
     κ_dry = κ_dry,
     κ_sat_frozen = κ_sat_frozen,
@@ -152,7 +152,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     earth_param_set,
 )
 
-canopy_model_args = (; parameters = shared_params, domain = land_domain.surface)
+canopy_model_args = (; parameters = shared_params, domain = canopy_domain)
 
 # Integrated plant hydraulics and soil model
 land_input = (atmos = atmos, radiation = radiation)

--- a/experiments/integrated/ozark/ozark_domain.jl
+++ b/experiments/integrated/ozark/ozark_domain.jl
@@ -6,11 +6,12 @@ zmax = FT(0)
 dz_bottom = FT(0.5)
 dz_top = FT(0.025)
 
-land_domain = LSMSingleColumnDomain(;
+land_domain = Column(;
     zlim = (zmin, zmax),
     nelements = nelements,
     dz_tuple = (dz_bottom, dz_top),
 )
+canopy_domain = ClimaLSM.Domains.obtain_surface_domain(land_domain)
 
 # Number of stem and leaf compartments. Leaf compartments are stacked on top of stem compartments
 n_stem = Int64(1)

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -2,7 +2,7 @@ import SciMLBase
 import ClimaTimeSteppers as CTS
 using ClimaCore
 using ClimaLSM
-using ClimaLSM.Domains: LSMSingleColumnDomain
+using ClimaLSM.Domains: Column
 using ClimaLSM.Soil
 using ClimaLSM.Soil.Biogeochemistry
 using ClimaLSM.Soil.Biogeochemistry: MicrobeProduction
@@ -58,7 +58,7 @@ zmin = FT(-1)
 nelems = 20
 Δz = abs(zmax - zmin) / nelems
 
-lsm_domain = LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelems)
+lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
 
 top_flux_bc_w = Soil.FluxBC((p, t) -> eltype(t)(-0.00001))
 bot_flux_bc_w = Soil.FreeDrainage()
@@ -75,7 +75,7 @@ boundary_fluxes = (;
 soil_args = (;
     boundary_conditions = boundary_fluxes,
     sources = sources,
-    domain = lsm_domain.subsurface,
+    domain = lsm_domain,
     parameters = soil_ps,
 )
 
@@ -99,7 +99,7 @@ soil_drivers = Soil.Biogeochemistry.SoilDrivers(
 soilco2_args = (;
     boundary_conditions = co2_boundary_conditions,
     sources = co2_sources,
-    domain = lsm_domain.subsurface,
+    domain = lsm_domain,
     parameters = co2_parameters,
     drivers = soil_drivers,
 )

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -123,7 +123,7 @@ zmax = FT(0)
 zmin = FT(-1.0)
 nelems = 10
 soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
+z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
 
 soil = Soil.EnergyHydrology{FT}(;
     parameters = params,
@@ -144,7 +144,7 @@ function init_soil!(Y, z, params)
         Soil.volumetric_internal_energy.(FT(0), ρc_s, T, Ref(params))
 end
 
-init_soil!(Y, cds.z, soil.parameters)
+init_soil!(Y, z, soil.parameters)
 
 t0 = FT(0)
 tf = FT(24 * 3600 * 15)

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -29,7 +29,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     zmin = FT(-1.5)
     nelems = 150
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
+    z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
 
     top_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν - 1e-3))
     bot_flux_bc = FreeDrainage()
@@ -122,7 +122,7 @@ end
     zmin = FT(-1.5)
     nelems = 150
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
+    z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
 
     top_state_bc = MoistureStateBC((p, t) -> eltype(t)(0.267))
     bot_flux_bc = FreeDrainage()

--- a/experiments/standalone/Soil/water_conservation.jl
+++ b/experiments/standalone/Soil/water_conservation.jl
@@ -219,7 +219,7 @@ for i in eachindex(dts)
 
     # Calculate water mass balance over entire simulation
     # Convert Dirichlet BC to flux
-    z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
+    z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
     Δz_top, Δz_bottom = get_Δz(z)
 
     times = collect(t_start:dt:t_end)

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -112,7 +112,9 @@ function SoilCanopyModel{FT}(;
     (; atmos, radiation) = land_args
     # These should always be set by the constructor.
     Δz = minimum(
-        ClimaCore.Fields.Δz_field(ClimaLSM.coordinates(soil_args.domain)),
+        ClimaCore.Fields.Δz_field(
+            ClimaLSM.coordinates(soil_args.domain).subsurface,
+        ),
     )
     sources = (RootExtraction{FT}(), Soil.PhaseChange{FT}(Δz))
     # add heat BC
@@ -219,7 +221,10 @@ function make_interactions_update_aux(
     land::SoilCanopyModel{FT, SM, RM},
 ) where {FT, SM <: Soil.EnergyHydrology{FT}, RM <: Canopy.CanopyModel{FT}}
     function update_aux!(p, Y, t)
-        z = ClimaCore.Fields.coordinate_field(land.soil.domain.space).z
+        z =
+            ClimaCore.Fields.coordinate_field(
+                land.soil.domain.space.subsurface,
+            ).z
         (; conductivity_model) = land.canopy.hydraulics.parameters
         area_index = p.canopy.hydraulics.area_index
         @. p.root_extraction =

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -48,8 +48,9 @@ function add_dss_buffer_to_aux(
     p::NamedTuple,
     domain::Union{Domains.Plane, Domains.SphericalSurface},
 )
-    buffer =
-        ClimaCore.Spaces.create_dss_buffer(ClimaCore.Fields.zeros(domain.space))
+    buffer = ClimaCore.Spaces.create_dss_buffer(
+        ClimaCore.Fields.zeros(domain.space.surface),
+    )
     return merge(p, (; dss_buffer_2d = buffer))
 end
 
@@ -59,8 +60,8 @@ end
         domain::Union{Domains.HybridBox, Domains.SphericalShell},
     )
 
-Adds a 3d dss buffer corresponding to `domain.space` to `p` with the name `dss_buffer_3d`,
-appropriate for a 3D domain.
+Adds a 2d and 3d dss buffer corresponding to `domain.space` to `p` with the names
+`dss_buffer_3d`, and `dss_buffer_2d`.
 
 This buffer is added so that we preallocate memory for the dss step and do not allocate it
 at every timestep. We use a name which specifically denotes that
@@ -73,9 +74,13 @@ function add_dss_buffer_to_aux(
     p::NamedTuple,
     domain::Union{Domains.HybridBox, Domains.SphericalShell},
 )
-    buffer =
-        ClimaCore.Spaces.create_dss_buffer(ClimaCore.Fields.zeros(domain.space))
-    return merge(p, (; dss_buffer_3d = buffer))
+    buffer_2d = ClimaCore.Spaces.create_dss_buffer(
+        ClimaCore.Fields.zeros(domain.space.surface),
+    )
+    buffer_3d = ClimaCore.Spaces.create_dss_buffer(
+        ClimaCore.Fields.zeros(domain.space.subsurface),
+    )
+    return merge(p, (; dss_buffer_3d = buffer_3d, dss_buffer_2d = buffer_2d))
 end
 
 

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -14,9 +14,10 @@ import ClimaLSM:
     prognostic_vars,
     auxiliary_vars,
     name,
-    domain_name,
     prognostic_types,
     auxiliary_types,
+    prognostic_domain_names,
+    auxiliary_domain_names,
     TopBoundary,
     BottomBoundary,
     boundary_flux,
@@ -182,13 +183,13 @@ function SoilCO2Model{FT}(;
 end
 
 ClimaLSM.name(model::SoilCO2Model) = :soilco2
-ClimaLSM.domain_name(model::SoilCO2Model) = :subsurface
-
-
 ClimaLSM.prognostic_vars(::SoilCO2Model) = (:C,)
 ClimaLSM.prognostic_types(::SoilCO2Model{FT}) where {FT} = (FT,)
+ClimaLSM.prognostic_domain_names(::SoilCO2Model) = (:subsurface,)
+
 ClimaLSM.auxiliary_vars(::SoilCO2Model) = (:D, :Sm)
 ClimaLSM.auxiliary_types(::SoilCO2Model{FT}) where {FT} = (FT, FT)
+ClimaLSM.auxiliary_domain_names(::SoilCO2Model) = (:subsurface, :subsurface)
 
 
 """
@@ -203,7 +204,7 @@ This has been written so as to work with Differential Equations.jl.
 """
 function ClimaLSM.make_compute_exp_tendency(model::SoilCO2Model)
     function compute_exp_tendency!(dY, Y, p, t)
-        z = ClimaCore.Fields.coordinate_field(model.domain.space).z
+        z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
         Δz_top, Δz_bottom = get_Δz(z)
 
         top_flux_bc = boundary_flux(
@@ -381,7 +382,7 @@ This has been written so as to work with Differential Equations.jl.
 function ClimaLSM.make_update_aux(model::SoilCO2Model)
     function update_aux!(p, Y, t)
         params = model.parameters
-        z = ClimaCore.Fields.coordinate_field(model.domain.space).z
+        z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
         T_soil = soil_temperature(model.driver.met, p, Y, t, z)
         θ_l = soil_moisture(model.driver.met, p, Y, t, z)
         Csom = soil_SOM_C(model.driver.soc, p, Y, t, z)

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -73,8 +73,9 @@ import ClimaLSM:
     make_update_jacobian,
     prognostic_vars,
     auxiliary_vars,
+    prognostic_domain_names,
+    auxiliary_domain_names,
     name,
-    domain_name,
     prognostic_types,
     auxiliary_types,
     AbstractSource,
@@ -120,8 +121,6 @@ and a fully integrated soil heat and water model, with phase change.
 abstract type AbstractSoilModel{FT} <: ClimaLSM.AbstractImExModel{FT} end
 
 ClimaLSM.name(::AbstractSoilModel) = :soil
-ClimaLSM.domain_name(::AbstractSoilModel) = :subsurface
-
 """
    horizontal_components!(dY::ClimaCore.Fields.FieldVector,
                           domain::Column, _...)

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -450,7 +450,7 @@ function ClimaLSM.∂tendencyBC∂Y(
     t,
 )
     (; ν, hydrology_cm, S_s, θ_r) = model.parameters
-    fs = ClimaLSM.Domains.obtain_face_space(model.domain.space)
+    fs = ClimaLSM.Domains.obtain_face_space(model.domain.space.subsurface)
     face_len = ClimaCore.Utilities.PlusHalf(ClimaCore.Spaces.nlevels(fs) - 1)
     interpc2f_op = Operators.InterpolateC2F(
         bottom = Operators.Extrapolate(),

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -198,7 +198,7 @@ function ClimaLSM.make_compute_exp_tendency(
     model::EnergyHydrology{FT},
 ) where {FT}
     function compute_exp_tendency!(dY, Y, p, t)
-        z = ClimaCore.Fields.coordinate_field(model.domain.space).z
+        z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
         Δz_top, Δz_bottom = get_Δz(z)
 
         # Convert all boundary conditions to FluxBCs
@@ -322,6 +322,9 @@ A function which returns the types of the prognostic variables
 of `EnergyHydrology`.
 """
 ClimaLSM.prognostic_types(soil::EnergyHydrology{FT}) where {FT} = (FT, FT, FT)
+
+ClimaLSM.prognostic_domain_names(soil::EnergyHydrology) =
+    (:subsurface, :subsurface, :subsurface)
 """
     auxiliary_vars(soil::EnergyHydrology)
 
@@ -339,6 +342,8 @@ of `EnergyHydrology`.
 ClimaLSM.auxiliary_types(soil::EnergyHydrology{FT}) where {FT} =
     (FT, FT, FT, FT, FT)
 
+ClimaLSM.auxiliary_domain_names(soil::EnergyHydrology) =
+    (:subsurface, :subsurface, :subsurface, :subsurface, :subsurface)
 """
     make_update_aux(model::EnergyHydrology)
 
@@ -599,9 +604,10 @@ end
 Returns the surface height of the `EnergyHydrology` model.
 """
 function ClimaLSM.surface_height(model::EnergyHydrology{FT}, Y, p) where {FT}
-    face_space = ClimaLSM.Domains.obtain_face_space(model.domain.space)
+    face_space =
+        ClimaLSM.Domains.obtain_face_space(model.domain.space.subsurface)
     N = ClimaCore.Spaces.nlevels(face_space)
-    surface_space = ClimaLSM.Domains.obtain_surface_space(model.domain.space)
+    surface_space = model.domain.space.surface
     z_sfc = ClimaCore.Fields.Field(
         ClimaCore.Fields.field_values(
             ClimaCore.Fields.level(

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -109,7 +109,7 @@ with that value.
 """
 function ClimaLSM.make_compute_imp_tendency(model::RichardsModel)
     function compute_imp_tendency!(dY, Y, p, t)
-        z = ClimaCore.Fields.coordinate_field(model.domain.space).z
+        z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
         Δz_top, Δz_bottom = get_Δz(z)
 
         top_flux_bc = boundary_flux(
@@ -171,7 +171,7 @@ function ClimaLSM.make_compute_exp_tendency(model::Soil.RichardsModel)
     function compute_exp_tendency!(dY, Y, p, t::FT) where {FT}
         # set dY before updating it
         dY.soil.ϑ_l .= FT(0)
-        z = ClimaCore.Fields.coordinate_field(model.domain.space).z
+        z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
 
         horizontal_components!(
             dY,
@@ -229,6 +229,8 @@ of `RichardsModel`.
 """
 ClimaLSM.prognostic_vars(soil::RichardsModel) = (:ϑ_l,)
 ClimaLSM.prognostic_types(soil::RichardsModel{FT}) where {FT} = (FT,)
+ClimaLSM.prognostic_domain_names(soil::RichardsModel) = (:subsurface,)
+
 """
     auxiliary_vars(soil::RichardsModel)
 
@@ -242,6 +244,8 @@ auxiliary vector `p`. We did so in this case as a demonstration.
 """
 ClimaLSM.auxiliary_vars(soil::RichardsModel) = (:K, :ψ)
 ClimaLSM.auxiliary_types(soil::RichardsModel{FT}) where {FT} = (FT, FT)
+ClimaLSM.auxiliary_domain_names(soil::RichardsModel) =
+    (:subsurface, :subsurface)
 """
     make_update_aux(model::RichardsModel)
 

--- a/src/standalone/SurfaceWater/Pond.jl
+++ b/src/standalone/SurfaceWater/Pond.jl
@@ -10,7 +10,8 @@ import ClimaLSM:
     make_compute_exp_tendency,
     prognostic_vars,
     name,
-    prognostic_types
+    prognostic_types,
+    prognostic_domain_names
 using ClimaLSM.Domains
 export PondModel, PrescribedRunoff, surface_runoff
 
@@ -61,8 +62,8 @@ end
 
 ClimaLSM.prognostic_vars(model::PondModel) = (:η,)
 ClimaLSM.prognostic_types(model::PondModel{FT}) where {FT} = (FT,)
+ClimaLSM.prognostic_domain_names(model::PondModel) = (:surface,)
 ClimaLSM.name(::AbstractSurfaceWaterModel) = :surface_water
-ClimaLSM.domain_name(::AbstractSurfaceWaterModel) = :surface
 
 function ClimaLSM.make_compute_exp_tendency(model::PondModel)
     function compute_exp_tendency!(dY, Y, p, t)

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -9,11 +9,12 @@ import ..Parameters as LSMP
 import ClimaLSM:
     AbstractExpModel,
     name,
-    domain_name,
     prognostic_vars,
     prognostic_types,
     auxiliary_vars,
     auxiliary_types,
+    auxiliary_domain_names,
+    prognostic_domain_names,
     initialize_prognostic,
     initialize_auxiliary,
     make_update_aux,
@@ -165,8 +166,6 @@ function CanopyModel{FT}(;
 end
 
 ClimaLSM.name(::CanopyModel) = :canopy
-ClimaLSM.domain_name(::CanopyModel) = :surface
-
 
 """
     canopy_components(::CanopyModel)
@@ -288,8 +287,7 @@ function initialize_prognostic(model::CanopyModel{FT}, coords) where {FT}
     components = canopy_components(model)
     Y_state_list = map(components) do (component)
         submodel = getproperty(model, component)
-        zero_state = map(_ -> zero(FT), coords)
-        getproperty(initialize_prognostic(submodel, zero_state), component)
+        getproperty(initialize_prognostic(submodel, coords), component)
     end
     Y = ClimaCore.Fields.FieldVector(;
         name(model) => NamedTuple{components}(Y_state_list),
@@ -316,8 +314,7 @@ function initialize_auxiliary(model::CanopyModel{FT}, coords) where {FT}
     components = canopy_components(model)
     p_state_list = map(components) do (component)
         submodel = getproperty(model, component)
-        zero_state = map(_ -> zero(FT), coords)
-        getproperty(initialize_auxiliary(submodel, zero_state), component)
+        getproperty(initialize_auxiliary(submodel, coords), component)
     end
     p = (; name(model) => NamedTuple{components}(p_state_list))
     p = ClimaLSM.add_dss_buffer_to_aux(p, model.domain)

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -10,14 +10,13 @@ using ClimaCore
 using DocStringExtensions
 
 import ClimaLSM:
-    initialize_prognostic,
     make_update_aux,
     make_compute_exp_tendency,
     prognostic_vars,
     prognostic_types,
     auxiliary_vars,
-    initialize,
-    initialize_auxiliary,
+    auxiliary_domain_names,
+    prognostic_domain_names,
     name
 export PlantHydraulicsModel,
     AbstractPlantHydraulicsModel,
@@ -261,6 +260,7 @@ Defines the prognostic types for the PlantHydraulicsModel.
 """
 ClimaLSM.prognostic_types(model::PlantHydraulicsModel{FT}) where {FT} =
     (NTuple{model.n_stem + model.n_leaf, FT},)
+ClimaLSM.prognostic_domain_names(::PlantHydraulicsModel) = (:surface,)
 
 """
     ClimaLSM.auxiliary_types(model::PlantHydraulicsModel{FT}) where {FT}
@@ -274,6 +274,8 @@ ClimaLSM.auxiliary_types(model::PlantHydraulicsModel{FT}) where {FT} = (
     FT,
     NamedTuple{(:root, :stem, :leaf), Tuple{FT, FT, FT}},
 )
+ClimaLSM.auxiliary_domain_names(::PlantHydraulicsModel) =
+    (:surface, :surface, :surface, :surface, :surface)
 
 
 """

--- a/src/standalone/Vegetation/component_models.jl
+++ b/src/standalone/Vegetation/component_models.jl
@@ -45,12 +45,26 @@ passed in as an argument.
 ClimaLSM.prognostic_vars(::AbstractCanopyComponent) = ()
 
 """
+   prognostic_domain_names(m::AbstractCanopyComponent)
+
+Returns the domain names for the prognostic variables in the form of a tuple.
+"""
+ClimaLSM.prognostic_domain_names(::AbstractCanopyComponent) = ()
+
+"""
     ClimaLSM.auxiliary_vars(::AbstractCanopyComponent)
 
 Returns the auxiliary types of the canopy component
 passed in as an argument.
 """
 ClimaLSM.auxiliary_vars(::AbstractCanopyComponent) = ()
+
+"""
+   auxiliary_domain_names(m::AbstractCanopyComponent)
+
+Returns the domain names for the auxiliary variables in the form of a tuple.
+"""
+ClimaLSM.auxiliary_domain_names(::AbstractCanopyComponent) = ()
 
 """
     initialize_prognostic(
@@ -68,6 +82,7 @@ function initialize_prognostic(component::AbstractCanopyComponent, state)
     ClimaLSM.initialize_vars(
         prognostic_vars(component),
         prognostic_types(component),
+        prognostic_domain_names(component),
         state,
         name(component),
     )
@@ -92,6 +107,7 @@ function initialize_auxiliary(
     ClimaLSM.initialize_vars(
         auxiliary_vars(component),
         auxiliary_types(component),
+        auxiliary_domain_names(component),
         state,
         name(component),
     )

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -133,7 +133,7 @@ end
 ClimaLSM.name(model::AbstractPhotosynthesisModel) = :photosynthesis
 ClimaLSM.auxiliary_vars(model::FarquharModel) = (:An, :GPP)
 ClimaLSM.auxiliary_types(model::FarquharModel{FT}) where {FT} = (FT, FT)
-
+ClimaLSM.auxiliary_domain_names(::FarquharModel) = (:surface, :surface)
 """
     compute_photosynthesis(
         model::FarquharModel,

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -181,3 +181,5 @@ ClimaLSM.auxiliary_vars(model::Union{BeerLambertModel, TwoStreamModel}) =
 ClimaLSM.auxiliary_types(
     model::Union{BeerLambertModel{FT}, TwoStreamModel{FT}},
 ) where {FT} = (FT, FT, FT, FT)
+ClimaLSM.auxiliary_domain_names(::Union{BeerLambertModel, TwoStreamModel}) =
+    (:surface, :surface, :surface, :surface)

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -46,3 +46,5 @@ ClimaLSM.auxiliary_vars(model::MedlynConductanceModel) =
     (:medlyn_term, :gs, :transpiration)
 ClimaLSM.auxiliary_types(model::MedlynConductanceModel{FT}) where {FT} =
     (FT, FT, FT)
+ClimaLSM.auxiliary_domain_names(::MedlynConductanceModel) =
+    (:surface, :surface, :surface)

--- a/test/integrated/lsms.jl
+++ b/test/integrated/lsms.jl
@@ -1,50 +1,55 @@
 using Test
 import ClimaLSM:
     name,
-    domain_name,
     prognostic_types,
     auxiliary_types,
     prognostic_vars,
     auxiliary_vars,
+    auxiliary_domain_names,
+    prognostic_domain_names,
+    prognostic_domain_names,
+    interaction_vars,
+    interaction_types,
+    interaction_domain_names,
+    make_compute_exp_tendency,
+    make_interactions_update_aux,
     make_update_aux,
     make_set_initial_aux_state,
     land_components
 using ClimaLSM
 
-
-@testset "LSM aux tests" begin
+@testset "LSM prognostic tests" begin
 
     struct DummyModel1{FT} <: ClimaLSM.AbstractModel{FT}
         domain::Any
     end
     ClimaLSM.name(::DummyModel1) = :m1
-    ClimaLSM.domain_name(::DummyModel1) = :surface
-    ClimaLSM.auxiliary_vars(::DummyModel1) = (:a, :b)
-    ClimaLSM.auxiliary_types(::DummyModel1{FT}) where {FT} = (FT, FT)
-
+    ClimaLSM.prognostic_vars(::DummyModel1) = (:a,)
+    ClimaLSM.prognostic_types(::DummyModel1{FT}) where {FT} = (FT,)
+    ClimaLSM.prognostic_domain_names(::DummyModel1) = (:surface,)
+    ClimaLSM.auxiliary_vars(::DummyModel1) = (:b,)
+    ClimaLSM.auxiliary_types(::DummyModel1{FT}) where {FT} = (FT,)
+    ClimaLSM.auxiliary_domain_names(::DummyModel1) = (:surface,)
     struct DummyModel2{FT} <: ClimaLSM.AbstractModel{FT}
         domain::Any
     end
 
     ClimaLSM.name(::DummyModel2) = :m2
-    ClimaLSM.domain_name(::DummyModel2) = :surface
-    ClimaLSM.auxiliary_vars(::DummyModel2) = (:c, :d)
-    ClimaLSM.auxiliary_types(::DummyModel2{FT}) where {FT} = (FT, FT)
+    ClimaLSM.prognostic_vars(::DummyModel2) = (:c, :d)
+    ClimaLSM.prognostic_types(::DummyModel2{FT}) where {FT} = (FT, FT)
+    ClimaLSM.prognostic_domain_names(::DummyModel2) = (:surface, :subsurface)
 
     struct DummyModel{FT} <: ClimaLSM.AbstractLandModel{FT}
         m1::Any
         m2::Any
     end
     ClimaLSM.land_components(::DummyModel) = (:m1, :m2)
+    ClimaLSM.interaction_vars(::DummyModel) = (:i1,)
+    ClimaLSM.interaction_types(::DummyModel{FT}) where {FT} = (FT,)
+    ClimaLSM.interaction_domain_names(::DummyModel) = (:surface,)
 
 
-    FT = Float32
-    d = ClimaLSM.Domains.Point(; z_sfc = FT(0.0))
-    m1 = DummyModel1{FT}(d)
-    m2 = DummyModel2{FT}(d)
-    m = DummyModel{FT}(m1, m2)
-    Y, p, cds = ClimaLSM.initialize(m)
-    @test propertynames(p) == (:m1, :m2)
+
     function ClimaLSM.make_update_aux(::DummyModel1{FT}) where {FT}
         function update_aux!(p, Y, t)
             p.m1.b .= FT(10.0)
@@ -52,7 +57,87 @@ using ClimaLSM
         return update_aux!
     end
 
-    function ClimaLSM.make_update_aux(::DummyModel2{FT}) where {FT}
+    function ClimaLSM.make_interactions_update_aux(::DummyModel{FT}) where {FT}
+        function update_aux!(p, Y, t)
+            p.i1 .= FT(5.0)
+        end
+        return update_aux!
+    end
+
+    function ClimaLSM.make_compute_exp_tendency(::DummyModel1{FT}) where {FT}
+        function compute_exp_tendency!(dY, Y, p, t)
+            dY.m1.a .= p.m1.b
+        end
+        return compute_exp_tendency!
+    end
+
+    function ClimaLSM.make_compute_exp_tendency(::DummyModel2{FT}) where {FT}
+        function compute_exp_tendency!(dY, Y, p, t)
+            dY.m2.c .= p.i1
+            dY.m2.d .= FT(-1.0)
+        end
+        return compute_exp_tendency!
+    end
+    FT = Float32
+    d = ClimaLSM.Domains.Column(; zlim = (FT(-2), FT(0)), nelements = 5)
+    m1 = DummyModel1{FT}(d)
+    m2 = DummyModel2{FT}(d)
+    m = DummyModel{FT}(m1, m2)
+    Y, p, cds = ClimaLSM.initialize(m)
+    @test propertynames(p) == (:i1, :m1, :m2)
+    exp_tendency! = make_exp_tendency(m)
+    dY = similar(Y)
+    exp_tendency!(dY, Y, p, FT(0))
+    @test all(parent(p.i1) .== FT(5))
+    @test all(parent(p.m1.b) .== FT(10))
+    @test all(parent(dY.m1.a) .== FT(10))
+    @test all(parent(dY.m2.c) .== FT(5))
+    @test all(parent(dY.m2.d) .== FT(-1))
+
+end
+
+
+@testset "LSM aux tests" begin
+
+    struct DummyModel3{FT} <: ClimaLSM.AbstractModel{FT}
+        domain::Any
+    end
+    ClimaLSM.name(::DummyModel3) = :m1
+    ClimaLSM.auxiliary_vars(::DummyModel3) = (:a, :b)
+    ClimaLSM.auxiliary_types(::DummyModel3{FT}) where {FT} = (FT, FT)
+    ClimaLSM.auxiliary_domain_names(::DummyModel3) = (:surface, :surface)
+
+    struct DummyModel4{FT} <: ClimaLSM.AbstractModel{FT}
+        domain::Any
+    end
+
+    ClimaLSM.name(::DummyModel4) = :m2
+    ClimaLSM.auxiliary_vars(::DummyModel4) = (:c, :d)
+    ClimaLSM.auxiliary_types(::DummyModel4{FT}) where {FT} = (FT, FT)
+    ClimaLSM.auxiliary_domain_names(::DummyModel4) = (:surface, :surface)
+
+    struct DummyModelB{FT} <: ClimaLSM.AbstractLandModel{FT}
+        m1::Any
+        m2::Any
+    end
+    ClimaLSM.land_components(::DummyModelB) = (:m1, :m2)
+
+
+    FT = Float32
+    d = ClimaLSM.Domains.Point(; z_sfc = FT(0.0))
+    m1 = DummyModel3{FT}(d)
+    m2 = DummyModel4{FT}(d)
+    m = DummyModelB{FT}(m1, m2)
+    Y, p, cds = ClimaLSM.initialize(m)
+    @test propertynames(p) == (:m1, :m2)
+    function ClimaLSM.make_update_aux(::DummyModel3{FT}) where {FT}
+        function update_aux!(p, Y, t)
+            p.m1.b .= FT(10.0)
+        end
+        return update_aux!
+    end
+
+    function ClimaLSM.make_update_aux(::DummyModel4{FT}) where {FT}
         function update_aux!(p, Y, t)
             p.m2.c .= FT(10.0)
             p.m2.d .= FT(10.0)
@@ -60,7 +145,7 @@ using ClimaLSM
         return update_aux!
     end
 
-    function ClimaLSM.make_set_initial_aux_state(m::DummyModel1{FT}) where {FT}
+    function ClimaLSM.make_set_initial_aux_state(m::DummyModel3{FT}) where {FT}
         update_aux! = ClimaLSM.make_update_aux(m)
         function set_initial_aux_state!(p, Y, t)
             p.m1.a .= FT(2.0)
@@ -71,7 +156,7 @@ using ClimaLSM
 
     # The scenario here is that model 1 has a single prescribed but constant
     # variable (a), with another that could get updated each step (b).
-    # DummyModel2 has only variables that get updated each step.
+    # DummyModel4 has only variables that get updated each step.
     # Test that the land model function properly calls the individual
     # model's functions
     set_initial_aux_state! = ClimaLSM.make_set_initial_aux_state(m)

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -1,7 +1,7 @@
 using Test
 using ClimaCore
 using ClimaLSM
-using ClimaLSM.Domains: LSMMultiColumnDomain, LSMSingleColumnDomain
+using ClimaLSM.Domains: HybridBox, Column, obtain_surface_domain
 using ClimaLSM.Soil
 using ClimaLSM.Pond
 
@@ -25,7 +25,7 @@ using ClimaLSM.Pond
     zmax = FT(0)
     zmin = FT(-1)
     nelems = 20
-    lsm_domain = LSMMultiColumnDomain(;
+    lsm_domain = HybridBox(;
         xlim = (0.0, 1.0),
         ylim = (0.0, 1.0),
         zlim = (zmin, zmax),
@@ -34,8 +34,8 @@ using ClimaLSM.Pond
         periodic = (true, true),
     )
     soil_ps = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
-    soil_args = (; domain = lsm_domain.subsurface, parameters = soil_ps)
-    surface_water_args = (; domain = lsm_domain.surface)
+    soil_args = (; domain = lsm_domain, parameters = soil_ps)
+    surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
 
     land_args = (; precip = precipitation)
 
@@ -57,12 +57,12 @@ using ClimaLSM.Pond
     )
     @test typeof(p.dss_buffer_3d) == typeof(
         ClimaCore.Spaces.create_dss_buffer(
-            ClimaCore.Fields.zeros(land.soil.domain.space),
+            ClimaCore.Fields.zeros(land.soil.domain.space.subsurface),
         ),
     )
     @test typeof(p.dss_buffer_2d) == typeof(
         ClimaCore.Spaces.create_dss_buffer(
-            ClimaCore.Fields.zeros(land.surface_water.domain.space),
+            ClimaCore.Fields.zeros(land.surface_water.domain.space.surface),
         ),
     )
     function init_soil!(Ysoil, coords, params)
@@ -153,12 +153,11 @@ end
     zmax = FT(0)
     zmin = FT(-1)
     nelems = 20
-    lsm_domain =
-        LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelems)
+    lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
 
     soil_ps = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
-    soil_args = (; domain = lsm_domain.subsurface, parameters = soil_ps)
-    surface_water_args = (; domain = lsm_domain.surface)
+    soil_args = (; domain = lsm_domain, parameters = soil_ps)
+    surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
 
     land_args = (; precip = precipitation)
 

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -1,7 +1,7 @@
 using Test
 using ClimaCore
 using ClimaLSM
-using ClimaLSM.Domains: LSMSingleColumnDomain
+using ClimaLSM.Domains: Column
 using ClimaLSM.Soil
 using ClimaLSM.Soil.Biogeochemistry
 
@@ -52,8 +52,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     zmax = FT(0)
     zmin = FT(-1)
     nelems = 20
-    lsm_domain =
-        LSMSingleColumnDomain(; zlim = (zmin, zmax), nelements = nelems)
+    lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
     zero_flux_bc = Soil.FluxBC((p, t) -> eltype(t)(0.0))
     sources = () # PhaseChange
     boundary_fluxes = (;
@@ -63,7 +62,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     soil_args = (;
         boundary_conditions = boundary_fluxes,
         sources = sources,
-        domain = lsm_domain.subsurface,
+        domain = lsm_domain,
         parameters = soil_ps,
     )
 
@@ -85,7 +84,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     soilco2_args = (;
         boundary_conditions = co2_boundary_conditions,
         sources = co2_sources,
-        domain = lsm_domain.subsurface,
+        domain = lsm_domain,
         parameters = co2_parameters,
         drivers = soil_drivers,
     )
@@ -157,7 +156,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         soilco2_args = (;
             boundary_conditions = co2_boundary_conditions,
             sources = co2_sources,
-            domain = lsm_domain.subsurface,
+            domain = lsm_domain,
             parameters = co2_parameters,
             drivers = soil_drivers,
         )
@@ -183,7 +182,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         soilco2_args = (;
             boundary_conditions = co2_boundary_conditions,
             sources = co2_sources,
-            domain = lsm_domain.subsurface,
+            domain = lsm_domain,
             parameters = co2_parameters,
             drivers = soil_drivers,
         )

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -7,14 +7,12 @@ using ClimaLSM.Domains:
     HybridBox,
     Plane,
     Point,
-    LSMSingleColumnDomain,
-    LSMMultiColumnDomain,
-    LSMSphericalShellDomain,
     SphericalShell,
     SphericalSurface,
     coordinates,
     obtain_surface_space,
-    obtain_face_space
+    obtain_face_space,
+    obtain_surface_domain
 
 TestFloatTypes = (Float32, Float64)
 
@@ -26,62 +24,70 @@ TestFloatTypes = (Float32, Float64)
         ylim = FT.((0.0, 1.0))
         zlim = FT.((zmin, zmax))
         nelements = (1, 1, 10)
+        radius = FT(100)
+        depth = FT(30)
+        n_elements_sphere = (6, 20)
+        npoly_sphere = 3
+        # Spherical Shell
         shell = SphericalShell(;
-            radius = FT(100.0),
-            depth = FT(30.0),
-            nelements = (6, 20),
-            npolynomial = 3,
+            radius = radius,
+            depth = depth,
+            nelements = n_elements_sphere,
+            npolynomial = npoly_sphere,
         )
-        @test shell.radius == FT(100)
-        @test shell.depth == FT(30)
-        @test shell.nelements == (6, 20)
-        @test shell.npolynomial == 3
-        shell_coords = coordinates(shell)
+        @test shell.radius == radius
+        @test shell.depth == depth
+        @test shell.nelements == n_elements_sphere
+        @test shell.npolynomial == npoly_sphere
+        shell_coords = coordinates(shell).subsurface
         @test eltype(shell_coords) == ClimaCore.Geometry.LatLongZPoint{FT}
         @test typeof(shell_coords) <: ClimaCore.Fields.Field
-        @test typeof(shell.space.horizontal_space) <:
+        @test typeof(shell.space.subsurface.horizontal_space) <:
               ClimaCore.Spaces.SpectralElementSpace2D
-        @test typeof(shell.space) <:
+        @test typeof(shell.space.subsurface) <:
               ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace
-
+        @test typeof(shell.space.surface) <:
+              ClimaCore.Spaces.SpectralElementSpace2D
+        @test obtain_surface_space(shell.space.subsurface) ==
+              shell.space.surface
+        @test obtain_surface_domain(shell) == SphericalSurface{FT}(
+            radius,
+            n_elements_sphere[1],
+            npoly_sphere,
+            (; surface = shell.space.surface),
+        )
         shell_stretch = SphericalShell(;
-            radius = FT(100.0),
+            radius = radius,
             depth = FT(1.0),
             dz_tuple = FT.((0.3, 0.03)),
             nelements = (6, 10),
             npolynomial = 3,
         )
-        shell_coords_stretch = coordinates(shell_stretch)
+        shell_coords_stretch = coordinates(shell_stretch).subsurface
         dz =
             parent(shell_coords_stretch.z)[:, 1, 4, 1, 216][2:end] .-
             parent(shell_coords_stretch.z)[:, 1, 4, 1, 216][1:(end - 1)]
         @test abs(dz[1] - 0.3) < 1e-1
         @test abs(dz[end] - 0.03) < 1e-2
 
-
+        # Spherical Surface
         shell_surface = SphericalSurface(;
-            radius = FT(100.0),
-            nelements = 6,
-            npolynomial = 3,
+            radius = radius,
+            nelements = n_elements_sphere[1],
+            npolynomial = npoly_sphere,
         )
-        @test shell_surface.radius == FT(100)
-        @test shell_surface.nelements == 6
-        @test shell_surface.npolynomial == 3
-        shell_surface_coords = coordinates(shell_surface)
+        @test shell_surface.radius == radius
+        @test shell_surface.nelements == n_elements_sphere[1]
+        @test shell_surface.npolynomial == npoly_sphere
+        shell_surface_coords = coordinates(shell_surface).surface
         @test eltype(shell_surface_coords) ==
               ClimaCore.Geometry.LatLongPoint{FT}
         @test typeof(shell_surface_coords) <: ClimaCore.Fields.Field
-        @test typeof(shell_surface.space) <:
+        @test typeof(shell_surface.space.surface) <:
               ClimaCore.Spaces.SpectralElementSpace2D
 
-        xy_plane = Plane(;
-            xlim = xlim,
-            ylim = ylim,
-            nelements = nelements[1:2],
-            periodic = (true, true),
-            npolynomial = 0,
-        )
 
+        # HybridBox
         xyz_column_box = HybridBox(;
             xlim = xlim,
             ylim = ylim,
@@ -89,7 +95,7 @@ TestFloatTypes = (Float32, Float64)
             nelements = nelements,
             npolynomial = 0,
         )
-        box_coords = coordinates(xyz_column_box)
+        box_coords = coordinates(xyz_column_box).subsurface
         @test eltype(box_coords) == ClimaCore.Geometry.XYZPoint{FT}
         @test typeof(box_coords) <: ClimaCore.Fields.Field
         @test xyz_column_box.xlim == FT.(xlim)
@@ -98,10 +104,22 @@ TestFloatTypes = (Float32, Float64)
         @test xyz_column_box.nelements == nelements
         @test xyz_column_box.npolynomial == 0
         @test xyz_column_box.periodic == (true, true)
-        @test typeof(xyz_column_box.space.horizontal_space) <:
+        @test typeof(xyz_column_box.space.subsurface.horizontal_space) <:
               ClimaCore.Spaces.SpectralElementSpace2D
-        @test typeof(xyz_column_box.space) <:
+        @test typeof(xyz_column_box.space.subsurface) <:
               ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace
+        @test typeof(xyz_column_box.space.surface) <:
+              ClimaCore.Spaces.SpectralElementSpace2D
+        @test obtain_surface_space(xyz_column_box.space.subsurface) ==
+              xyz_column_box.space.surface
+        @test obtain_surface_domain(xyz_column_box) == Plane{FT}(
+            xlim,
+            ylim,
+            nelements[1:2],
+            (true, true),
+            0,
+            (; surface = xyz_column_box.space.surface),
+        )
 
         xyz_stretch_column_box = HybridBox(;
             xlim = xlim,
@@ -111,12 +129,14 @@ TestFloatTypes = (Float32, Float64)
             nelements = nelements,
             npolynomial = 0,
         )
-        box_coords_stretch = coordinates(xyz_stretch_column_box)
+        box_coords_stretch = coordinates(xyz_stretch_column_box).subsurface
         dz =
             parent(box_coords_stretch.z)[:][2:end] .-
             parent(box_coords_stretch.z)[:][1:(end - 1)]
         @test abs(dz[1] - 0.3) < 1e-1
         @test abs(dz[end] - 0.03) < 1e-2
+
+        # Plane
         xy_plane = Plane(;
             xlim = xlim,
             ylim = ylim,
@@ -124,7 +144,7 @@ TestFloatTypes = (Float32, Float64)
             periodic = (true, true),
             npolynomial = 0,
         )
-        plane_coords = coordinates(xy_plane)
+        plane_coords = coordinates(xy_plane).surface
         @test eltype(plane_coords) == ClimaCore.Geometry.XYPoint{FT}
         @test typeof(plane_coords) <: ClimaCore.Fields.Field
         @test xy_plane.xlim == FT.(xlim)
@@ -132,25 +152,33 @@ TestFloatTypes = (Float32, Float64)
         @test xy_plane.nelements == nelements[1:2]
         @test xy_plane.npolynomial == 0
         @test xy_plane.periodic == (true, true)
-        @test typeof(xy_plane.space) <: ClimaCore.Spaces.SpectralElementSpace2D
+        @test typeof(xy_plane.space.surface) <:
+              ClimaCore.Spaces.SpectralElementSpace2D
+
+
+        # Column
 
         z_column = Column(; zlim = zlim, nelements = nelements[3])
-        column_coords = coordinates(z_column)
+        column_coords = coordinates(z_column).subsurface
         @test z_column.zlim == FT.(zlim)
         @test z_column.nelements[1] == nelements[3]
         @test eltype(column_coords) == ClimaCore.Geometry.ZPoint{FT}
         @test typeof(column_coords) <: ClimaCore.Fields.Field
-        @test typeof(z_column.space) <:
+        @test typeof(z_column.space.subsurface) <:
               ClimaCore.Spaces.CenterFiniteDifferenceSpace
+        @test typeof(z_column.space.surface) <: ClimaCore.Spaces.PointSpace
         @test any(
             parent(column_coords)[:][2:end] .-
             parent(column_coords)[:][1:(end - 1)] .≈
             (zmax - zmin) / nelements[3],
         )
-
+        @test obtain_surface_space(z_column.space.subsurface) ==
+              z_column.space.surface
+        @test obtain_surface_domain(z_column) ==
+              Point{FT}(zlim[2], (; surface = z_column.space.surface))
         z_column_stretch =
             Column(; zlim = zlim, nelements = 10, dz_tuple = FT.((0.3, 0.03)))
-        column_coords = coordinates(z_column_stretch)
+        column_coords = coordinates(z_column_stretch).subsurface
         @test z_column_stretch.zlim == FT.(zlim)
         dz =
             parent(column_coords)[:][2:end] .-
@@ -166,88 +194,12 @@ end
         zmin = FT(1.0)
         point = Point(; z_sfc = zmin)
         @test point.z_sfc == zmin
-        point_space = point.space
+        point_space = point.space.surface
         @test point_space isa ClimaCore.Spaces.PointSpace
-        coords = coordinates(point)
+        coords = coordinates(point).surface
         @test coords isa ClimaCore.Fields.Field
         @test eltype(coords) == ClimaCore.Geometry.ZPoint{FT}
         @test ClimaCore.Fields.field_values(coords)[] ==
               ClimaCore.Geometry.ZPoint(zmin)
-    end
-end
-
-
-@testset "LSMSingleColumnDomain" begin
-    for FT in TestFloatTypes
-        zmin = FT(-1.0)
-        zmax = FT(0.0)
-        zlim = FT.((zmin, zmax))
-        nelements = 5
-        domain = LSMSingleColumnDomain(;
-            zlim = zlim,
-            nelements = nelements,
-            dz_tuple = FT.((0.3, 0.03)),
-        )
-        point = domain.surface
-        column = domain.subsurface
-
-        @test typeof(column) == Column{FT, typeof(column.space)}
-        @test typeof(point) == Point{FT, typeof(point.space)}
-        @test coordinates(point) === coordinates(domain).surface
-        @test coordinates(domain).subsurface === coordinates(column)
-        @test obtain_surface_space(column.space) === point.space
-    end
-end
-
-
-@testset "LSMMultiColumnDomain" begin
-    for FT in TestFloatTypes
-        zmin = FT(-1.0)
-        zmax = FT(0.0)
-        zlim = FT.((zmin, zmax))
-        xlim = FT.((0.0, 10.0))
-        ylim = FT.((0.0, 1.0))
-        zlim = FT.((zmin, zmax))
-        nelements = (1, 1, 5)
-        npolynomial = 2
-        domain = LSMMultiColumnDomain(;
-            xlim = xlim,
-            ylim = ylim,
-            zlim = zlim,
-            nelements = nelements,
-            periodic = (true, true),
-            npolynomial = npolynomial,
-            dz_tuple = FT.((0.3, 0.03)),
-        )
-        plane = domain.surface
-        box = domain.subsurface
-
-        @test typeof(box) == HybridBox{FT, typeof(box.space)}
-        @test typeof(plane) == Plane{FT, typeof(plane.space)}
-        @test coordinates(plane) === coordinates(domain).surface
-        @test coordinates(domain).subsurface === coordinates(box)
-        @test obtain_surface_space(box.space) === plane.space
-    end
-end
-
-
-
-@testset "LSMSphericalShellDomain" begin
-    for FT in TestFloatTypes
-        domain = LSMSphericalShellDomain(;
-            radius = FT(100.0),
-            depth = FT(30.0),
-            nelements = (6, 20),
-            npolynomial = 3,
-            dz_tuple = FT.((5.0, 0.3)),
-        )
-        surf = domain.surface
-        shell = domain.subsurface
-
-        @test typeof(shell) == SphericalShell{FT, typeof(shell.space)}
-        @test typeof(surf) == SphericalSurface{FT, typeof(surf.space)}
-        @test coordinates(surf) === coordinates(domain).surface
-        @test coordinates(domain).subsurface === coordinates(shell)
-        @test obtain_surface_space(shell.space) === surf.space
     end
 end

--- a/test/shared_utilities/regridder.jl
+++ b/test/shared_utilities/regridder.jl
@@ -24,7 +24,7 @@ using Test
 
     surface_domain =
         SphericalSurface(; radius = FT(1), nelements = 2, npolynomial = 3)
-    boundary_space = surface_domain.space
+    boundary_space = surface_domain.space.surface
     field = regrid_netcdf_to_field(
         FT,
         regrid_dirpath,

--- a/test/shared_utilities/utilities.jl
+++ b/test/shared_utilities/utilities.jl
@@ -115,9 +115,13 @@ end
         domain1 = ClimaLSM.Domains.Point(; z_sfc = FT(0))
         domain2 =
             ClimaLSM.Domains.Column(; zlim = FT.((-1.0, 0.0)), nelements = (5))
-        domains = (domain1, domain2)
-        for domain in domains
-            space = domain.space
+        domains = (domain1, domain2, domain2)
+        spaces = (
+            domain1.space.surface,
+            domain2.space.subsurface,
+            domain2.space.surface,
+        )
+        for (domain, space) in zip(domains, spaces)
             field = Fields.coordinate_field(space)
             subfield1 = similar(field)
             parent(subfield1) .= parent(copy(field)) .+ FT(1)
@@ -155,7 +159,7 @@ end
 
         domains = (domain1, domain2)
         for domain in domains
-            space = domain.space
+            space = domain.space.surface
             field = Fields.zeros(space)
             subfield1 = Fields.zeros(space)
             subfield2 = Fields.zeros(space)
@@ -176,7 +180,7 @@ end
             p = (;)
             p = ClimaLSM.add_dss_buffer_to_aux(p, domain)
             @test typeof(p.dss_buffer_2d) ==
-                  typeof(Spaces.create_dss_buffer(Fields.zeros(domain.space)))
+                  typeof(Spaces.create_dss_buffer(Fields.zeros(space)))
             ClimaLSM.dss!(Y, p, FT(0))
 
             # On a 2D space, we expect dss! to change Y
@@ -206,7 +210,7 @@ end
 
         domains = (domain1, domain2)
         for domain in domains
-            space = domain.space
+            space = domain.space.subsurface
             field = Fields.zeros(space)
             subfield1 = Fields.zeros(space)
             subfield2 = Fields.zeros(space)
@@ -227,7 +231,10 @@ end
             p = (;)
             p = ClimaLSM.add_dss_buffer_to_aux(p, domain)
             @test typeof(p.dss_buffer_3d) ==
-                  typeof(Spaces.create_dss_buffer(Fields.zeros(domain.space)))
+                  typeof(Spaces.create_dss_buffer(Fields.zeros(space)))
+            @test typeof(p.dss_buffer_2d) == typeof(
+                Spaces.create_dss_buffer(Fields.zeros(domain.space.surface)),
+            )
             ClimaLSM.dss!(Y, p, FT(0))
 
             # On a 3D space, we expect dss! to change Y

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -9,11 +9,7 @@ using ClimaLSM.Bucket:
     BucketModelParameters,
     BulkAlbedoFunction,
     partition_surface_fluxes
-using ClimaLSM.Domains:
-    coordinates,
-    LSMSingleColumnDomain,
-    LSMMultiColumnDomain,
-    LSMSphericalShellDomain
+using ClimaLSM.Domains: coordinates, Column, HybridBox, SphericalShell
 using ClimaLSM:
     initialize,
     make_update_aux,
@@ -41,8 +37,8 @@ z_0b = FT(1e-3)
 
 # Model domain
 bucket_domains = [
-    LSMSingleColumnDomain(; zlim = (-100.0, 0.0), nelements = 10),
-    LSMMultiColumnDomain(;
+    Column(; zlim = (-100.0, 0.0), nelements = 10),
+    HybridBox(;
         xlim = (-1.0, 0.0),
         ylim = (-1.0, 0.0),
         zlim = (-100.0, 0.0),
@@ -50,7 +46,7 @@ bucket_domains = [
         npolynomial = 1,
         periodic = (true, true),
     ),
-    LSMSphericalShellDomain(;
+    SphericalShell(;
         radius = 100.0,
         depth = 3.5,
         nelements = (1, 10),
@@ -148,7 +144,7 @@ for i in 1:3
 
 
         if i == 1
-            A_point = sum(ones(bucket_domains[i].surface.space))
+            A_point = sum(ones(bucket_domains[i].space.surface))
         else
             A_point = 1
         end
@@ -255,7 +251,7 @@ for i in 1:3
             liquid_precip(t0) + snow_precip(t0) .- p.bucket.evaporation
 
         if i == 1
-            A_point = sum(ones(bucket_domains[i].surface.space))
+            A_point = sum(ones(bucket_domains[i].space.surface))
         else
             A_point = 1
         end
@@ -335,7 +331,7 @@ end
     compute_exp_tendency! = ClimaLSM.make_compute_exp_tendency(model)
     set_initial_aux_state! = make_set_initial_aux_state(model)
     set_initial_aux_state!(p, Y, t0)
-    random = zeros(bucket_domains[i].surface.space)
+    random = zeros(bucket_domains[i].space.surface)
     parent(random) .= rand(FT, size(parent(random)))
     p.bucket.evaporation .= random .* 1e-7
     compute_exp_tendency!(dY, Y, p, t0)

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -134,15 +134,15 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         end
 
         t = FT(0)
-        init_soil!(Y, coords.z, model.parameters)
+        init_soil!(Y, coords.subsurface.z, model.parameters)
         set_initial_aux_state! = make_set_initial_aux_state(model)
         set_initial_aux_state!(p, Y, t)
 
 
-        face_space = ClimaLSM.Domains.obtain_face_space(model.domain.space)
+        face_space =
+            ClimaLSM.Domains.obtain_face_space(model.domain.space.subsurface)
         N = ClimaCore.Spaces.nlevels(face_space)
-        surface_space =
-            ClimaLSM.Domains.obtain_surface_space(model.domain.space)
+        surface_space = model.domain.space.surface
         z_sfc = ClimaCore.Fields.Field(
             ClimaCore.Fields.field_values(
                 ClimaCore.Fields.level(

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -26,9 +26,9 @@ FT = Float64
     )
 
     coords = ClimaLSM.Domains.coordinates(domain) # center coordinates
-    ϕ = (FT(90) .- coords.lat)
-    θ = coords.long
-    r = coords.z .+ FT(1.0)
+    ϕ = (FT(90) .- coords.subsurface.lat)
+    θ = coords.subsurface.long
+    r = coords.subsurface.z .+ FT(1.0)
 
     #=
     # For my own sanity, convert lat/lon to usual spherical coords, to cartesian components,
@@ -105,7 +105,7 @@ end
     zmin = FT(-10)
     nelems = 50
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    z = ClimaCore.Fields.coordinate_field(soil_domain.space).z
+    z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
     Δz = abs(zmax - zmin) / nelems / 2.0
 
     top_Δz, bottom_Δz = get_Δz(z)

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -62,7 +62,7 @@ FT = Float64
         Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
     end
 
-    init_soil!(Y, coords.z, soil.parameters)
+    init_soil!(Y, coords.subsurface.z, soil.parameters)
 
     t0 = FT(0)
     set_initial_aux_state! = make_set_initial_aux_state(soil)
@@ -77,7 +77,7 @@ FT = Float64
 
     @test mean(parent(dY)) < 1e-8
     # should be hydrostatic equilibrium at every layer, at each step:
-    @test mean(parent(p.soil.ψ .+ coords.z)[:] .+ 10.0) < 1e-10
+    @test mean(parent(p.soil.ψ .+ coords.subsurface.z)[:] .+ 10.0) < 1e-10
 end
 
 
@@ -158,7 +158,7 @@ end
     end
 
     t0 = FT(0)
-    init_soil_heat!(Y, coords.z, soil_heat_on.parameters)
+    init_soil_heat!(Y, coords.subsurface.z, soil_heat_on.parameters)
     set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
     set_initial_aux_state!(p, Y, t0)
     exp_tendency! = make_exp_tendency(soil_heat_on)
@@ -217,7 +217,7 @@ end
     end
 
     t0 = FT(0)
-    init_soil_water!(Y, coords.z, soil_water_on.parameters)
+    init_soil_water!(Y, coords.subsurface.z, soil_water_on.parameters)
     set_initial_aux_state! = make_set_initial_aux_state(soil_water_on)
     set_initial_aux_state!(p, Y, t0)
     exp_tendency! = make_exp_tendency(soil_water_on)
@@ -290,7 +290,7 @@ end
 
     θ = parent(Y.soil.ϑ_l)# on the center
     θ_face = 0.5 * (θ[2:end] + θ[1:(end - 1)])
-    Z = parent(coords.z)
+    Z = parent(coords.subsurface.z)
     Z_face = 0.5 * (Z[2:end] + Z[1:(end - 1)])
     K_face = 0.5 .* (K.(θ[2:end]) .+ K.(θ[1:(end - 1)]))
     flux_interior = (@. -K_face * (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
@@ -362,7 +362,7 @@ end
     end
 
     t0 = FT(0)
-    init_soil_off!(Y, coords.z, soil_both_off.parameters)
+    init_soil_off!(Y, coords.subsurface.z, soil_both_off.parameters)
     set_initial_aux_state! = make_set_initial_aux_state(soil_both_off)
     set_initial_aux_state!(p, Y, t0)
     exp_tendency! = make_exp_tendency(soil_both_off)
@@ -413,7 +413,7 @@ end
     end
 
     t0 = FT(0)
-    init_soil_on!(Y, coords.z, soil_both_on.parameters)
+    init_soil_on!(Y, coords.subsurface.z, soil_both_on.parameters)
     set_initial_aux_state! = make_set_initial_aux_state(soil_both_on)
     set_initial_aux_state!(p, Y, t0)
 
@@ -426,7 +426,7 @@ end
 
     θ = parent(Y.soil.ϑ_l)# on the center
     θ_face = 0.5 * (θ[2:end] + θ[1:(end - 1)])
-    Z = parent(coords.z)
+    Z = parent(coords.subsurface.z)
     Z_face = 0.5 * (Z[2:end] + Z[1:(end - 1)])
     K_face = 0.5 .* (K.(θ[2:end]) .+ K.(θ[1:(end - 1)]))
     vf = parent(
@@ -553,7 +553,7 @@ end
             Soil.volumetric_internal_energy.(0.0, ρc_s, T, Ref(params))
     end
 
-    init_soil_heat!(Y, coords.z, soil_heat_on.parameters)
+    init_soil_heat!(Y, coords.subsurface.z, soil_heat_on.parameters)
     set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
     set_initial_aux_state!(p, Y, FT(0.0))
     dY = similar(Y)

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -273,7 +273,6 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         Ref(Thermodynamics.Liquid()),
     )
     @test ρ_sfc == compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
-    @test ClimaLSM.domain_name(canopy) == :surface
 end
 
 
@@ -351,7 +350,7 @@ end
                 )
             )
         ),
-        domain.space,
+        domain.space.surface,
     )
     # Test that they are set properly
     set_canopy_prescribed_field!(plant_hydraulics, p, t0)

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -330,7 +330,7 @@ end
             @test propertynames(p) == (:canopy, :dss_buffer_2d)
             @test typeof(p.dss_buffer_2d) == typeof(
                 ClimaCore.Spaces.create_dss_buffer(
-                    ClimaCore.Fields.zeros(domain.space),
+                    ClimaCore.Fields.zeros(domain.space.surface),
                 ),
             )
         end


### PR DESCRIPTION
## Purpose 
Allow standalone models to define variables on subdomains (e.g. just on the surface, or throughout the domain).

Required for 2d aux variables of the soil model (for example).

Removes requirement for bucket model to have its own methods for `initialize`

Simplifies our domains by removing the LSM domains

Down the road will reduce allocations as we can now pre-allocate surface fields for e.g. the soil model for storing the boundary fluxes


## To-do
Review
Propagate to docs and experiments once approach is settled.


## Content
1. Remove LSM domains (LSMSingleColumnDomain, LSMMultiColumnDomain, LSMSphericalShellDomain)
2. Changes the `space` stored in the domains to have the spaces of the surface (for 0D-2D domains) or of the subsurface+surface(for 1D/3D domains). This is more general in case we ever need to store additional spaces (e.g. the face space, which we do use in some places). They are stored as a NamedTuple.
3. Calling `coordinates(domain)` now also returns a NamedTuple with the coordinates for each space associated with that domain.
4. add `prognostic_domain_names` and `auxiliary_domain_names` which now must be defined for all variables of all models (e.g. :surface, :subsurface)
5. updates methods appropriately for `initialize` to include the domain types. When initializing a variable, we use the coordinates of the domain, along with the "state" =  `getproperty(coords, var_domain_name)`.
6. Removes unnecessary Bucket `initialize` methods and updates LSM methods for the new functionality.
7. removes `domain_name(model)` function as this is superceded by variable domain names.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [ ] I have read and checked the items on the review checklist.
