### PR TITLE
Added canopy prognostic energy

### DIFF
--- a/docs/src/APIs/canopy/CanopyEnergy.md
+++ b/docs/src/APIs/canopy/CanopyEnergy.md
@@ -8,6 +8,7 @@ CurrentModule = ClimaLSM.Canopy
 
 ```@docs
 ClimaLSM.Canopy.canopy_temperature
+ClimaLSM.Canopy.root_energy_flux_per_ground_area!
 ```
 
 ## Types
@@ -15,4 +16,5 @@ ClimaLSM.Canopy.canopy_temperature
 ```@docs
 ClimaLSM.Canopy.AbstractCanopyEnergyModel
 ClimaLSM.Canopy.PrescribedCanopyTempModel
+ClimaLSM.Canopy.BigLeafEnergyModel
 ```

--- a/experiments/integrated/ozark/conservation/ozark_simulation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_simulation.jl
@@ -1,7 +1,7 @@
 t0 = FT(120 * 3600 * 24)# start mid year
 N_days = 10
 tf = t0 + FT(3600 * 24 * N_days)
-dt = FT(300)
+dt = FT(150)
 n = 1
 saveat = Array(t0:(n * dt):tf)
 timestepper = CTS.ARS111()

--- a/experiments/integrated/ozark/ozark_domain.jl
+++ b/experiments/integrated/ozark/ozark_domain.jl
@@ -1,9 +1,9 @@
 # Domain setup
 # For soil column
-nelements = 10
-zmin = FT(-2)
+nelements = 20
+zmin = FT(-10)
 zmax = FT(0)
-dz_bottom = FT(0.5)
+dz_bottom = FT(1.5)
 dz_top = FT(0.025)
 
 land_domain = Column(;

--- a/experiments/integrated/ozark/ozark_parameters.jl
+++ b/experiments/integrated/ozark/ozark_parameters.jl
@@ -35,10 +35,10 @@ z_0m_soil = FT(0.01)
 z_0b_soil = FT(0.001)
 soil_ϵ = FT(0.98)
 soil_α_PAR = FT(0.2)
-soil_α_NIR = FT(0.2)
+soil_α_NIR = FT(0.3)
 
 # TwoStreamModel parameters
-Ω = FT(0.69)
+Ω = FT(0.89)
 ld = FT(0.5)
 α_PAR_leaf = FT(0.1)
 λ_γ_PAR = FT(5e-7)
@@ -49,8 +49,11 @@ ld = FT(0.5)
 n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
+# Energy Balance model
+ac_canopy = FT(2.5e3)
+
 # Conductance Model
-g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
+g1 = FT(70) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
 Drel = FT(1.6)
 g0 = FT(1e-4)
 
@@ -81,7 +84,7 @@ RAI = (SAI + maxLAI) * f_root_to_shoot # CLM
 K_sat_plant = 5e-9 # m/s # seems much too small?
 ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
 Weibull_param = FT(4) # unitless, Holtzman's original c param value
-a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+a = FT(0.08 * 0.0098) # Natan used 0.05
 conductivity_model =
     PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
 retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -298,7 +298,10 @@ using .Canopy
 using .Canopy.PlantHydraulics
 import .Canopy.PlantHydraulics: root_water_flux_per_ground_area!
 import .Canopy:
-    ground_albedo_PAR, ground_albedo_NIR, canopy_radiant_energy_fluxes!
+    ground_albedo_PAR,
+    ground_albedo_NIR,
+    canopy_radiant_energy_fluxes!,
+    root_energy_flux_per_ground_area!
 ### Concrete types of AbstractLandModels
 ### and associated methods
 include("integrated/soil_energy_hydrology_biogeochemistry.jl")

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -1,7 +1,21 @@
-export PrescribedCanopyTempModel, AbstractCanopyEnergyModel, canopy_temperature
+export PrescribedCanopyTempModel,
+    BigLeafEnergyModel,
+    AbstractCanopyEnergyModel,
+    canopy_temperature,
+    root_energy_flux_per_ground_area!,
+    BigLeafEnergyParameters
+
 abstract type AbstractCanopyEnergyModel{FT} <: AbstractCanopyComponent{FT} end
 
 ClimaLSM.name(model::AbstractCanopyEnergyModel) = :energy
+
+
+ClimaLSM.auxiliary_vars(model::AbstractCanopyEnergyModel) =
+    (:shf, :lhf, :fa_energy_roots, :r_ae)
+ClimaLSM.auxiliary_types(model::AbstractCanopyEnergyModel{FT}) where {FT} =
+    (FT, FT, FT, FT)
+ClimaLSM.auxiliary_domain_names(model::AbstractCanopyEnergyModel) =
+    (:surface, :surface, :surface, :surface)
 
 """
     PrescribedCanopyTempModel{FT} <: AbstractCanopyEnergyModel{FT}
@@ -14,12 +28,6 @@ No equation for the energy of the canopy is solved.
 """
 struct PrescribedCanopyTempModel{FT} <: AbstractCanopyEnergyModel{FT} end
 
-ClimaLSM.auxiliary_vars(model::AbstractCanopyEnergyModel) = (:shf, :lhf)
-ClimaLSM.auxiliary_types(model::AbstractCanopyEnergyModel{FT}) where {FT} =
-    (FT, FT)
-ClimaLSM.auxiliary_domain_names(model::AbstractCanopyEnergyModel) =
-    (:surface, :surface)
-
 """
     canopy_temperature(model::PrescribedCanopyTempModel, canopy, Y, p, t)
 
@@ -29,3 +37,105 @@ temperature.
 """
 canopy_temperature(model::PrescribedCanopyTempModel, canopy, Y, p, t) =
     canopy.atmos.T(t)
+
+## Prognostic Canopy Temperature
+"""
+    BigLeafEnergyParameters{FT <: AbstractFloat}
+
+$(DocStringExtensions.FIELDS)
+
+"""
+struct BigLeafEnergyParameters{FT <: AbstractFloat}
+    "Specific heat per emitting area [J/m^2/K]"
+    ac_canopy::FT
+end
+
+function BigLeafEnergyParameters{FT}(; ac_canopy = FT(2e3)) where {FT}
+    return BigLeafEnergyParameters{FT}(ac_canopy)
+end
+
+
+"""
+    BigLeafEnergyModel{FT} <: AbstractCanopyEnergyModel{FT}
+"""
+struct BigLeafEnergyModel{FT} <: AbstractCanopyEnergyModel{FT}
+    parameters::BigLeafEnergyParameters{FT}
+end
+
+ClimaLSM.prognostic_vars(model::BigLeafEnergyModel) = (:T,)
+ClimaLSM.prognostic_types(model::BigLeafEnergyModel{FT}) where {FT} = (FT,)
+ClimaLSM.prognostic_domain_names(model::BigLeafEnergyModel) = (:surface,)
+
+"""
+    canopy_temperature(model::BigLeafEnergyModel, canopy, Y, p, t)
+
+Returns the canopy temperature under the `BigLeafEnergyModel` model, 
+where the canopy temperature is modeled prognostically.
+"""
+canopy_temperature(model::BigLeafEnergyModel, canopy, Y, p, t) =
+    Y.canopy.energy.T
+
+function make_compute_exp_tendency(
+    model::BigLeafEnergyModel{FT},
+    canopy,
+) where {FT}
+    function compute_exp_tendency!(dY, Y, p, t)
+        area_index = p.canopy.hydraulics.area_index
+        ac_canopy = model.parameters.ac_canopy
+        # Energy Equation:
+        # (ρc_canopy h_canopy AI) ∂T∂t = -∑F
+        # or( ac_canopy AI)∂T∂t = -∑F
+        # where ∑F = F_sfc - F_bot, and both F_sfc and F_bot are per
+        # unit area ground [W/m^2].
+        # Because they are per unit area ground, we need the factor of
+        # area index on the LHF, as ac_canopy [J/m^2/K]
+        # is per unit area plant.
+
+        net_energy_flux = @. -p.canopy.radiative_transfer.LW_n -
+           p.canopy.radiative_transfer.SW_n +
+           p.canopy.energy.shf +
+           p.canopy.energy.lhf - p.canopy.energy.fa_energy_roots
+
+        # To prevent dividing by zero, change AI" to
+        # "max(AI, eps(FT))"
+        c_per_ground_area =
+            @. ac_canopy * max(area_index.leaf + area_index.stem, eps(FT))
+        @. dY.canopy.energy.T = -net_energy_flux / c_per_ground_area
+    end
+    return compute_exp_tendency!
+end
+
+"""
+    root_energy_flux_per_ground_area!(
+        fa_energy::ClimaCore.Fields.Field,
+        s::PrescribedSoil{FT},
+        model::AbstractCanopyEnergyModel{FT},
+        Y::ClimaCore.Fields.FieldVector,
+        p::NamedTuple,
+        t::FT,
+    ) where {FT}
+
+
+A method which updates the ClimaCore.Fields.Field `fa_energy` in place
+with  the energy flux associated with the root-soil
+water flux for the `CanopyModel` run in standalone mode,
+with a `PrescribedSoil` model.This value is ignored and set to zero 
+in this case. 
+
+Background information: This energy 
+flux is not typically included in land surface
+models. We account for it when the soil model is prognostic because 
+the soil model includes the energy in the soil water in its energy 
+balance; therefore, in order to conserve energy, the canopy model
+must account for it as well.
+"""
+function root_energy_flux_per_ground_area!(
+    fa_energy::ClimaCore.Fields.Field,
+    s::PrescribedSoil{FT},
+    model::AbstractCanopyEnergyModel{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::NamedTuple,
+    t::FT,
+) where {FT}
+    fa_energy .= FT(0)
+end

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -1,3 +1,4 @@
+
 using Test
 using Statistics
 using NLsolve
@@ -234,6 +235,7 @@ end
     end
 
     ψ_soil0 = FT(0.0)
+
     transpiration =
         PrescribedTranspiration{FT}((t::FT) -> leaf_transpiration(t))
 
@@ -486,10 +488,8 @@ end
         retention_model = retention_model,
     )
 
-    ψ_soil0 = FT(0.0)
     transpiration = DiagnosticTranspiration{FT}()
     soil_driver = PrescribedSoil{FT}()
-
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,
         transpiration = transpiration,


### PR DESCRIPTION
## Purpose 
Prognostic energy for the canopy

## To-do
Update ozark conservation test [ future PR]


## Content
1. Adds root energy flux as variable to `p`, updates in interactions_update_aux; uses precomputed quantity in soil source.
2. Since a PrescribedCanopyTemp is the default, have case statement inside of constructor for the SoilCanopyModel to handle when we use the default (don’t pass anything in for a canopy energy model vs when we do)
3. Simple expressions for SHF,  LHF. Update the plots in ozark.jl
4. `canopy_boundary_flux` function - computed in RHS
5. Adds BigLeafEnergyModel with a prognostic equation for T_canopy.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [] I have read and checked the items on the review checklist.
