### PR TITLE
replace MapInfo with PrescribedDataStatic

### DIFF
--- a/docs/src/APIs/Regridder.md
+++ b/docs/src/APIs/Regridder.md
@@ -3,11 +3,6 @@
 ```@meta
 CurrentModule = ClimaLSM.Regridder
 ```
-## Types
-
-```@docs
-ClimaLSM.Regridder.MapInfo
-```
 
 ## Functions
 

--- a/src/shared_utilities/Regridder.jl
+++ b/src/shared_utilities/Regridder.jl
@@ -8,7 +8,7 @@ using Dates
 using JLD2
 using DocStringExtensions
 
-export MapInfo, regrid_netcdf_to_field
+export regrid_netcdf_to_field
 
 nans_to_zero(v::T) where {T} = isnan(v) ? T(0) : v
 
@@ -281,6 +281,7 @@ function hdwrite_regridfile_rll_to_cgll(
     )
 
     # TODO: extend write! to handle time-dependent fields
+    comms_ctx = space.topology.context
     map(
         x -> write_to_hdf5(
             REGRID_DIR,
@@ -288,6 +289,7 @@ function hdwrite_regridfile_rll_to_cgll(
             times[x],
             offline_fields[x],
             varname,
+            comms_ctx,
         ),
         1:length(times),
     )
@@ -344,26 +346,6 @@ function swap_space!(field, new_space)
     field_out = zeros(new_space)
     parent(field_out) .= parent(field)
     return field_out
-end
-
-"""
-    MapInfo
-
-A struct holding the information required to identify the
-netcdf file where a global map of a particular parameter is stored,
-and for carrying out regridding of that dataset to a ClimaCore.Domains.AbstractDomain.
-
-$(DocStringExtensions.FIELDS)
-"""
-struct MapInfo
-    "Local path to NetCDF file"
-    path::String
-    "Variable name of interest"
-    varname::String
-    "Path where temporary regrid files are stored."
-    regrid_dirpath::String
-    "Communication context. Not tested yet with MPI"
-    comms::ClimaComms.AbstractCommsContext
 end
 
 end

--- a/test/shared_utilities/regridder.jl
+++ b/test/shared_utilities/regridder.jl
@@ -1,4 +1,5 @@
-using ClimaLSM.Regridder: MapInfo, regrid_netcdf_to_field
+using ClimaLSM.Regridder: regrid_netcdf_to_field
+using ClimaLSM.FileReader: PrescribedDataStatic
 using ClimaLSM.Bucket:
     BulkAlbedoStatic,
     bareground_albedo_dataset_path,
@@ -10,21 +11,20 @@ using ClimaCore
 using Test
 
 
-@testset "Spatially varying map" begin
+@testset "Spatially varying map - regrid to field" begin
     FT = Float32
     path = bareground_albedo_dataset_path()
     regrid_dirpath =
         joinpath(pkgdir(ClimaLSM), "test/standalone/Bucket/regridder_tmpfiles")
     mkpath(regrid_dirpath)
-    rm(regrid_dirpath, recursive = true)
 
     varname = "sw_alb"
-    comms = ClimaComms.SingletonCommsContext()
-    albedo = MapInfo(path, varname, regrid_dirpath, comms)
+    albedo = PrescribedDataStatic(path, regrid_dirpath, varname)
 
     surface_domain =
         SphericalSurface(; radius = FT(1), nelements = 2, npolynomial = 3)
     boundary_space = surface_domain.space.surface
+    comms = boundary_space.topology.context
     field = regrid_netcdf_to_field(
         FT,
         regrid_dirpath,

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -83,14 +83,14 @@ end
 
     # set up for manual data reading
     comms = ClimaComms.SingletonCommsContext()
-    input_file = bareground_albedo_dataset_path()
+    infile_path = bareground_albedo_dataset_path()
     varname = "sw_alb"
 
     data_manual = regrid_netcdf_to_field(
         FT,
         regrid_dir_static,
         comms,
-        input_file,
+        infile_path,
         varname,
         space,
     )
@@ -106,8 +106,8 @@ end
     domain = create_domain_2d(FT)
     space = domain.space.surface
 
-    input_file = cesm2_albedo_dataset_path()
-    date_ref = to_datetime(NCDataset(input_file, "r") do ds
+    infile_path = cesm2_albedo_dataset_path()
+    date_ref = to_datetime(NCDataset(infile_path, "r") do ds
         ds["time"][1]
     end)
 
@@ -120,14 +120,14 @@ end
 
     # set up for manual data reading
     comms = ClimaComms.SingletonCommsContext()
-    input_file = bareground_albedo_dataset_path()
+    infile_path = bareground_albedo_dataset_path()
     varname = "sw_alb"
 
     data_manual = regrid_netcdf_to_field(
         FT,
         regrid_dir_temporal,
         comms,
-        input_file,
+        infile_path,
         varname,
         space,
     )
@@ -206,8 +206,8 @@ end
     space = domain.space.surface
     surface_coords = Fields.coordinate_field(space)
 
-    input_file = cesm2_albedo_dataset_path()
-    date_ref = to_datetime(NCDataset(input_file, "r") do ds
+    infile_path = cesm2_albedo_dataset_path()
+    date_ref = to_datetime(NCDataset(infile_path, "r") do ds
         ds["time"][1]
     end)
     t_start = FT(0)
@@ -240,7 +240,7 @@ end
             FT,
             regrid_dir_temporal,
             comms,
-            input_file,
+            infile_path,
             varname,
             space,
             date_idx = i,
@@ -368,7 +368,7 @@ end
 @testset "Test BulkAlbedoTemporal error with static map" begin
     FT = Float32
     regrid_dirpath = ""
-    input_file = bareground_albedo_dataset_path()
+    infile_path = bareground_albedo_dataset_path()
     date_ref = Dates.DateTime(1900, 1, 1)
     t_start = FT(0)
     domain = create_domain_2d(FT)
@@ -381,7 +381,7 @@ end
                 date_ref,
                 t_start,
                 space,
-                input_file = input_file,
+                infile_path = infile_path,
             )
         catch err
         end
@@ -398,7 +398,7 @@ end
     FT = Float32
     earth_param_set = create_lsm_parameters(FT)
     varname = "sw_alb"
-    input_file = cesm2_albedo_dataset_path()
+    infile_path = cesm2_albedo_dataset_path()
     comms = ClimaComms.SingletonCommsContext()
     regrid_dirpath = joinpath(pkgdir(ClimaLSM), "test/albedo_tmpfiles/")
     mkpath(regrid_dirpath)
@@ -412,7 +412,7 @@ end
     init_temp(z::FT, value::FT) where {FT} = FT(value)
 
     t_start = FT(0)
-    date_ref = to_datetime(NCDataset(input_file, "r") do ds
+    date_ref = to_datetime(NCDataset(infile_path, "r") do ds
         ds["time"][1]
     end)
 
@@ -492,7 +492,7 @@ end
                 FT,
                 regrid_dirpath,
                 comms,
-                input_file,
+                infile_path,
                 varname,
                 model.domain.space.surface,
                 date_idx = 1,
@@ -517,7 +517,7 @@ end
                     FT,
                     regrid_dirpath,
                     comms,
-                    input_file,
+                    infile_path,
                     varname,
                     model.domain.space.surface,
                     date_idx = i,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Currently, the `BulkAlbedoStatic` and `BulkAlbedoTemporal` types make use of very similar data structures, `MapInfo` and `FileInfo` respectively. Instead of keeping both of these around, we should unify them and just keep one. It's easier to make the change to keep `FileInfo`, so I've done that.

Once we've unified these two types, it will be easier to generalize the albedo types we have defined to input data for any variable.

Closes #295

## To Do
- [x] add `infile_path` to `FileInfo`, update constructor calls to include it
- [x] reorder `FileInfo` struct fields so time-related ones are last (makes `PrescribedDataStatic` constructor clearer)
- [x] replace `MapInfo` with `PrescribedDataStatic ` in `BulkAlbedoStatic` constructor
- [x] add `PrescribedDataTemporal` and `PrescribedDataStatic` types
- [x] add `PrescribedDataStatic` constructor which makes a `FileInfo` internally

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.