### PR TITLE
Surface resistance effects on SHF

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -70,4 +70,7 @@ ClimaLSM.construct_atmos_ts
 ClimaLSM.surface_air_density
 ClimaLSM.liquid_precipitation
 ClimaLSM.snow_precipitation
+ClimaLSM.surface_temperature
+ClimaLSM.surface_resistance
+ClimaLSM.surface_specific_humidity
 ```

--- a/experiments/integrated/ozark/ozark_parameters.jl
+++ b/experiments/integrated/ozark/ozark_parameters.jl
@@ -47,7 +47,6 @@ ld = FT(0.5)
 α_NIR_leaf = FT(0.45)
 τ_NIR_leaf = FT(0.25)
 n_layers = UInt64(20)
-diff_perc = FT(0.2)
 ϵ_canopy = FT(0.97)
 
 # Conductance Model

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -266,19 +266,9 @@ function make_interactions_update_aux(
         # Soil boundary fluxes under canopy or for bare soil
         bc = land.soil.boundary_conditions.top
         soil_conditions = surface_fluxes(bc.atmos, land.soil, Y, p, t)
-
-        r_soil = ClimaLSM.Domains.top_center_to_surface(
-            ClimaLSM.Soil.soil_resistance.(
-                p.soil.θ_l,
-                Y.soil.ϑ_l,
-                Y.soil.θ_i,
-                land.soil.parameters,
-            ),
-        )
-        r_ae = soil_conditions.r_ae
-        @. p.soil_evap = soil_conditions.vapor_flux * r_ae / (r_soil + r_ae)
-        @. p.soil_lhf = soil_conditions.lhf * r_ae / (r_soil + r_ae)
         @. p.soil_shf = soil_conditions.shf
+        @. p.soil_evap = soil_conditions.vapor_flux
+        @. p.soil_lhf = soil_conditions.lhf
         p.T_soil .= surface_temperature(land.soil, Y, p, t)
         p.α_soil .= surface_albedo(land.soil, Y, p)
         p.ϵ_soil .= surface_emissivity(land.soil, Y, p)

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -86,7 +86,8 @@ import ClimaLSM:
     surface_albedo,
     surface_emissivity,
     surface_air_density,
-    surface_height
+    surface_height,
+    surface_resistance
 export RichardsModel,
     RichardsParameters,
     RichardsTridiagonalW,

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -172,27 +172,16 @@ function soil_boundary_fluxes(
     conditions = surface_fluxes(bc.atmos, model, Y, p, t)
     R_n = net_radiation(bc.radiation, model, Y, p, t)
     # We are ignoring sublimation for now
-    r_soil = ClimaLSM.Domains.top_center_to_surface(
-        soil_resistance.(
-            p.soil.θ_l,
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            Ref(model.parameters),
-        ),
-    )
-    r_ae = conditions.r_ae
     precip = bc.atmos.liquid_precip(t)
-    evaporation = @. conditions.vapor_flux * r_ae / (r_soil + r_ae)
     infiltration = soil_surface_infiltration(
         bc.runoff,
-        precip .+ evaporation,
+        precip .+ conditions.vapor_flux,
         Y,
         p,
         model.parameters,
     )
     # We do not model the energy flux from infiltration
-    net_energy_flux =
-        @. R_n + conditions.lhf * r_ae / (r_soil + r_ae) + conditions.shf
+    net_energy_flux = @. R_n + conditions.lhf + conditions.shf
     return infiltration, net_energy_flux
 
 end

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -480,6 +480,34 @@ function ClimaLSM.surface_temperature(
 end
 
 """
+    ClimaLSM.surface_resistance(
+        model::EnergyHydrology{FT},
+        Y,
+        p,
+        t,
+    ) where {FT}
+
+Returns the surface resistance field of the
+`EnergyHydrology` soil model.
+"""
+function ClimaLSM.surface_resistance(
+    model::EnergyHydrology{FT},
+    Y,
+    p,
+    t,
+) where {FT}
+    return ClimaLSM.Domains.top_center_to_surface(
+        ClimaLSM.Soil.soil_resistance.(
+            p.soil.θ_l,
+            Y.soil.ϑ_l,
+            Y.soil.θ_i,
+            model.parameters,
+        ),
+    )
+end
+
+
+"""
     ClimaLSM.surface_emissivity(
         model::EnergyHydrology{FT},
         Y,

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -107,7 +107,6 @@ end
         λ_γ_PAR = FT(5e-7),
         λ_γ_NIR = FT(1.65e-6),
         n_layers = UInt64(20),
-        diff_perc = FT(0)
     ) where {FT}
 
 A constructor supplying default values for the TwoStreamParameters struct.

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -225,12 +225,6 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         dsl = Soil.dry_soil_layer_thickness.(S_l_sfc, S_c, d_ds)
         r_soil = @. dsl / (_D_vapor * τ_a) # [s\m]
         r_ae = conditions.r_ae
-        @test r_ae == @. 1 / (
-            conditions.Ch * max(
-                abs(model.boundary_conditions.top.atmos.u(t)),
-                FT(atmos.gustiness),
-            )
-        )
         expected_water_flux = @. atmos.liquid_precip(t) .+
            conditions.vapor_flux * r_ae / (r_soil + r_ae)
         @test computed_water_flux == expected_water_flux

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -237,7 +237,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     VPD = es .- ea
 
     conditions = surface_fluxes(atmos, canopy, Y, p, t0) #Per unit m^2 of leaf
-    r_ae = conditions.r_ae # s/m
+    r_ae = parent(conditions.r_ae)[1] # s/m
     ga = 1 / r_ae
     γ = FT(66)
     R = FT(LSMP.gas_constant(earth_param_set))


### PR DESCRIPTION
## Purpose 
Previously, we had accounted for the surface resistance to evaporation/vapor loss by calling a wrapper function (defined in ClimaLSM) of SurfaceFluxes functions:
https://github.com/CliMA/ClimaLSM.jl/blob/2b56772e704e4b53f2b46a7d2f7f6805ff8404a1/src/shared_utilities/drivers.jl#L149
https://github.com/CliMA/ClimaLSM.jl/blob/2b56772e704e4b53f2b46a7d2f7f6805ff8404a1/src/shared_utilities/drivers.jl#L195.
and then taking the returned LHF and E and correcting them for the surface resistance. However, we realized E shows up in the SHF as well, and this has to be corrected also.

This PR does two things:
1. Accounts for surface resistance when computing SHF as well as LHF, and E, because E appears in the SHF expression.
2. Moves the r_sfc computation inside of the surface_fluxes wrapper function, which also obtains T_sfc, q_sfc, etc. Then this function only returns the resistance-corrected SHF, LHF, and E, and does not require the correction to happen outside of the surface fluxes wrapper function.

In order to achieve the latter, we defined a new function `surface_resistance(model, ...)` which returns the surface resistance for that land component `model`. The default is zero (no additional resistance).


## To-do

## Content

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [X] I have read and checked the items on the review checklist.
