### PR TITLE
restore Float32 compatibility

### DIFF
--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -226,8 +226,8 @@ ref_time = DateTime(2005);
 # `ρ_a` (kg/m^3) at a reference height `h_a` (m).
 
 # Here we define the model drivers, starting with downward radiation.
-SW_d = (t) -> eltype(t)(300);
-LW_d = (t) -> eltype(t)(300);
+SW_d = (t) -> 300;
+LW_d = (t) -> 300;
 bucket_rad = PrescribedRadiativeFluxes(
     FT,
     SW_d,
@@ -239,15 +239,15 @@ bucket_rad = PrescribedRadiativeFluxes(
 # Prescribed atmospheric variables
 
 # Stochastic precipitation:
-precip = (t) -> eltype(t)(0);
-snow_precip = (t) -> eltype(t)(5e-7 * (t > 3 * 86400) * (t < 4 * 86400));
+precip = (t) -> 0;
+snow_precip = (t) -> 5e-7 * (t > 3 * 86400) * (t < 4 * 86400);
 # Diurnal temperature variations:
-T_atmos = (t) -> eltype(t)(275.0 + 5.0 * sin(2.0 * π * t / 86400 + 7200));
+T_atmos = (t) -> 275.0 + 5.0 * sin(2.0 * π * t / 86400 + 7200);
 # Constant otherwise:
-u_atmos = (t) -> eltype(t)(3.0);
-q_atmos = (t) -> eltype(t)(0.005);
+u_atmos = (t) -> 3.0;
+q_atmos = (t) -> 0.005;
 h_atmos = FT(2);
-P_atmos = (t) -> eltype(t)(101325);
+P_atmos = (t) -> 101325;
 bucket_atmos = PrescribedAtmosphere(
     precip,
     snow_precip,

--- a/docs/tutorials/Bucket/coupled_bucket.jl
+++ b/docs/tutorials/Bucket/coupled_bucket.jl
@@ -29,13 +29,13 @@
 
 # In a coupled simulation, this changes. As we will see, the coupler computes turbulent surface fluxes
 # based on information (prognostic state, parameters) passed to it by both the atmosphere and land models.
-# Net radiation 
+# Net radiation
 # is computed within the atmosphere model, using the prognostic land surface temperature and the land surface
 # albedo, and passed back to the land model via the coupler. Similarily, precipitation is computed within the
 # atmosphere model, and passed back to the land model via the coupler. These details are important, but from
 # the point of view of the land
 # model, we only need to know that the coupler accesses land model variables to compute fluxes,
-# and that the coupler passes these fluxes back to the land model. 
+# and that the coupler passes these fluxes back to the land model.
 
 # In our current setup, "passed back to the land model via the coupler" means that the coupler
 # accesses the auxiliary state of the land model and modifies it, at each step in the simulation, so that
@@ -86,7 +86,7 @@ function ClimaLSM.Bucket.surface_fluxes(
     model::BucketModel{FT},
     p,
     _...,
-) where {FT <: AbstractFloat}
+) where {FT}
     return (
         turbulent_energy_flux = p.bucket.turbulent_energy_flux,
         evaporation = p.bucket.evaporation,
@@ -99,11 +99,11 @@ function ClimaLSM.Bucket.net_radiation(
     model::BucketModel{FT},
     p,
     _...,
-) where {FT <: AbstractFloat}
+) where {FT}
     return p.bucket.R_n
 end
 # Essentially, these methods simply returns the values stored in the auxiliary state `p`. Importantly, these functions are
-# called by the bucket model 
+# called by the bucket model
 # each time step **after** the coupler has already computed these values
 # (or extracted them from another model) and modifed `p`!
 

--- a/docs/tutorials/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/Canopy/canopy_tutorial.jl
@@ -116,7 +116,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
 
 soil_driver = PrescribedSoil{FT}(
     root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0),
-    ψ = t -> eltype(t)(ψ_soil0),
+    ψ = t -> ψ_soil0,
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     T = t -> 298.0,
@@ -185,7 +185,7 @@ AR_model = AutotrophicRespirationModel{FT}(AR_params);
 # indices of the canopy, we choose a `PrescribedSiteAreaIndex`,
 # which supports LAI as a function of time, with RAI and SAI as constant.
 LAI = 4.2
-LAIfunction = (t) -> eltype(t)(LAI)
+LAIfunction = (t) -> LAI
 SAI = FT(0.00242)
 f_root_to_shoot = FT(3.5)
 RAI = (SAI + LAI) * f_root_to_shoot

--- a/docs/tutorials/Canopy/soil_canopy_tutorial.jl
+++ b/docs/tutorials/Canopy/soil_canopy_tutorial.jl
@@ -1,31 +1,31 @@
 # # Coupling the CliMA Canopy and Soil Hydraulics Models
 
-# In the 
+# In the
 # [`previous tutorial`](@ref https://clima.github.io/ClimaLSM.jl/dev/generated/soil_plant_hydrology_tutorial/),
-# we demonstrated how to run the canopy model in 
-# standalone mode using prescribed values for the inputs of soil hydraulics 
-# into the canopy hydraulics model. However, ClimaLSM has the built-in capacity 
-# to couple the canopy model with a soil physics model and timestep the two 
-# simulations together to model a canopy-soil system. This tutorial 
-# demonstrates how to setup and run a coupled simulation, again using 
-# initial conditions, atmospheric and radiative flux conditions, and canopy 
-# properties observed at the US-MOz flux tower, a flux tower located within an 
+# we demonstrated how to run the canopy model in
+# standalone mode using prescribed values for the inputs of soil hydraulics
+# into the canopy hydraulics model. However, ClimaLSM has the built-in capacity
+# to couple the canopy model with a soil physics model and timestep the two
+# simulations together to model a canopy-soil system. This tutorial
+# demonstrates how to setup and run a coupled simulation, again using
+# initial conditions, atmospheric and radiative flux conditions, and canopy
+# properties observed at the US-MOz flux tower, a flux tower located within an
 # oak-hickory forest in Ozark, Missouri, USA. See [Wang et al. 2021]
 # (https://doi.org/10.5194/gmd-14-6741-2021) for details on the site and
 # parameters.
 
 
-# In ClimaLSM, the coupling of the canopy and soil models is done by 
-# pairing the inputs and outputs which between the two models so that they match. 
-# For example, the root extraction of the canopy hydraulics model, which acts as a 
-# boundary flux for the plant system, is paired with a source term for root extraction in 
-# the soil model, so that the flux of water from the soil into the roots is 
-# equal and factored into both models. This pairing is done automatically in the 
-# constructor for a 
+# In ClimaLSM, the coupling of the canopy and soil models is done by
+# pairing the inputs and outputs which between the two models so that they match.
+# For example, the root extraction of the canopy hydraulics model, which acts as a
+# boundary flux for the plant system, is paired with a source term for root extraction in
+# the soil model, so that the flux of water from the soil into the roots is
+# equal and factored into both models. This pairing is done automatically in the
+# constructor for a
 # [`SoilCanopyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/ClimaLSM/#LSM-Model-Types-and-methods)
-# so that a 
-# user needs only specify the necessary arguments for each of the component 
-# models, and the two models will automatically be paired into a coupled 
+# so that a
+# user needs only specify the necessary arguments for each of the component
+# models, and the two models will automatically be paired into a coupled
 # simulation.
 
 # # Preliminary Setup
@@ -59,7 +59,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"));
 const FT = Float64;
 earth_param_set = create_lsm_parameters(FT);
 
-# - We will be using prescribed atmospheric and radiative drivers from the 
+# - We will be using prescribed atmospheric and radiative drivers from the
 #   US-MOz tower, which we read in here. We are using prescribed
 #   atmospheric and radiative flux conditions, but it is also possible to couple
 #   the simulation with atmospheric and radiative flux models. We also
@@ -74,12 +74,12 @@ include(
 
 # # Setup the Coupled Canopy and Soil Physics Model
 
-# We want to simulate the canopy-soil system together, so the model type 
+# We want to simulate the canopy-soil system together, so the model type
 # [`SoilCanopyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/ClimaLSM/#LSM-Model-Types-and-methods)
 # is chosen.
-# From the linked documentation, we see that we need to provide the soil model 
+# From the linked documentation, we see that we need to provide the soil model
 # type and arguments as well as the canopy model component types, component
-# arguments, and the canopy model arguments, so we first need to initialize 
+# arguments, and the canopy model arguments, so we first need to initialize
 # all of these.
 
 # Setup the domain for the model:
@@ -90,12 +90,12 @@ zmax = FT(0)
 land_domain = Column(; zlim = (zmin, zmax), nelements = nelements);
 
 # For our soil model, we will choose the
-# [`EnergyHydrology`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Soil/#Soil-Models-2) 
-# and set up all the necessary arguments. See the 
+# [`EnergyHydrology`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Soil/#Soil-Models-2)
+# and set up all the necessary arguments. See the
 # [tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/Soil/soil_energy_hydrology/)
 # on the model for a more detailed explanation of the soil model.
 
-# We will be using prescribed atmospheric and radiative drivers from the 
+# We will be using prescribed atmospheric and radiative drivers from the
 # US-MOz tower. We are using prescribed
 # atmospheric and radiative flux conditions, but it is also possible to couple
 # the simulation with atmospheric and radiative flux models.
@@ -107,7 +107,7 @@ include(
     ),
 );
 
-# Define the parameters for the soil model and provide them to the model 
+# Define the parameters for the soil model and provide them to the model
 # parameters struct:
 
 # Soil parameters
@@ -167,7 +167,7 @@ soil_model_type = Soil.EnergyHydrology{FT}
 
 # For the heterotrophic respiration model, see the
 # [documentation](https://clima.github.io/ClimaLSM.jl/previews/PR214/dynamicdocs/pages/soil_biogeochemistry/microbial_respiration/)
-# to understand the parameterisation. 
+# to understand the parameterisation.
 # The domain is defined similarly to the soil domain described above.
 ν = soil_ν # defined above
 θ_a100 = FT(0.1816)
@@ -211,8 +211,8 @@ soilco2_boundary_conditions =
     (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,));
 
 soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
-    Soil.Biogeochemistry.PrognosticMet(),
-    Soil.Biogeochemistry.PrescribedSOC(Csom),
+    Soil.Biogeochemistry.PrognosticMet{FT}(),
+    Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
     atmos,
 );
 
@@ -227,12 +227,12 @@ soilco2_args = (;
 # Next we need to set up the [`CanopyModel`](https://clima.github.io/ClimaLSM.jl/dev/APIs/canopy/Canopy/#Canopy-Model-Structs).
 # For more details on the specifics of this model see the previous tutorial.
 
-# Begin by declaring the component types of the canopy model. Unlike in the 
-# previous tutorial, collect the arguments to each component into tuples and do 
-# not instantiate the component models yet. The constructor for the 
-# SoilPlantHydrologyModel will use these arguments and internally instatiate the 
-# component CanopyModel and RichardsModel instances. This is done so that the 
-# constructor may enforce consistency constraints between the two models, and 
+# Begin by declaring the component types of the canopy model. Unlike in the
+# previous tutorial, collect the arguments to each component into tuples and do
+# not instantiate the component models yet. The constructor for the
+# SoilPlantHydrologyModel will use these arguments and internally instatiate the
+# component CanopyModel and RichardsModel instances. This is done so that the
+# constructor may enforce consistency constraints between the two models, and
 # this must be done internally from the constructor.
 
 canopy_component_types = (;
@@ -306,7 +306,7 @@ photosynthesis_args = (;
 f_root_to_shoot = FT(3.5)
 SAI = FT(0.00242)
 maxLAI = FT(4.2)
-K_sat_plant = 1.8e-8
+K_sat_plant = FT(1.8e-8)
 RAI = (SAI + maxLAI) * f_root_to_shoot;
 # Note: LAIfunction was determined from data in the script we included above.
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
@@ -350,7 +350,7 @@ plant_hydraulics_args = (
     compartment_surfaces = compartment_surfaces,
 );
 
-# We may now collect all of the canopy component argument tuples into one 
+# We may now collect all of the canopy component argument tuples into one
 # arguments tuple for the canopy component models.
 
 canopy_component_args = (;
@@ -373,9 +373,9 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
 canopy_domain = obtain_surface_domain(land_domain)
 canopy_model_args = (; parameters = shared_params, domain = canopy_domain);
 
-# We may now instantiate the integrated plant and soil model. In this example, 
-# we will compute transpiration diagnostically, and work with prescribed 
-# atmospheric and radiative flux conditions from the observations at the Ozark 
+# We may now instantiate the integrated plant and soil model. In this example,
+# we will compute transpiration diagnostically, and work with prescribed
+# atmospheric and radiative flux conditions from the observations at the Ozark
 # site as was done in the previous tutorial.
 
 land_input = (atmos = atmos, radiation = radiation)
@@ -391,15 +391,15 @@ land = SoilCanopyModel{FT}(;
     canopy_model_args = canopy_model_args,
 );
 
-# Now we can initialize the state vectors and model coordinates, and initialize 
-# the explicit/implicit tendencies as usual. The Richard's equation time 
-# stepping is done implicitly, while the canopy model may be explicitly stepped, 
+# Now we can initialize the state vectors and model coordinates, and initialize
+# the explicit/implicit tendencies as usual. The Richard's equation time
+# stepping is done implicitly, while the canopy model may be explicitly stepped,
 # so we use an IMEX (implicit-explicit) scheme for the combined model.
 
 Y, p, coords = initialize(land);
 exp_tendency! = make_exp_tendency(land);
 
-# We need to provide initial conditions for the soil and canopy hydraulics 
+# We need to provide initial conditions for the soil and canopy hydraulics
 # models:
 Y.soil.ϑ_l = FT(0.4)
 Y.soil.θ_i = FT(0.0)
@@ -476,9 +476,9 @@ sol = SciMLBase.solve(
 
 # # Plotting
 
-# Now that we have both a soil and canopy model incorporated together, we will 
-# show how to plot some model data demonstrating the time series produced from 
-# each of these models. As before, we may plot the GPP of the system as well 
+# Now that we have both a soil and canopy model incorporated together, we will
+# show how to plot some model data demonstrating the time series produced from
+# each of these models. As before, we may plot the GPP of the system as well
 # as transpiration showing fluxes in the canopy.
 
 daily = sol.t ./ 3600 ./ 24
@@ -525,7 +525,7 @@ Plots.plot(plt1, plt2, layout = (2, 1));
 savefig("ozark_canopy_flux_test.png");
 # ![](ozark_canopy_flux_test.png)
 
-# Now, we will plot the augmented volumetric liquid water fraction at different 
+# Now, we will plot the augmented volumetric liquid water fraction at different
 # depths in the soil over the course of the simulation.
 
 plt1 = Plots.plot(size = (500, 700));

--- a/docs/tutorials/Soil/freezing_front.jl
+++ b/docs/tutorials/Soil/freezing_front.jl
@@ -145,15 +145,17 @@ nelems = 20
 soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
 # Set the boundary conditions:
-zero_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
+zero_flux_bc = FluxBC((p, t) -> 0.0)
 function top_heat_flux(p, t)
+    FT = eltype(p.soil.T)
     p_len = ClimaCore.Spaces.nlevels(axes(p.soil.T))
     T_c = ClimaCore.Fields.level(p.soil.T, p_len)
-    return @. eltype(t)(28 * (T_c - 267.15))
+    return @. FT(28 * (T_c - 267.15))
 end
 function bottom_heat_flux(p, t)
+    FT = eltype(p.soil.T)
     T_c = ClimaCore.Fields.level(p.soil.T, 1)
-    return @. eltype(t)(-3 * (T_c - 279.85))
+    return @. FT(-3 * (T_c - 279.85))
 end
 top_heat_flux_bc = FluxBC(top_heat_flux)
 bottom_heat_flux_bc = FluxBC(bottom_heat_flux)
@@ -194,7 +196,7 @@ Y, p, coords = initialize(soil);
 
 function init_soil!(Ysoil, z, params)
     ν = params.ν
-    FT = eltype(Y.soil.ϑ_l)
+    FT = eltype(Ysoil.soil.ϑ_l)
     Ysoil.soil.ϑ_l .= FT(0.33)
     Ysoil.soil.θ_i .= FT(0.0)
     T = FT(279.85)

--- a/docs/tutorials/Soil/richards_equation.jl
+++ b/docs/tutorials/Soil/richards_equation.jl
@@ -92,7 +92,7 @@ vg_α = FT(2.6)
 vg_n = FT(2)
 hcm = vanGenuchten(; α = vg_α, n = vg_n);
 θ_r = FT(0)
-params = Soil.RichardsParameters(;
+params = Soil.RichardsParameters{FT, typeof(hcm)}(;
     ν = ν,
     hydrology_cm = hcm,
     K_sat = K_sat,
@@ -113,8 +113,8 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 # are passed as the (scalar) z-component of the flux `f`, i.e. F⃗ = f ẑ.
 # In either case, the user must pass a function of the auxiliary variables `p` and time `t`:
 
-surface_flux = Soil.FluxBC((p, t) -> eltype(t)(0.0))
-bottom_flux = Soil.FluxBC((p, t) -> eltype(t)(0.0))
+surface_flux = Soil.FluxBC((p, t) -> 0.0)
+bottom_flux = Soil.FluxBC((p, t) -> 0.0)
 boundary_conditions =
     (; top = (water = surface_flux,), bottom = (water = bottom_flux,));
 

--- a/docs/tutorials/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/Soil/soil_energy_hydrology.jl
@@ -170,12 +170,12 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 # `p` and time `t`.
 
 # Water boundary conditions:
-surface_water_flux = FluxBC((p, t) -> eltype(t)(0.0))
-bottom_water_flux = FluxBC((p, t) -> eltype(t)(0.0));
+surface_water_flux = FluxBC((p, t) -> 0.0)
+bottom_water_flux = FluxBC((p, t) -> 0.0);
 
 # The boundary conditions for the heat equation:
-surface_heat_flux = FluxBC((p, t) -> eltype(t)(0.0))
-bottom_heat_flux = FluxBC((p, t) -> eltype(t)(0.0));
+surface_heat_flux = FluxBC((p, t) -> 0.0)
+bottom_heat_flux = FluxBC((p, t) -> 0.0);
 
 # We wrap up all of those in a NamedTuple:
 boundary_fluxes = (;

--- a/docs/tutorials/Usage/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/Usage/LSM_single_column_tutorial.jl
@@ -81,7 +81,7 @@ vg_n = FT(2.0);
 vg_α = FT(2.6); # inverse meters
 hcm = vanGenuchten(; α = vg_α, n = vg_n);
 θ_r = FT(0);
-soil_ps = Soil.RichardsParameters(;
+soil_ps = Soil.RichardsParameters{FT, typeof(hcm)}(;
     ν = ν,
     hydrology_cm = hcm,
     K_sat = K_sat,
@@ -96,8 +96,8 @@ nelems = 20;
 soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
 # And boundary conditions and source terms (none currently):
-top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
+top_flux_bc = FluxBC((p, t) -> 0.0);
+bot_flux_bc = FluxBC((p, t) -> 0.0);
 sources = ()
 boundary_fluxes =
     (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
@@ -173,9 +173,9 @@ soil_ode! = make_exp_tendency(soil);
 # them inside our pond model, since again, the pond model structure
 # must contain everything needed to make the tendency function:
 
-precipitation(t::T) where {T} = t < T(20) ? -T(1e-5) : T(0.0) # m/s
+precipitation(t) = t < 20 ? -1e-5 : 0.0 # m/s
 
-infiltration(t::T) where {T} = -T(1e-6) #m/s
+infiltration(t) = -(1e-6) #m/s
 pond_model = Pond.PondModel{FT}(;
     runoff = PrescribedRunoff{FT}(precipitation, infiltration),
 );

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -96,8 +96,8 @@ soilco2_boundary_conditions =
     (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,))
 
 soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
-    Soil.Biogeochemistry.PrognosticMet(),
-    Soil.Biogeochemistry.PrescribedSOC(Csom),
+    Soil.Biogeochemistry.PrognosticMet{FT}(),
+    Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
     atmos,
 )
 

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -94,8 +94,8 @@ soilco2_boundary_conditions =
     (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,))
 
 soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
-    Soil.Biogeochemistry.PrognosticMet(),
-    Soil.Biogeochemistry.PrescribedSOC(Csom),
+    Soil.Biogeochemistry.PrognosticMet{FT}(),
+    Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
     atmos,
 )
 
@@ -332,8 +332,8 @@ model_daily_indices =
 data_per_model = Int64(dt * n ÷ DATA_DT)
 
 # This function will be used to compute averages over diurnal cycles. Input a
-# data series to average over and the total number of days in the data series, 
-# and it will return a vector of the average value at each timestamp in the 
+# data series to average over and the total number of days in the data series,
+# and it will return a vector of the average value at each timestamp in the
 # day averaged over every day in the series.
 function diurnal_avg(series)
     num_days = Int64(N_days - N_spinup_days)

--- a/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
+++ b/experiments/integrated/ozark/ozark_met_drivers_FLUXNET.jl
@@ -106,8 +106,12 @@ atmos_u = Spline1D(seconds, WS[:])
 LW_IN_spline = Spline1D(seconds, LW_IN[:])
 SW_IN_spline = Spline1D(seconds, SW_IN[:])
 atmos_h = FT(32)
-precipitation_function(t::FT) where {FT} = p_spline(t) < 0.0 ? p_spline(t) : 0.0 # m/s
-snow_precip(t) = eltype(t)(0) # this is likely not correct
+
+function precipitation_function(t)
+    spline = p_spline(t)
+    spline < 0 ? spline : 0 # m/s
+end
+snow_precip(t) = 0 # this is likely not correct
 
 
 # Construct the drivers. For the reference time we will use the UTC time at the
@@ -174,4 +178,4 @@ LAI_column_names = LAI_data[1, :]
 LAI_data = LAI_data[2:end, LAI_column_names .== "lai_mean"] #m2.m-2
 # This has the same timestamp as the driver data, so it's ok to use the time column from that file here
 LAIspline = Spline1D(seconds, LAI_data[:])
-LAIfunction = (t) -> eltype(t)(LAIspline(t))
+LAIfunction = (t) -> LAIspline(t)

--- a/experiments/integrated/vaira_ranch/vaira.jl
+++ b/experiments/integrated/vaira_ranch/vaira.jl
@@ -105,8 +105,8 @@ soilco2_boundary_conditions =
     (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,))
 
 soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
-    Soil.Biogeochemistry.PrognosticMet(),
-    Soil.Biogeochemistry.PrescribedSOC(Csom),
+    Soil.Biogeochemistry.PrognosticMet{FT}(),
+    Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
     atmos,
 )
 
@@ -332,8 +332,8 @@ model_daily_indices =
 data_per_model = Int64(dt * n ÷ DATA_DT)
 
 # This function will be used to compute averages over diurnal cycles. Input a
-# data series to average over and the total number of days in the data series, 
-# and it will return a vector of the average value at each timestamp in the 
+# data series to average over and the total number of days in the data series,
+# and it will return a vector of the average value at each timestamp in the
 # day averaged over every day in the series.
 function diurnal_avg(series)
     num_days = Int64(N_days - N_days_spinup)

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -61,11 +61,11 @@ nelems = 20
 
 lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
 
-top_flux_bc_w = Soil.FluxBC((p, t) -> eltype(t)(-0.00001))
+top_flux_bc_w = Soil.FluxBC((p, t) -> -0.00001)
 bot_flux_bc_w = Soil.FreeDrainage()
 
-top_flux_bc_h = Soil.FluxBC((p, t) -> eltype(t)(0.0))
-bot_flux_bc_h = Soil.FluxBC((p, t) -> eltype(t)(0.0))
+top_flux_bc_h = Soil.FluxBC((p, t) -> 0.0)
+bot_flux_bc_h = Soil.FluxBC((p, t) -> 0.0)
 
 
 sources = (PhaseChange{FT}(Δz),)
@@ -81,15 +81,15 @@ soil_args = (;
 )
 
 # Make biogeochemistry model args
-Csom = (z, t) -> eltype(t)(5.0)
+Csom = (z, t) -> 5.0
 
 co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
     earth_param_set = earth_param_set,
 )
 C = FT(100)
 
-co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> eltype(t)(0.0))
-co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> eltype(t)(0.0))
+co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)
+co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)
 co2_sources = (MicrobeProduction{FT}(),)
 co2_boundary_conditions =
     (; top = (CO2 = co2_top_bc,), bottom = (CO2 = co2_bot_bc,))
@@ -118,8 +118,8 @@ atmos = ClimaLSM.PrescribedAtmosphere(
 )
 
 soil_drivers = Soil.Biogeochemistry.SoilDrivers(
-    Soil.Biogeochemistry.PrognosticMet(),
-    Soil.Biogeochemistry.PrescribedSOC(Csom),
+    Soil.Biogeochemistry.PrognosticMet{FT}(),
+    Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
     atmos,
 )
 

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -59,8 +59,8 @@ z_0m = 5e-4
 z_0b = 1e-5
 
 ref_time = DateTime(2005)
-SW_d = (t) -> eltype(t)(0)
-LW_d = (t) -> eltype(t)(301.15^4 * 5.67e-8)
+SW_d = (t) -> 0
+LW_d = (t) -> 301.15^4 * 5.67e-8
 radiation = PrescribedRadiativeFluxes(
     FT,
     SW_d,
@@ -78,12 +78,12 @@ esat = Thermodynamics.saturation_vapor_pressure(
 )
 e = rh * esat
 q = FT(0.622 * e / (101325 - 0.378 * e))
-precip = (t) -> eltype(t)(0.0)
-T_atmos = (t) -> eltype(t)(T_air)
-u_atmos = (t) -> eltype(t)(1)
-q_atmos = (t) -> eltype(t)(q)
+precip = (t) -> 0.0
+T_atmos = (t) -> T_air
+u_atmos = (t) -> 1
+q_atmos = (t) -> q
 h_atmos = FT(0.1)
-P_atmos = (t) -> eltype(t)(101325)
+P_atmos = (t) -> 101325
 gustiness = FT(1e-2)
 atmos = PrescribedAtmosphere(
     precip,
@@ -97,7 +97,7 @@ atmos = PrescribedAtmosphere(
     gustiness = gustiness,
 )
 top_bc = ClimaLSM.Soil.AtmosDrivenFluxBC(atmos, radiation)
-zero_flux = FluxBC((p, t) -> eltype(t)(0.0))
+zero_flux = FluxBC((p, t) -> 0)
 boundary_fluxes =
     (; top = top_bc, bottom = (water = zero_flux, heat = zero_flux))
 params = ClimaLSM.Soil.EnergyHydrologyParameters{FT}(;
@@ -138,7 +138,7 @@ soil = Soil.EnergyHydrology{FT}(;
 Y, p, cds = initialize(soil) # begins saturated
 function init_soil!(Y, z, params)
     ν = params.ν
-    FT = typeof(ν)
+    FT = eltype(ν)
     Y.soil.ϑ_l .= ν - 1e-2
     Y.soil.θ_i .= 0
     T = FT(301.15)

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -31,7 +31,7 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
     z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
 
-    top_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν - 1e-3))
+    top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
     bot_flux_bc = FreeDrainage()
     sources = ()
     boundary_states =
@@ -124,7 +124,7 @@ end
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
     z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
 
-    top_state_bc = MoistureStateBC((p, t) -> eltype(t)(0.267))
+    top_state_bc = MoistureStateBC((p, t) -> 0.267)
     bot_flux_bc = FreeDrainage()
     sources = ()
     boundary_states =

--- a/experiments/standalone/Soil/water_conservation.jl
+++ b/experiments/standalone/Soil/water_conservation.jl
@@ -72,9 +72,9 @@ sources = ()
 
 # Set flux boundary conditions (used for calculating mass balance)
 flux_in = FT(-1e-7)
-top_bc = Soil.FluxBC((p, t) -> eltype(t)(flux_in))
+top_bc = Soil.FluxBC((p, t) -> flux_in)
 flux_out = FT(0)
-bot_bc = Soil.FluxBC((p, t) -> eltype(t)(flux_out))
+bot_bc = Soil.FluxBC((p, t) -> flux_out)
 
 boundary_fluxes = (; top = (water = top_bc,), bottom = (water = bot_bc,))
 
@@ -174,9 +174,9 @@ Plots.savefig(joinpath(savedir, "water_conservation_flux.png"))
 
 
 # Perform simulation with Dirichlet boundary conditions
-top_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν - 1e-3))
+top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
 flux_out = FT(0)
-bot_flux_bc = Soil.FluxBC((p, t) -> eltype(t)(flux_out))
+bot_flux_bc = Soil.FluxBC((p, t) -> flux_out)
 boundary_conds =
     (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
 
@@ -290,5 +290,6 @@ Plots.savefig(joinpath(savedir, "water_conservation_dirichlet.png"))
 # Uncomment to recreate Dirichlet BC reference solution artifact (using small dt)
 # soln_file_dirichlet = joinpath(savedir, "ref_soln_dirichlet.csv")
 # open((soln_file_dirichlet), "w") do io
+#     writedlm(io, parent(sol.u[end].soil.ϑ_l), ',')
 #     writedlm(io, parent(sol.u[end].soil.ϑ_l), ',')
 # end

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -53,7 +53,7 @@ Returns a NamedTuple of the unique set of coordinates for the LSM
 `model`, where the unique set is taken over the coordinates of all
 of the subcomponents.
 
-For example, an LSM with a single layer snow model, multi-layer 
+For example, an LSM with a single layer snow model, multi-layer
 soil model, and canopy model would have a coordinate set corresponding
 to the coordinates of the surface (snow), the subsurface coordinates (soil)
 and the coordinates of the surface (canopy). This would return the coordinates

--- a/src/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/src/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -7,7 +7,7 @@ export LandSoilBiogeochemistry, PrognosticMet
         SB <: Soil.Biogeochemistry.SoilCO2Model{FT},
     } <: AbstractLandModel{FT}
 
-A concrete type of land model used for simulating systems with a 
+A concrete type of land model used for simulating systems with a
 soil energy, hydrology, and biogeochemistry component.
 $(DocStringExtensions.FIELDS)"""
 struct LandSoilBiogeochemistry{
@@ -47,10 +47,10 @@ function LandSoilBiogeochemistry{FT}(;
     )
 
     soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(; soilco2_args...)
-    if typeof(soilco2_args.drivers.met) != PrognosticMet
+    if !(soilco2_args.drivers.met isa PrognosticMet)
         throw(
             AssertionError(
-                "To run with a prognostic soil energy and hydrology model, the met driver must be of type PrognosticSoil.",
+                "To run with a prognostic soil energy and hydrology model, the met driver must be of type PrognosticMet.",
             ),
         )
     end
@@ -66,7 +66,7 @@ function LandSoilBiogeochemistry{FT}(;
     return LandSoilBiogeochemistry{FT, typeof.(args)...}(args...)
 end
 
-struct PrognosticMet <: Soil.Biogeochemistry.AbstractSoilDriver end
+struct PrognosticMet{FT} <: Soil.Biogeochemistry.AbstractSoilDriver{FT} end
 
 """
     soil_temperature(driver::PrognosticSoil, p, Y, t, z)

--- a/src/shared_utilities/FileReader.jl
+++ b/src/shared_utilities/FileReader.jl
@@ -123,11 +123,11 @@ objects if we're reading in data over time for multiple variables.
 
 # Inputs:
 - date_ref::D    # a reference date before or at the start of the simulation
-- t_start::FT    # time in seconds since `date_ref`
+- t_start        # time in seconds since `date_ref`
 """
-struct SimInfo{D, FT}
+struct SimInfo{D}
     date_ref::D
-    t_start::FT
+    t_start::Any
 end
 
 """
@@ -154,7 +154,7 @@ end
 
 
 """
-    PrescribedDataTemporal(
+    PrescribedDataTemporal{FT}(
         regrid_dirpath,
         infile_path,
         varname,
@@ -162,7 +162,7 @@ end
         t_start,
         surface_space;
         mono = true,
-    )
+    ) where {FT <: AbstractFloat}
 
 Constructor for the `PrescribedDataTemporal` type.
 Regrids from the input lat-lon grid to the simulation cgll grid, saving
@@ -182,15 +182,15 @@ data packaged into a single `PrescribedDataTemporal` struct.
 # Returns
 - `PrescribedDataTemporal` object
 """
-function PrescribedDataTemporal(
+function PrescribedDataTemporal{FT}(
     regrid_dirpath::String,
     infile_path::String,
     varname::String,
     date_ref::Union{DateTime, DateTimeNoLeap},
-    t_start::FT,
+    t_start,
     surface_space::Spaces.AbstractSpace;
     mono::Bool = true,
-) where {FT}
+) where {FT <: AbstractFloat}
     comms_ctx = surface_space.topology.context
     outfile_root = varname * "_cgll"
 
@@ -240,7 +240,8 @@ function PrescribedDataTemporal(
     file_state = FileState(data_fields, copy(date_idx0), segment_length)
     sim_info = SimInfo(date_ref, t_start)
 
-    return PrescribedDataTemporal(file_info, file_state, sim_info)
+    args = (file_info, file_state, sim_info)
+    return PrescribedDataTemporal{typeof.(args)...}(args...)
 end
 
 """

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -85,16 +85,12 @@ end
 
 
 """
-      dss!(Y::ClimaCore.Fields.FieldVector, p::NamedTuple, t::FT)
+      dss!(Y::ClimaCore.Fields.FieldVector, p::NamedTuple, t)
 
 Computes the weighted direct stiffness summation and updates `Y` in place.
 In the case of a column domain, no dss operations are performed.
 """
-function dss!(
-    Y::ClimaCore.Fields.FieldVector{FT},
-    p::NamedTuple,
-    t::FT,
-) where {FT}
+function dss!(Y::ClimaCore.Fields.FieldVector, p::NamedTuple, t)
     for key in propertynames(Y)
         property = getproperty(Y, key)
         dss_helper!(property, axes(property), p)

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -141,7 +141,7 @@ end
     BulkAlbedoTemporal{FT}(
         regrid_dirpath::String,
         date_ref::Union{DateTime, DateTimeNoLeap},
-        t_start::FT,
+        t_start,
         Space::ClimaCore.Spaces.AbstractSpace;
         infile_path = Bucket.cesm2_albedo_dataset_path(),
         varname = "sw_alb"
@@ -156,7 +156,7 @@ should be used.
 function BulkAlbedoTemporal{FT}(
     regrid_dirpath::String,
     date_ref::Union{DateTime, DateTimeNoLeap},
-    t_start::FT,
+    t_start,
     space::ClimaCore.Spaces.AbstractSpace;
     infile_path = Bucket.cesm2_albedo_dataset_path(),
     varname = "sw_alb",
@@ -174,7 +174,7 @@ function BulkAlbedoTemporal{FT}(
     end
 
     # Construct object containing info to read in surface albedo over time
-    data_info = PrescribedDataTemporal(
+    data_info = PrescribedDataTemporal{FT}(
         regrid_dirpath,
         infile_path,
         varname,

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -55,13 +55,13 @@ a helper function which computes and returns the surface air density for the buc
 model.
 """
 function ClimaLSM.surface_air_density(
-    atmos::PrescribedAtmosphere,
+    atmos::PrescribedAtmosphere{FT},
     model::BucketModel,
     Y,
     p,
     t,
     T_sfc,
-)
+) where {FT}
     thermo_params =
         LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
     ts_in = construct_atmos_ts(atmos, t, thermo_params)
@@ -69,7 +69,7 @@ function ClimaLSM.surface_air_density(
 end
 
 """
-    ClimaLSM.surface_temperature(model::BucketModel, Y, p)
+    ClimaLSM.surface_evaporative_scaling(model::BucketModel, Y, p)
 
 a helper function which computes and returns the surface evaporative scaling
  factor for the bucket model.

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -30,13 +30,13 @@ struct SnowParameters{FT <: AbstractFloat, PSE}
     "Thermal conductivity of ice (W/m/K)"
     κ_ice::FT
     "Timestep of the model"
-    Δt::FT
+    Δt::Any
     "Clima-wide parameters"
     earth_param_set::PSE
 end
 
 """
-   SnowParameters{FT}(Δt::FT;
+   SnowParameters{FT}(Δt;
                       ρ_snow = FT(200),
                       z_0m = FT(0.0024),
                       z_0b = FT(0.00024),
@@ -52,7 +52,7 @@ An outer constructor for `SnowParameters` which supplies defaults for
 all arguments but `earth_param_set`.
 """
 function SnowParameters{FT}(
-    Δt::FT;
+    Δt;
     ρ_snow = FT(200),
     z_0m = FT(0.0024),
     z_0b = FT(0.00024),
@@ -63,7 +63,7 @@ function SnowParameters{FT}(
     fS_c = FT(0.2),
     κ_ice = FT(2.21),
     earth_param_set::PSE,
-) where {FT, PSE}
+) where {FT <: AbstractFloat, PSE}
     return SnowParameters{FT, PSE}(
         ρ_snow,
         z_0m,

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -74,8 +74,8 @@ end
                           c_s::FT,
                           parameters::SnowParameters{FT}) where {FT}
 
-Computes the bulk snow temperature from the snow water equivalent SWE, 
-energy per unit area U, liquid water mass fraction q_l, and specific heat 
+Computes the bulk snow temperature from the snow water equivalent SWE,
+energy per unit area U, liquid water mass fraction q_l, and specific heat
 capacity c_s, along with other needed parameters.
 
 If there is no snow (U = SWE = 0), the bulk temperature is the reference temperature,
@@ -156,12 +156,12 @@ function maximum_liquid_mass_fraction(
 end
 
 """
-    runoff_timescale(z::FT, Ksat::FT, Δt::FT) where {FT}
+    runoff_timescale(z::FT, Ksat::FT, Δt) where {FT}
 
 Computes the timescale for liquid water to percolate and leave the snowpack,
 given the depth of the snowpack z and the hydraulic conductivity Ksat.
 """
-function runoff_timescale(z::FT, Ksat::FT, Δt::FT) where {FT}
+function runoff_timescale(z::FT, Ksat::FT, Δt) where {FT}
     τ = max(Δt, z / Ksat)
     return τ
 end

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -82,7 +82,7 @@ function EnergyHydrologyParameters{FT}(;
     z_0b = FT(0.01),
     d_ds = FT(0.015),
     earth_param_set::PSE,
-) where {FT <: AbstractFloat, PSE, C <: AbstractSoilHydrologyClosure}
+) where {FT, PSE, C <: AbstractSoilHydrologyClosure}
     # These were determined in the Balland and Arp paper, from 2003.
     α = FT(0.24)
     β = FT(18.3)
@@ -129,7 +129,7 @@ in a porous medium by solving the Richardson-Richards equation
 and the heat equation, including terms for phase change.
 
 A variety of boundary condition types are supported, including
-FluxBC, MoistureStateBC/TemperatureStateBC, 
+FluxBC, MoistureStateBC/TemperatureStateBC,
 FreeDrainage (only for the bottom of the domain),
 and an AtmosDrivenFluxBC (under which radiative fluxes and
 turbulent surface fluxes are computed and used as boundary conditions).
@@ -280,7 +280,7 @@ end
 
 Updates dY in place by adding in the tendency terms resulting from
 horizontal derivative operators for the `EnergyHydrology` model,
- in the case of a hybrid box or 
+ in the case of a hybrid box or
 spherical shell domain with the model
 `lateral_flag` set to true.
 
@@ -570,7 +570,6 @@ function ClimaLSM.surface_air_density(
     t,
     T_sfc,
 ) where {FT}
-
     thermo_params =
         LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
     ts_in = construct_atmos_ts(atmos, t, thermo_params)

--- a/src/standalone/SurfaceWater/Pond.jl
+++ b/src/standalone/SurfaceWater/Pond.jl
@@ -38,7 +38,7 @@ end
 
 function PondModel{FT}(;
     domain::ClimaLSM.Domains.AbstractDomain{FT} = ClimaLSM.Domains.Point(
-        z_sfc = 0.0,
+        z_sfc = FT(0),
     ),
     runoff::AbstractSurfaceRunoff{FT},
 ) where {FT}
@@ -47,7 +47,7 @@ end
 
 
 """
-    PrescribedRunoff <:  AbstractSurfaceRunoff
+    PrescribedRunoff{FT} <:  AbstractSurfaceRunoff{FT}
 
 The required input for driving the simple pond model: precipitation, as a
 function of time, soil effective saturation at a depth `Δz` below the surface,
@@ -75,7 +75,7 @@ end
 
 # Runoff > 0 -> into river system.
 function surface_runoff(runoff::PrescribedRunoff{FT}, Y, p, t) where {FT}
-    return -(runoff.precip(t) - runoff.infil(t))
+    return @. -FT((runoff.precip(t) - runoff.infil(t)))
 end
 
 end

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -82,10 +82,10 @@ fluxes.
 (of type `PrescribedRadiativeFluxes`) or computed via a coupled simulation
 (of type `CoupledRadiativeFluxes`).
 - The soil conditions, which are either prescribed (of type PrecribedSoil, for
-running the canopy model in standalone mode), or prognostic (of type 
+running the canopy model in standalone mode), or prognostic (of type
 PrognosticSoil, for running integrated soil+canopy models)
 
-Note that the canopy height is specified as part of the 
+Note that the canopy height is specified as part of the
 PlantHydraulicsModel, along with the area indices of the leaves, roots, and
 stems. Eventually, when plant biomass becomes a prognostic variable (by
 integrating with a carbon model), some parameters specified here will be
@@ -332,7 +332,7 @@ Returns the set_initial_aux_state! function, which updates the auxiliary
 state `p` in place with the initial values corresponding to Y(t=t0) = Y0.
 
 In this case, we also use this method to update the initial values for the
-spatially and temporally varying canopy parameter fields, 
+spatially and temporally varying canopy parameter fields,
 read in from data files or otherwise prescribed.
 """
 function ClimaLSM.make_set_initial_aux_state(model::CanopyModel)
@@ -345,7 +345,7 @@ function ClimaLSM.make_set_initial_aux_state(model::CanopyModel)
 end
 
 """
-     ClimaLSM.make_update_aux(canopy::CanopyModel{FT, 
+     ClimaLSM.make_update_aux(canopy::CanopyModel{FT,
                                                   <:AutotrophicRespirationModel,
                                                   <:Union{BeerLambertModel, TwoStreamModel},
                                                   <:FarquharModel,
@@ -405,7 +405,7 @@ function ClimaLSM.make_update_aux(
         ϑ_l = Y.canopy.hydraulics.ϑ_l
         fa = p.canopy.hydraulics.fa
 
-        #unpack parameters         
+        #unpack parameters
         area_index = p.canopy.hydraulics.area_index
         LAI = area_index.leaf
         RAI = area_index.root

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -315,7 +315,7 @@ function ClimaLSM.Canopy.update_canopy_prescribed_field!(
     t,
 ) where {FT}
     (; LAIfunction) = component.parameters.ai_parameterization
-    @. p.canopy.hydraulics.area_index.leaf = LAIfunction(t)
+    @. p.canopy.hydraulics.area_index.leaf = FT(LAIfunction(t))
 end
 
 
@@ -519,14 +519,16 @@ zero because they are scaled by AI.
 To prevent dividing by zero, we change AI/(AI x dz)" to
 "AI/max(AI x dz, eps(FT))"
 """
-function make_compute_exp_tendency(model::PlantHydraulicsModel, canopy)
+function make_compute_exp_tendency(
+    model::PlantHydraulicsModel{FT},
+    canopy,
+) where {FT}
     function compute_exp_tendency!(dY, Y, p, t)
         area_index = p.canopy.hydraulics.area_index
         n_stem = model.n_stem
         n_leaf = model.n_leaf
         fa = p.canopy.hydraulics.fa
         fa_roots = p.canopy.hydraulics.fa_roots
-        FT = eltype(t)
 
         # Inside of a loop, we need to use a single dollar sign
         # for indexing into Fields of Tuples in non broadcasted
@@ -566,8 +568,8 @@ end
         model::PlantHydraulicsModel{FT},
         Y::ClimaCore.Fields.FieldVector,
         p::NamedTuple,
-        t::FT,
-    )::FT where {FT}
+        t,
+    ) where {FT}
 
 A method which computes the water flux between the soil and the stem, via the roots,
 and multiplied by the RAI, in the case of a model running without an integrated
@@ -582,7 +584,7 @@ function root_water_flux_per_ground_area!(
     model::PlantHydraulicsModel{FT},
     Y::ClimaCore.Fields.FieldVector,
     p::NamedTuple,
-    t::FT,
+    t,
 ) where {FT}
 
     (; conductivity_model, root_distribution) = model.parameters
@@ -646,7 +648,7 @@ end
         transpiration::PrescribedTranspiration{FT},
         Y,
         p,
-        t::FT,
+        t,
     )::FT where {FT}
 
 A method which computes the transpiration in meters/sec between the leaf
@@ -660,9 +662,9 @@ function transpiration_per_ground_area(
     transpiration::PrescribedTranspiration{FT},
     _,
     _,
-    t::FT,
+    t,
 )::FT where {FT}
-    return transpiration.T(t) # (m/s)
+    return FT(transpiration.T(t)) # (m/s)
 end
 
 """

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -27,7 +27,7 @@ end
                           model::CanopyModel,
                           Y,
                           p,
-                          t::FT) where {FT}
+                          t) where {FT}
 
 Computes canopy transpiration using Monin-Obukhov Surface Theory,
 the prescribed atmospheric conditions, and the canopy conductance.
@@ -37,12 +37,12 @@ function canopy_turbulent_surface_fluxes(
     model::CanopyModel,
     Y,
     p,
-    t::FT,
+    t,
 ) where {FT}
     conditions = surface_fluxes(atmos, model, Y, p, t)
     # We upscaled LHF and E from leaf level to canopy level via the
     # upscaling of stomatal conductance.
-    # Do we need to upscale SHF? 
+    # Do we need to upscale SHF?
     return conditions.vapor_flux,
     conditions.shf,
     conditions.lhf,

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -22,7 +22,7 @@ ClimaLSM.auxiliary_domain_names(model::AbstractCanopyEnergyModel) =
 
 A model for the energy of the canopy which assumes the canopy temperature
 is the same as the atmosphere temperature prescribed in the
-`PrescribedAtmos` struct. 
+`PrescribedAtmos` struct.
 
 No equation for the energy of the canopy is solved.
 """
@@ -31,12 +31,19 @@ struct PrescribedCanopyTempModel{FT} <: AbstractCanopyEnergyModel{FT} end
 """
     canopy_temperature(model::PrescribedCanopyTempModel, canopy, Y, p, t)
 
-Returns the canopy temperature under the `PrescribedCanopyTemp` model, 
+Returns the canopy temperature under the `PrescribedCanopyTemp` model,
 where the canopy temperature is assumed to be the same as the atmosphere
 temperature.
 """
-canopy_temperature(model::PrescribedCanopyTempModel, canopy, Y, p, t) =
-    canopy.atmos.T(t)
+function canopy_temperature(
+    model::PrescribedCanopyTempModel{FT},
+    canopy,
+    Y,
+    p,
+    t,
+) where {FT}
+    FT.(canopy.atmos.T(t))
+end
 
 ## Prognostic Canopy Temperature
 """
@@ -69,7 +76,7 @@ ClimaLSM.prognostic_domain_names(model::BigLeafEnergyModel) = (:surface,)
 """
     canopy_temperature(model::BigLeafEnergyModel, canopy, Y, p, t)
 
-Returns the canopy temperature under the `BigLeafEnergyModel` model, 
+Returns the canopy temperature under the `BigLeafEnergyModel` model,
 where the canopy temperature is modeled prognostically.
 """
 canopy_temperature(model::BigLeafEnergyModel, canopy, Y, p, t) =
@@ -112,20 +119,20 @@ end
         model::AbstractCanopyEnergyModel{FT},
         Y::ClimaCore.Fields.FieldVector,
         p::NamedTuple,
-        t::FT,
+        t,
     ) where {FT}
 
 
 A method which updates the ClimaCore.Fields.Field `fa_energy` in place
 with  the energy flux associated with the root-soil
 water flux for the `CanopyModel` run in standalone mode,
-with a `PrescribedSoil` model.This value is ignored and set to zero 
-in this case. 
+with a `PrescribedSoil` model.This value is ignored and set to zero
+in this case.
 
-Background information: This energy 
+Background information: This energy
 flux is not typically included in land surface
-models. We account for it when the soil model is prognostic because 
-the soil model includes the energy in the soil water in its energy 
+models. We account for it when the soil model is prognostic because
+the soil model includes the energy in the soil water in its energy
 balance; therefore, in order to conserve energy, the canopy model
 must account for it as well.
 """
@@ -135,7 +142,7 @@ function root_energy_flux_per_ground_area!(
     model::AbstractCanopyEnergyModel{FT},
     Y::ClimaCore.Fields.FieldVector,
     p::NamedTuple,
-    t::FT,
+    t,
 ) where {FT}
     fa_energy .= FT(0)
 end

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -33,7 +33,7 @@ end
 
 """
     function BeerLambertParameters{FT}(;
-        ld = FT(0.5),    
+        ld = FT(0.5),
         α_PAR_leaf = FT(0.1),
         α_NIR_leaf = FT(0.4),
         ϵ_canopy = FT(0.98),
@@ -146,7 +146,7 @@ end
 
 """
     compute_PAR(
-        model::AbstractRadiationModel,
+        model::{FT}},
         solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
         t,
     )
@@ -157,17 +157,17 @@ for a radiative transfer model.
 The estimated PAR is half of the incident shortwave radiation.
 """
 function compute_PAR(
-    model::AbstractRadiationModel,
-    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+    model::AbstractRadiationModel{FT},
+    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes{FT},
     t,
-)
-    return solar_radiation.SW_d(t) / 2
+) where {FT}
+    return FT(solar_radiation.SW_d(t) / 2)
 end
 
 """
     compute_NIR(
-        model::AbstractRadiationModel,
-        solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+        model::AbstractRadiationModel{FT},
+        solar_radiation::ClimaLSM.PrescribedRadiativeFluxes{FT},
         t,
     )
 
@@ -177,11 +177,11 @@ for a radiative transfer model.
 The estimated PNIR is half of the incident shortwave radiation.
 """
 function compute_NIR(
-    model::AbstractRadiationModel,
-    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+    model::AbstractRadiationModel{FT},
+    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes{FT},
     t,
-)
-    return solar_radiation.SW_d(t) / 2
+) where {FT}
+    return FT(solar_radiation.SW_d(t) / 2)
 end
 
 # Make radiation models broadcastable
@@ -250,7 +250,7 @@ function canopy_radiant_energy_fluxes!(
         (energy_per_photon_NIR * N_a * ANIR)
 
     # Long wave: use soil conditions from the PrescribedSoil driver
-    T_soil = s.T(t)
+    T_soil::FT = s.T(t)
     ϵ_soil = s.ϵ
     _σ = FT(LSMP.Stefan(earth_param_set))
     LW_d::FT = canopy.radiation.LW_d(t)

--- a/src/standalone/Vegetation/soil_drivers.jl
+++ b/src/standalone/Vegetation/soil_drivers.jl
@@ -38,16 +38,16 @@ end
          ϵ::FT
      ) where {FT}
 
-An outer constructor for the PrescribedSoil soil driver allowing the user to 
+An outer constructor for the PrescribedSoil soil driver allowing the user to
 specify the soil parameters by keyword arguments.
 """
 function PrescribedSoil{FT}(;
     root_depths::Vector{FT} = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0),
-    ψ::Function = t -> eltype(t)(FT(0.0)),
+    ψ::Function = t -> 0.0,
     T::Function = t -> 298.0,
-    α_PAR = FT(0.2),
-    α_NIR = FT(0.4),
-    ϵ = FT(0.99),
+    α_PAR::FT = FT(0.2),
+    α_NIR::FT = FT(0.4),
+    ϵ::FT = FT(0.99),
 ) where {FT}
     return PrescribedSoil{FT}(root_depths, ψ, T, α_PAR, α_NIR, ϵ)
 end

--- a/test/integrated/lsms.jl
+++ b/test/integrated/lsms.jl
@@ -18,152 +18,156 @@ import ClimaLSM:
     land_components
 using ClimaLSM
 
-@testset "LSM prognostic tests" begin
-
-    struct DummyModel1{FT} <: ClimaLSM.AbstractModel{FT}
-        domain::Any
-    end
-    ClimaLSM.name(::DummyModel1) = :m1
-    ClimaLSM.prognostic_vars(::DummyModel1) = (:a,)
-    ClimaLSM.prognostic_types(::DummyModel1{FT}) where {FT} = (FT,)
-    ClimaLSM.prognostic_domain_names(::DummyModel1) = (:surface,)
-    ClimaLSM.auxiliary_vars(::DummyModel1) = (:b,)
-    ClimaLSM.auxiliary_types(::DummyModel1{FT}) where {FT} = (FT,)
-    ClimaLSM.auxiliary_domain_names(::DummyModel1) = (:surface,)
-    struct DummyModel2{FT} <: ClimaLSM.AbstractModel{FT}
-        domain::Any
-    end
-
-    ClimaLSM.name(::DummyModel2) = :m2
-    ClimaLSM.prognostic_vars(::DummyModel2) = (:c, :d)
-    ClimaLSM.prognostic_types(::DummyModel2{FT}) where {FT} = (FT, FT)
-    ClimaLSM.prognostic_domain_names(::DummyModel2) = (:surface, :subsurface)
-
-    struct DummyModel{FT} <: ClimaLSM.AbstractLandModel{FT}
-        m1::Any
-        m2::Any
-    end
-    ClimaLSM.land_components(::DummyModel) = (:m1, :m2)
-    ClimaLSM.interaction_vars(::DummyModel) = (:i1,)
-    ClimaLSM.interaction_types(::DummyModel{FT}) where {FT} = (FT,)
-    ClimaLSM.interaction_domain_names(::DummyModel) = (:surface,)
-
-
-
-    function ClimaLSM.make_update_aux(::DummyModel1{FT}) where {FT}
-        function update_aux!(p, Y, t)
-            p.m1.b .= FT(10.0)
+for FT in (Float32, Float64)
+    @testset "LSM prognostic tests, FT = $FT" begin
+        struct DummyModel1{FT} <: ClimaLSM.AbstractModel{FT}
+            domain::Any
         end
-        return update_aux!
-    end
-
-    function ClimaLSM.make_interactions_update_aux(::DummyModel{FT}) where {FT}
-        function update_aux!(p, Y, t)
-            p.i1 .= FT(5.0)
+        ClimaLSM.name(::DummyModel1) = :m1
+        ClimaLSM.prognostic_vars(::DummyModel1) = (:a,)
+        ClimaLSM.prognostic_types(::DummyModel1{FT}) where {FT} = (FT,)
+        ClimaLSM.prognostic_domain_names(::DummyModel1) = (:surface,)
+        ClimaLSM.auxiliary_vars(::DummyModel1) = (:b,)
+        ClimaLSM.auxiliary_types(::DummyModel1{FT}) where {FT} = (FT,)
+        ClimaLSM.auxiliary_domain_names(::DummyModel1) = (:surface,)
+        struct DummyModel2{FT} <: ClimaLSM.AbstractModel{FT}
+            domain::Any
         end
-        return update_aux!
-    end
 
-    function ClimaLSM.make_compute_exp_tendency(::DummyModel1{FT}) where {FT}
-        function compute_exp_tendency!(dY, Y, p, t)
-            dY.m1.a .= p.m1.b
+        ClimaLSM.name(::DummyModel2) = :m2
+        ClimaLSM.prognostic_vars(::DummyModel2) = (:c, :d)
+        ClimaLSM.prognostic_types(::DummyModel2{FT}) where {FT} = (FT, FT)
+        ClimaLSM.prognostic_domain_names(::DummyModel2) =
+            (:surface, :subsurface)
+
+        struct DummyModel{FT} <: ClimaLSM.AbstractLandModel{FT}
+            m1::Any
+            m2::Any
         end
-        return compute_exp_tendency!
-    end
+        ClimaLSM.land_components(::DummyModel) = (:m1, :m2)
+        ClimaLSM.interaction_vars(::DummyModel) = (:i1,)
+        ClimaLSM.interaction_types(::DummyModel{FT}) where {FT} = (FT,)
+        ClimaLSM.interaction_domain_names(::DummyModel) = (:surface,)
 
-    function ClimaLSM.make_compute_exp_tendency(::DummyModel2{FT}) where {FT}
-        function compute_exp_tendency!(dY, Y, p, t)
-            dY.m2.c .= p.i1
-            dY.m2.d .= FT(-1.0)
+
+
+        function ClimaLSM.make_update_aux(::DummyModel1{FT}) where {FT}
+            function update_aux!(p, Y, t)
+                p.m1.b .= FT(10.0)
+            end
+            return update_aux!
         end
-        return compute_exp_tendency!
-    end
-    FT = Float32
-    d = ClimaLSM.Domains.Column(; zlim = (FT(-2), FT(0)), nelements = 5)
-    m1 = DummyModel1{FT}(d)
-    m2 = DummyModel2{FT}(d)
-    m = DummyModel{FT}(m1, m2)
-    Y, p, cds = ClimaLSM.initialize(m)
-    @test propertynames(p) == (:i1, :m1, :m2)
-    exp_tendency! = make_exp_tendency(m)
-    dY = similar(Y)
-    exp_tendency!(dY, Y, p, FT(0))
-    @test all(parent(p.i1) .== FT(5))
-    @test all(parent(p.m1.b) .== FT(10))
-    @test all(parent(dY.m1.a) .== FT(10))
-    @test all(parent(dY.m2.c) .== FT(5))
-    @test all(parent(dY.m2.d) .== FT(-1))
 
-end
-
-
-@testset "LSM aux tests" begin
-
-    struct DummyModel3{FT} <: ClimaLSM.AbstractModel{FT}
-        domain::Any
-    end
-    ClimaLSM.name(::DummyModel3) = :m1
-    ClimaLSM.auxiliary_vars(::DummyModel3) = (:a, :b)
-    ClimaLSM.auxiliary_types(::DummyModel3{FT}) where {FT} = (FT, FT)
-    ClimaLSM.auxiliary_domain_names(::DummyModel3) = (:surface, :surface)
-
-    struct DummyModel4{FT} <: ClimaLSM.AbstractModel{FT}
-        domain::Any
-    end
-
-    ClimaLSM.name(::DummyModel4) = :m2
-    ClimaLSM.auxiliary_vars(::DummyModel4) = (:c, :d)
-    ClimaLSM.auxiliary_types(::DummyModel4{FT}) where {FT} = (FT, FT)
-    ClimaLSM.auxiliary_domain_names(::DummyModel4) = (:surface, :surface)
-
-    struct DummyModelB{FT} <: ClimaLSM.AbstractLandModel{FT}
-        m1::Any
-        m2::Any
-    end
-    ClimaLSM.land_components(::DummyModelB) = (:m1, :m2)
-
-
-    FT = Float32
-    d = ClimaLSM.Domains.Point(; z_sfc = FT(0.0))
-    m1 = DummyModel3{FT}(d)
-    m2 = DummyModel4{FT}(d)
-    m = DummyModelB{FT}(m1, m2)
-    Y, p, cds = ClimaLSM.initialize(m)
-    @test propertynames(p) == (:m1, :m2)
-    function ClimaLSM.make_update_aux(::DummyModel3{FT}) where {FT}
-        function update_aux!(p, Y, t)
-            p.m1.b .= FT(10.0)
+        function ClimaLSM.make_interactions_update_aux(
+            ::DummyModel{FT},
+        ) where {FT}
+            function update_aux!(p, Y, t)
+                p.i1 .= FT(5.0)
+            end
+            return update_aux!
         end
-        return update_aux!
-    end
 
-    function ClimaLSM.make_update_aux(::DummyModel4{FT}) where {FT}
-        function update_aux!(p, Y, t)
-            p.m2.c .= FT(10.0)
-            p.m2.d .= FT(10.0)
+        function ClimaLSM.make_compute_exp_tendency(
+            ::DummyModel1{FT},
+        ) where {FT}
+            function compute_exp_tendency!(dY, Y, p, t)
+                dY.m1.a .= p.m1.b
+            end
+            return compute_exp_tendency!
         end
-        return update_aux!
-    end
 
-    function ClimaLSM.make_set_initial_aux_state(m::DummyModel3{FT}) where {FT}
-        update_aux! = ClimaLSM.make_update_aux(m)
-        function set_initial_aux_state!(p, Y, t)
-            p.m1.a .= FT(2.0)
-            update_aux!(p, Y, t)
+        function ClimaLSM.make_compute_exp_tendency(
+            ::DummyModel2{FT},
+        ) where {FT}
+            function compute_exp_tendency!(dY, Y, p, t)
+                dY.m2.c .= p.i1
+                dY.m2.d .= FT(-1.0)
+            end
+            return compute_exp_tendency!
         end
-        return set_initial_aux_state!
+        d = ClimaLSM.Domains.Column(; zlim = (FT(-2), FT(0)), nelements = 5)
+        m1 = DummyModel1{FT}(d)
+        m2 = DummyModel2{FT}(d)
+        m = DummyModel{FT}(m1, m2)
+        Y, p, cds = ClimaLSM.initialize(m)
+        @test propertynames(p) == (:i1, :m1, :m2)
+        exp_tendency! = make_exp_tendency(m)
+        dY = similar(Y)
+        exp_tendency!(dY, Y, p, FT(0))
+        @test all(parent(p.i1) .== FT(5))
+        @test all(parent(p.m1.b) .== FT(10))
+        @test all(parent(dY.m1.a) .== FT(10))
+        @test all(parent(dY.m2.c) .== FT(5))
+        @test all(parent(dY.m2.d) .== FT(-1))
+
     end
 
-    # The scenario here is that model 1 has a single prescribed but constant
-    # variable (a), with another that could get updated each step (b).
-    # DummyModel4 has only variables that get updated each step.
-    # Test that the land model function properly calls the individual
-    # model's functions
-    set_initial_aux_state! = ClimaLSM.make_set_initial_aux_state(m)
-    set_initial_aux_state!(p, Y, FT(0.0))
-    @test all(parent(p.m1.a) .== FT(2))
-    @test all(parent(p.m1.b) .== FT(10))
-    @test all(parent(p.m2.c) .== FT(10))
-    @test all(parent(p.m2.d) .== FT(10))
+    @testset "LSM aux tests, FT = $FT" begin
+        struct DummyModel3{FT} <: ClimaLSM.AbstractModel{FT}
+            domain::Any
+        end
+        ClimaLSM.name(::DummyModel3) = :m1
+        ClimaLSM.auxiliary_vars(::DummyModel3) = (:a, :b)
+        ClimaLSM.auxiliary_types(::DummyModel3{FT}) where {FT} = (FT, FT)
+        ClimaLSM.auxiliary_domain_names(::DummyModel3) = (:surface, :surface)
 
+        struct DummyModel4{FT} <: ClimaLSM.AbstractModel{FT}
+            domain::Any
+        end
+
+        ClimaLSM.name(::DummyModel4) = :m2
+        ClimaLSM.auxiliary_vars(::DummyModel4) = (:c, :d)
+        ClimaLSM.auxiliary_types(::DummyModel4{FT}) where {FT} = (FT, FT)
+        ClimaLSM.auxiliary_domain_names(::DummyModel4) = (:surface, :surface)
+
+        struct DummyModelB{FT} <: ClimaLSM.AbstractLandModel{FT}
+            m1::Any
+            m2::Any
+        end
+        ClimaLSM.land_components(::DummyModelB) = (:m1, :m2)
+
+        d = ClimaLSM.Domains.Point(; z_sfc = FT(0.0))
+        m1 = DummyModel3{FT}(d)
+        m2 = DummyModel4{FT}(d)
+        m = DummyModelB{FT}(m1, m2)
+        Y, p, cds = ClimaLSM.initialize(m)
+        @test propertynames(p) == (:m1, :m2)
+        function ClimaLSM.make_update_aux(::DummyModel3{FT}) where {FT}
+            function update_aux!(p, Y, t)
+                p.m1.b .= FT(10.0)
+            end
+            return update_aux!
+        end
+
+        function ClimaLSM.make_update_aux(::DummyModel4{FT}) where {FT}
+            function update_aux!(p, Y, t)
+                p.m2.c .= FT(10.0)
+                p.m2.d .= FT(10.0)
+            end
+            return update_aux!
+        end
+
+        function ClimaLSM.make_set_initial_aux_state(
+            m::DummyModel3{FT},
+        ) where {FT}
+            update_aux! = ClimaLSM.make_update_aux(m)
+            function set_initial_aux_state!(p, Y, t)
+                p.m1.a .= FT(2.0)
+                update_aux!(p, Y, t)
+            end
+            return set_initial_aux_state!
+        end
+
+        # The scenario here is that model 1 has a single prescribed but constant
+        # variable (a), with another that could get updated each step (b).
+        # DummyModel4 has only variables that get updated each step.
+        # Test that the land model function properly calls the individual
+        # model's functions
+        set_initial_aux_state! = ClimaLSM.make_set_initial_aux_state(m)
+        set_initial_aux_state!(p, Y, FT(0.0))
+        @test all(parent(p.m1.a) .== FT(2))
+        @test all(parent(p.m1.b) .== FT(10))
+        @test all(parent(p.m2.c) .== FT(10))
+        @test all(parent(p.m2.d) .== FT(10))
+    end
 end

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -5,199 +5,203 @@ using ClimaLSM.Domains: HybridBox, Column, obtain_surface_domain
 using ClimaLSM.Soil
 using ClimaLSM.Pond
 
-@testset "Pond soil Multi Column LSM integration test" begin
-    FT = Float64
-    function precipitation(t::FT) where {FT}
-        if t < FT(20)
-            precip = -FT(1e-8)
-        else
-            precip = t < FT(100) ? -FT(5e-5) : FT(0.0)
+for FT in (Float32, Float64)
+    @testset "Pond soil Multi Column LSM integration test, FT = $FT" begin
+        function precipitation(t)
+            if t < 20
+                precip = -1e-8
+            else
+                precip = t < 100 ? -5e-5 : 0
+            end
+            return precip
         end
-        return precip
-    end
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0)
-    zmax = FT(0)
-    zmin = FT(-1)
-    nelems = 20
-    lsm_domain = HybridBox(;
-        xlim = (0.0, 1.0),
-        ylim = (0.0, 1.0),
-        zlim = (zmin, zmax),
-        nelements = (1, 1, nelems),
-        npolynomial = 1,
-        periodic = (true, true),
-    )
-    soil_ps = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
-    soil_args = (; domain = lsm_domain, parameters = soil_ps)
-    surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0)
+        zmax = FT(0)
+        zmin = FT(-1)
+        nelems = 20
+        lsm_domain = HybridBox(;
+            xlim = (FT(0), FT(1)),
+            ylim = (FT(0), FT(1)),
+            zlim = (zmin, zmax),
+            nelements = (1, 1, nelems),
+            npolynomial = 1,
+            periodic = (true, true),
+        )
+        soil_ps =
+            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        soil_args = (; domain = lsm_domain, parameters = soil_ps)
+        surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
 
-    land_args = (; precip = precipitation)
+        land_args = (; precip = precipitation)
 
-    land = LandHydrology{FT}(;
-        land_args = land_args,
-        soil_model_type = Soil.RichardsModel{FT},
-        soil_args = soil_args,
-        surface_water_model_type = Pond.PondModel{FT},
-        surface_water_args = surface_water_args,
-    )
-    Y, p, coords = initialize(land)
-    # test that the dss buffers are correctly added
-    @test propertynames(p) == (
-        :soil_infiltration,
-        :soil,
-        :surface_water,
-        :dss_buffer_3d,
-        :dss_buffer_2d,
-    )
-    @test typeof(p.dss_buffer_3d) == typeof(
-        ClimaCore.Spaces.create_dss_buffer(
-            ClimaCore.Fields.zeros(land.soil.domain.space.subsurface),
-        ),
-    )
-    @test typeof(p.dss_buffer_2d) == typeof(
-        ClimaCore.Spaces.create_dss_buffer(
-            ClimaCore.Fields.zeros(land.surface_water.domain.space.surface),
-        ),
-    )
-    function init_soil!(Ysoil, coords, params)
-        function hydrostatic_profile(
-            z::FT,
-            params::RichardsParameters{FT},
-        ) where {FT}
-            (; ν, hydrology_cm, θ_r) = params
-            (; α, n) = hydrology_cm
-            m = 1 - 1 / n
-            #unsaturated zone only, assumes water table starts at z_∇
-            z_∇ = FT(-1)# matches zmin
-            S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-            ϑ_l = S * (ν - θ_r) + θ_r
-            return FT(ϑ_l)
+        land = LandHydrology{FT}(;
+            land_args = land_args,
+            soil_model_type = Soil.RichardsModel{FT},
+            soil_args = soil_args,
+            surface_water_model_type = Pond.PondModel{FT},
+            surface_water_args = surface_water_args,
+        )
+        Y, p, coords = initialize(land)
+        # test that the dss buffers are correctly added
+        @test propertynames(p) == (
+            :soil_infiltration,
+            :soil,
+            :surface_water,
+            :dss_buffer_3d,
+            :dss_buffer_2d,
+        )
+        @test typeof(p.dss_buffer_3d) == typeof(
+            ClimaCore.Spaces.create_dss_buffer(
+                ClimaCore.Fields.zeros(land.soil.domain.space.subsurface),
+            ),
+        )
+        @test typeof(p.dss_buffer_2d) == typeof(
+            ClimaCore.Spaces.create_dss_buffer(
+                ClimaCore.Fields.zeros(land.surface_water.domain.space.surface),
+            ),
+        )
+        function init_soil!(Ysoil, coords, params)
+            function hydrostatic_profile(
+                z::FT,
+                params::RichardsParameters{FT},
+            ) where {FT}
+                (; ν, hydrology_cm, θ_r) = params
+                (; α, n) = hydrology_cm
+                m = 1 - 1 / n
+                #unsaturated zone only, assumes water table starts at z_∇
+                z_∇ = FT(-1)# matches zmin
+                S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
+                ϑ_l = S * (ν - θ_r) + θ_r
+                return FT(ϑ_l)
+            end
+            Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z, Ref(params))
         end
-        Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z, Ref(params))
-    end
-    init_soil!(Y, coords.subsurface, land.soil.parameters)
-    # initialize the pond height to zero
-    Y.surface_water.η .= 0.0
-    dY = similar(Y)
+        init_soil!(Y, coords.subsurface, land.soil.parameters)
+        # initialize the pond height to zero
+        Y.surface_water.η .= FT(0)
+        dY = similar(Y)
 
-    exp_tendency! = make_exp_tendency(land)
-    t = FT(0)
-    dt = FT(1)
-    # set aux state values to those corresponding with Y(t=0)
-    set_initial_aux_state! = make_set_initial_aux_state(land)
-    set_initial_aux_state!(p, Y, t)
-    # integrate
-    for step in 1:10
-        exp_tendency!(dY, Y, p, t)
-        t = t + dt
-        @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
-    end
-    # it running is the test
-
-    # Infiltration at point test
-
-    η = [0.0, 0.0, 0.0, 0.0, 1.0, 1.0]
-    i_c = [2.0, 2.0, -2.0, -2.0, 2.0, 2.0]
-    P = [3.0, -1.0, 3.0, -3.0, 1.0, 3.0]
-    iap = [2.0, -1.0, -2.0, -3.0, 2.0, 2.0]
-    @test infiltration_at_point.(η, i_c, P) ≈ iap
-
-    land_prognostic_vars = prognostic_vars(land)
-    land_prognostic_types = prognostic_types(land)
-    land_auxiliary_vars = auxiliary_vars(land)
-    land_auxiliary_types = auxiliary_types(land)
-    # prognostic vars
-    @test land_prognostic_vars.soil == prognostic_vars(land.soil)
-    @test land_prognostic_vars.surface_water ==
-          prognostic_vars(land.surface_water)
-    # auxiliary vars
-    @test land_auxiliary_vars.soil == auxiliary_vars(land.soil)
-    @test land_auxiliary_vars.surface_water ==
-          auxiliary_vars(land.surface_water)
-    @test land_auxiliary_vars.interactions == ClimaLSM.interaction_vars(land)
-    # prognostic types
-    @test land_prognostic_types.soil == prognostic_types(land.soil)
-    @test land_prognostic_types.surface_water ==
-          prognostic_types(land.surface_water)
-    # auxiliary types
-    @test land_auxiliary_types.soil == auxiliary_types(land.soil)
-    @test land_auxiliary_types.surface_water ==
-          auxiliary_types(land.surface_water)
-    @test land_auxiliary_types.interactions == ClimaLSM.interaction_types(land)
-end
-
-
-@testset "Pond soil Single Column LSM integration test" begin
-    FT = Float64
-    function precipitation(t::FT) where {FT}
-        if t < FT(20)
-            precip = -FT(1e-8)
-        else
-            precip = t < FT(100) ? -FT(5e-5) : FT(0.0)
+        exp_tendency! = make_exp_tendency(land)
+        t = FT(0)
+        dt = FT(1)
+        # set aux state values to those corresponding with Y(t=0)
+        set_initial_aux_state! = make_set_initial_aux_state(land)
+        set_initial_aux_state!(p, Y, t)
+        # integrate
+        for step in 1:10
+            exp_tendency!(dY, Y, p, t)
+            t = t + dt
+            @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
         end
-        return precip
+        # it running is the test
+
+        # Infiltration at point test
+
+        η = FT.([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])
+        i_c = FT.([2.0, 2.0, -2.0, -2.0, 2.0, 2.0])
+        P = FT.([3.0, -1.0, 3.0, -3.0, 1.0, 3.0])
+        iap = FT.([2.0, -1.0, -2.0, -3.0, 2.0, 2.0])
+        @test infiltration_at_point.(η, i_c, P) ≈ iap
+
+        land_prognostic_vars = prognostic_vars(land)
+        land_prognostic_types = prognostic_types(land)
+        land_auxiliary_vars = auxiliary_vars(land)
+        land_auxiliary_types = auxiliary_types(land)
+        # prognostic vars
+        @test land_prognostic_vars.soil == prognostic_vars(land.soil)
+        @test land_prognostic_vars.surface_water ==
+              prognostic_vars(land.surface_water)
+        # auxiliary vars
+        @test land_auxiliary_vars.soil == auxiliary_vars(land.soil)
+        @test land_auxiliary_vars.surface_water ==
+              auxiliary_vars(land.surface_water)
+        @test land_auxiliary_vars.interactions ==
+              ClimaLSM.interaction_vars(land)
+        # prognostic types
+        @test land_prognostic_types.soil == prognostic_types(land.soil)
+        @test land_prognostic_types.surface_water ==
+              prognostic_types(land.surface_water)
+        # auxiliary types
+        @test land_auxiliary_types.soil == auxiliary_types(land.soil)
+        @test land_auxiliary_types.surface_water ==
+              auxiliary_types(land.surface_water)
+        @test land_auxiliary_types.interactions ==
+              ClimaLSM.interaction_types(land)
     end
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0)
-    zmax = FT(0)
-    zmin = FT(-1)
-    nelems = 20
-    lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
 
-    soil_ps = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
-    soil_args = (; domain = lsm_domain, parameters = soil_ps)
-    surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
 
-    land_args = (; precip = precipitation)
-
-    land = LandHydrology{FT}(;
-        land_args = land_args,
-        soil_model_type = Soil.RichardsModel{FT},
-        soil_args = soil_args,
-        surface_water_model_type = Pond.PondModel{FT},
-        surface_water_args = surface_water_args,
-    )
-    Y, p, coords = initialize(land)
-    @test propertynames(p) == (:soil_infiltration, :soil, :surface_water)
-    function init_soil!(Ysoil, coords, params)
-        function hydrostatic_profile(
-            z::FT,
-            params::RichardsParameters{FT},
-        ) where {FT}
-            (; ν, hydrology_cm, θ_r) = params
-            (; α, n) = hydrology_cm
-            m = 1 - 1 / n
-            #unsaturated zone only, assumes water table starts at z_∇
-            z_∇ = FT(-1)# matches zmin
-            S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-            ϑ_l = S * (ν - θ_r) + θ_r
-            return FT(ϑ_l)
+    @testset "Pond soil Single Column LSM integration test, FT = $FT" begin
+        function precipitation(t)
+            if t < 20
+                precip = -1e-8
+            else
+                precip = t < 100 ? -5e-5 : 0.0
+            end
+            return precip
         end
-        Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z, Ref(params))
-    end
-    init_soil!(Y, coords.subsurface, land.soil.parameters)
-    # initialize the pond height to zero
-    Y.surface_water.η .= 0.0
-    dY = similar(Y)
-    exp_tendency! = make_exp_tendency(land)
-    t = FT(0)
-    dt = FT(1)
-    for step in 1:10
-        exp_tendency!(dY, Y, p, t)
-        t = t + dt
-        @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
-    end
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0)
+        zmax = FT(0)
+        zmin = FT(-1)
+        nelems = 20
+        lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
 
-    # it running is the test
+        soil_ps =
+            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        soil_args = (; domain = lsm_domain, parameters = soil_ps)
+        surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
+
+        land_args = (; precip = precipitation)
+
+        land = LandHydrology{FT}(;
+            land_args = land_args,
+            soil_model_type = Soil.RichardsModel{FT},
+            soil_args = soil_args,
+            surface_water_model_type = Pond.PondModel{FT},
+            surface_water_args = surface_water_args,
+        )
+        Y, p, coords = initialize(land)
+        @test propertynames(p) == (:soil_infiltration, :soil, :surface_water)
+        function init_soil!(Ysoil, coords, params)
+            function hydrostatic_profile(
+                z::FT,
+                params::RichardsParameters{FT},
+            ) where {FT}
+                (; ν, hydrology_cm, θ_r) = params
+                (; α, n) = hydrology_cm
+                m = 1 - 1 / n
+                #unsaturated zone only, assumes water table starts at z_∇
+                z_∇ = FT(-1)# matches zmin
+                S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
+                ϑ_l = S * (ν - θ_r) + θ_r
+                return FT(ϑ_l)
+            end
+            Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z, Ref(params))
+        end
+        init_soil!(Y, coords.subsurface, land.soil.parameters)
+        # initialize the pond height to zero
+        Y.surface_water.η .= FT(0)
+        dY = similar(Y)
+        exp_tendency! = make_exp_tendency(land)
+        t = FT(0)
+        dt = FT(1)
+        for step in 1:10
+            exp_tendency!(dY, Y, p, t)
+            t = t + dt
+            @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
+        end
+
+        # it running is the test
+    end
 end

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -8,220 +8,250 @@ using Dates
 
 import ClimaLSM.Parameters as LSMP
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-@testset "Soil respiration test set" begin
-    FT = Float64
-    earth_param_set = create_lsm_parameters(FT)
-    # Make soil model args
-    ν = FT(0.556)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.1)
-    ν_ss_om = FT(0.0)
-    ν_ss_quartz = FT(1.0)
-    ν_ss_gravel = FT(0.0)
-    κ_minerals = FT(2.5)
-    κ_om = FT(0.25)
-    κ_quartz = FT(8.0)
-    κ_air = FT(0.025)
-    κ_ice = FT(2.21)
-    κ_liq = FT(0.57)
-    ρp = FT(2.66 / 1e3 * 1e6)
-    ρc_ds = FT(2e6 * (1.0 - ν))
-    κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-    κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-    κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
 
-    soil_ps = Soil.EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        K_sat = K_sat,
-        hydrology_cm = hcm,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-    zmax = FT(0)
-    zmin = FT(-1)
-    nelems = 20
-    lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    zero_flux_bc = Soil.FluxBC((p, t) -> eltype(t)(0.0))
-    sources = () # PhaseChange
-    boundary_fluxes = (;
-        top = (water = zero_flux_bc, heat = zero_flux_bc),
-        bottom = (water = zero_flux_bc, heat = zero_flux_bc),
-    )
-    soil_args = (;
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-        domain = lsm_domain,
-        parameters = soil_ps,
-    )
+for FT in (Float32, Float64)
+    @testset "Soil respiration test set, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        # Make soil model args
+        ν = FT(0.556)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.1)
+        ν_ss_om = FT(0.0)
+        ν_ss_quartz = FT(1.0)
+        ν_ss_gravel = FT(0.0)
+        κ_minerals = FT(2.5)
+        κ_om = FT(0.25)
+        κ_quartz = FT(8.0)
+        κ_air = FT(0.025)
+        κ_ice = FT(2.21)
+        κ_liq = FT(0.57)
+        ρp = FT(2.66 / 1e3 * 1e6)
+        ρc_ds = FT(2e6 * (1.0 - ν))
+        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
+        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
 
-    # Make biogeochemistry model args
-    Csom = (z, t) -> eltype(t)(5.0)
+        soil_ps = Soil.EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            K_sat = K_sat,
+            hydrology_cm = hcm,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
+        )
+        zmax = FT(0)
+        zmin = FT(-1)
+        nelems = 20
+        lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+        zero_flux_bc = Soil.FluxBC((p, t) -> eltype(t)(0.0))
+        sources = () # PhaseChange
+        boundary_fluxes = (;
+            top = (water = zero_flux_bc, heat = zero_flux_bc),
+            bottom = (water = zero_flux_bc, heat = zero_flux_bc),
+        )
+        soil_args = (;
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+            domain = lsm_domain,
+            parameters = soil_ps,
+        )
 
-    co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
-        earth_param_set = earth_param_set,
-    )
-    C = FT(4)
-    co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> eltype(t)(C))
-    co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> eltype(t)(C))
-    co2_sources = ()
-    co2_boundary_conditions = (; CO2 = (top = co2_top_bc, bottom = co2_bot_bc))
+        # Make biogeochemistry model args
+        Csom = (z, t) -> eltype(z)(5.0)
 
-    # Make a PrescribedAtmosphere - we only care about atmos_p though
-    precipitation_function = (t) -> 1.0
-    snow_precip = (t) -> 1.0
-    atmos_T = (t) -> 1.0
-    atmos_u = (t) -> 1.0
-    atmos_q = (t) -> 1.0
-    atmos_p = (t) -> 100000.0
-    UTC_DATETIME = Dates.now()
-    atmos_h = FT(30)
-    atmos_co2 = (t) -> 1.0
+        co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
+            earth_param_set = earth_param_set,
+        )
+        C = FT(4)
+        co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)
+        co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)
+        co2_sources = ()
+        co2_boundary_conditions =
+            (; CO2 = (top = co2_top_bc, bottom = co2_bot_bc))
 
-    atmos = ClimaLSM.PrescribedAtmosphere(
-        precipitation_function,
-        snow_precip,
-        atmos_T,
-        atmos_u,
-        atmos_q,
-        atmos_p,
-        UTC_DATETIME,
-        atmos_h;
-        c_co2 = atmos_co2,
-    )
+        # Make a PrescribedAtmosphere - we only care about atmos_p though
+        precipitation_function = (t) -> 1.0
+        snow_precip = (t) -> 1.0
+        atmos_T = (t) -> 1.0
+        atmos_u = (t) -> 1.0
+        atmos_q = (t) -> 1.0
+        atmos_p = (t) -> 100000.0
+        UTC_DATETIME = Dates.now()
+        atmos_h = FT(30)
+        atmos_co2 = (t) -> 1.0
+
+        atmos = ClimaLSM.PrescribedAtmosphere(
+            precipitation_function,
+            snow_precip,
+            atmos_T,
+            atmos_u,
+            atmos_q,
+            atmos_p,
+            UTC_DATETIME,
+            atmos_h;
+            c_co2 = atmos_co2,
+        )
 
 
-    soil_drivers = Soil.Biogeochemistry.SoilDrivers(
-        Soil.Biogeochemistry.PrognosticMet(),
-        Soil.Biogeochemistry.PrescribedSOC(Csom),
-        atmos,
-    )
-    soilco2_args = (;
-        boundary_conditions = co2_boundary_conditions,
-        sources = co2_sources,
-        domain = lsm_domain,
-        parameters = co2_parameters,
-        drivers = soil_drivers,
-    )
+        soil_drivers = Soil.Biogeochemistry.SoilDrivers(
+            Soil.Biogeochemistry.PrognosticMet{FT}(),
+            Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
+            atmos,
+        )
+        soilco2_args = (;
+            boundary_conditions = co2_boundary_conditions,
+            sources = co2_sources,
+            domain = lsm_domain,
+            parameters = co2_parameters,
+            drivers = soil_drivers,
+        )
 
-    # Create integrated model instance
-    model = LandSoilBiogeochemistry{FT}(;
-        soil_args = soil_args,
-        soilco2_args = soilco2_args,
-    )
-    Y, p, coords = initialize(model)
+        # Create integrated model instance
+        model = LandSoilBiogeochemistry{FT}(;
+            soil_args = soil_args,
+            soilco2_args = soilco2_args,
+        )
+        Y, p, coords = initialize(model)
 
-    function init_soil!(Y, z, params)
-        ν = params.ν
-        FT = eltype(Y.soil.ϑ_l)
-        Y.soil.ϑ_l .= FT(0.33)
-        Y.soil.θ_i .= FT(0.0)
-        T = FT(279.85)
-        ρc_s = Soil.volumetric_heat_capacity(FT(0.33), FT(0.0), params)
-        Y.soil.ρe_int .=
-            Soil.volumetric_internal_energy.(FT(0.0), ρc_s, T, Ref(params))
-    end
+        function init_soil!(Y, z, params)
+            ν = params.ν
+            FT = eltype(Y.soil.ϑ_l)
+            Y.soil.ϑ_l .= FT(0.33)
+            Y.soil.θ_i .= FT(0.0)
+            T = FT(279.85)
+            ρc_s = FT.(Soil.volumetric_heat_capacity(FT(0.33), FT(0.0), params))
+            Y.soil.ρe_int .=
+                Soil.volumetric_internal_energy.(FT(0.0), ρc_s, T, Ref(params))
+        end
 
-    function init_co2!(Y, C_0)
-        Y.soilco2.C .= C_0
-    end
+        function init_co2!(Y, C_0)
+            Y.soilco2.C .= C_0
+        end
 
-    z = coords.subsurface.z
-    init_soil!(Y, z, model.soil.parameters)
-    init_co2!(Y, C)
-    t0 = FT(0.0)
-    set_initial_aux_state! = make_set_initial_aux_state(model)
-    set_initial_aux_state!(p, Y, t0)
+        z = coords.subsurface.z
+        init_soil!(Y, z, model.soil.parameters)
+        init_co2!(Y, C)
+        t0 = FT(0.0)
+        set_initial_aux_state! = make_set_initial_aux_state(model)
+        set_initial_aux_state!(p, Y, t0)
 
-    @test p.soil.T ≈ Soil.Biogeochemistry.soil_temperature(
-        model.soilco2.driver.met,
-        p,
-        Y,
-        t0,
-        z,
-    )
-    @test all(
-        parent(
-            Soil.Biogeochemistry.soil_SOM_C(
-                model.soilco2.driver.soc,
+        @test p.soil.T ≈ Soil.Biogeochemistry.soil_temperature(
+            model.soilco2.driver.met,
+            p,
+            Y,
+            t0,
+            z,
+        )
+        @test all(
+            parent(
+                Soil.Biogeochemistry.soil_SOM_C(
+                    model.soilco2.driver.soc,
+                    p,
+                    Y,
+                    t0,
+                    z,
+                ),
+            ) .== FT(5.0),
+        )
+        @test p.soil.θ_l ≈ Soil.Biogeochemistry.soil_moisture(
+            model.soilco2.driver.met,
+            p,
+            Y,
+            t0,
+            z,
+        )
+
+        try
+            co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
+                ν = FT(0.2),
+                earth_param_set = earth_param_set,
+            )
+            soil_drivers = Soil.Biogeochemistry.SoilDrivers(
+                Soil.Biogeochemistry.PrognosticMet{FT}(),
+                Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
+                atmos,
+            )
+            soilco2_args = (;
+                boundary_conditions = co2_boundary_conditions,
+                sources = co2_sources,
+                domain = lsm_domain,
+                parameters = co2_parameters,
+                drivers = soil_drivers,
+            )
+
+            # Create integrated model instance
+            model = LandSoilBiogeochemistry{FT}(;
+                soil_args = soil_args,
+                soilco2_args = soilco2_args,
+            )
+            Y, p, coords = initialize(model)
+
+            function init_soil!(Y, z, params)
+                ν = params.ν
+                FT = eltype(Y.soil.ϑ_l)
+                Y.soil.ϑ_l .= FT(0.33)
+                Y.soil.θ_i .= FT(0.0)
+                T = FT(279.85)
+                ρc_s = Soil.volumetric_heat_capacity(FT(0.33), FT(0.0), params)
+                Y.soil.ρe_int .=
+                    Soil.volumetric_internal_energy.(
+                        FT(0.0),
+                        ρc_s,
+                        T,
+                        Ref(params),
+                    )
+            end
+
+            function init_co2!(Y, C_0)
+                Y.soilco2.C .= C_0
+            end
+
+            z = coords.subsurface.z
+            init_soil!(Y, z, model.soil.parameters)
+            init_co2!(Y, C)
+            t0 = FT(0.0)
+            set_initial_aux_state! = make_set_initial_aux_state(model)
+            set_initial_aux_state!(p, Y, t0)
+
+            @test p.soil.T ≈ Soil.Biogeochemistry.soil_temperature(
+                model.soilco2.driver.met,
                 p,
                 Y,
                 t0,
                 z,
-            ),
-        ) .== FT(5.0),
-    )
-    @test p.soil.θ_l ≈ Soil.Biogeochemistry.soil_moisture(
-        model.soilco2.driver.met,
-        p,
-        Y,
-        t0,
-        z,
-    )
+            )
+            soil_drivers = Soil.Biogeochemistry.SoilDrivers(
+                Soil.Biogeochemistry.PrescribedMet{FT}(Csom, Csom),
+                Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
+                atmos,
+            )
+            soilco2_args = (;
+                boundary_conditions = co2_boundary_conditions,
+                sources = co2_sources,
+                domain = lsm_domain,
+                parameters = co2_parameters,
+                drivers = soil_drivers,
+            )
 
-    try
-        co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
-            ν = FT(0.2),
-            earth_param_set = earth_param_set,
-        )
-        soil_drivers = Soil.Biogeochemistry.SoilDrivers(
-            Soil.Biogeochemistry.PrognosticMet(),
-            Soil.Biogeochemistry.PrescribedSOC(Csom),
-            atmos,
-        )
-        soilco2_args = (;
-            boundary_conditions = co2_boundary_conditions,
-            sources = co2_sources,
-            domain = lsm_domain,
-            parameters = co2_parameters,
-            drivers = soil_drivers,
-        )
-
-        # Create integrated model instance
-        model = LandSoilBiogeochemistry{FT}(;
-            soil_args = soil_args,
-            soilco2_args = soilco2_args,
-        )
-    catch err
-        @test isa(err, AssertionError)
-    end
-
-
-    try
-        co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
-            earth_param_set = earth_param_set,
-        )
-        soil_drivers = Soil.Biogeochemistry.SoilDrivers(
-            Soil.Biogeochemistry.PrescribedMet(Csom, Csom),
-            Soil.Biogeochemistry.PrescribedSOC(Csom),
-            atmos,
-        )
-        soilco2_args = (;
-            boundary_conditions = co2_boundary_conditions,
-            sources = co2_sources,
-            domain = lsm_domain,
-            parameters = co2_parameters,
-            drivers = soil_drivers,
-        )
-
-        # Create integrated model instance
-        model = LandSoilBiogeochemistry{FT}(;
-            soil_args = soil_args,
-            soilco2_args = soilco2_args,
-        )
-    catch err
-        @test isa(err, AssertionError)
+            # Create integrated model instance
+            model = LandSoilBiogeochemistry{FT}(;
+                soil_args = soil_args,
+                soilco2_args = soilco2_args,
+            )
+        catch err
+            @test isa(err, AssertionError)
+        end
     end
 end

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -14,192 +14,181 @@ using ClimaLSM.Domains:
     obtain_face_space,
     obtain_surface_domain
 
-TestFloatTypes = (Float32, Float64)
+FT = Float32
+@testset "Clima Core Domains, FT = $FT" begin
+    zmin = FT(-1.0)
+    zmax = FT(0.0)
+    xlim = FT.((0.0, 10.0))
+    ylim = FT.((0.0, 1.0))
+    zlim = FT.((zmin, zmax))
+    nelements = (1, 1, 10)
+    radius = FT(100)
+    depth = FT(30)
+    n_elements_sphere = (6, 20)
+    npoly_sphere = 3
+    # Spherical Shell
+    shell = SphericalShell(;
+        radius = radius,
+        depth = depth,
+        nelements = n_elements_sphere,
+        npolynomial = npoly_sphere,
+    )
+    @test shell.radius == radius
+    @test shell.depth == depth
+    @test shell.nelements == n_elements_sphere
+    @test shell.npolynomial == npoly_sphere
+    shell_coords = coordinates(shell).subsurface
+    @test eltype(shell_coords) == ClimaCore.Geometry.LatLongZPoint{FT}
+    @test typeof(shell_coords) <: ClimaCore.Fields.Field
+    @test typeof(shell.space.subsurface.horizontal_space) <:
+          ClimaCore.Spaces.SpectralElementSpace2D
+    @test typeof(shell.space.subsurface) <:
+          ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace
+    @test typeof(shell.space.surface) <: ClimaCore.Spaces.SpectralElementSpace2D
+    @test obtain_surface_space(shell.space.subsurface) == shell.space.surface
+    @test obtain_surface_domain(shell) == SphericalSurface{FT}(
+        radius,
+        n_elements_sphere[1],
+        npoly_sphere,
+        (; surface = shell.space.surface),
+    )
+    shell_stretch = SphericalShell(;
+        radius = radius,
+        depth = FT(1.0),
+        dz_tuple = FT.((0.3, 0.03)),
+        nelements = (6, 10),
+        npolynomial = 3,
+    )
+    shell_coords_stretch = coordinates(shell_stretch).subsurface
+    dz =
+        parent(shell_coords_stretch.z)[:, 1, 4, 1, 216][2:end] .-
+        parent(shell_coords_stretch.z)[:, 1, 4, 1, 216][1:(end - 1)]
+    @test abs(dz[1] - 0.3) < 1e-1
+    @test abs(dz[end] - 0.03) < 1e-2
 
-@testset "Clima Core Domains" begin
-    for FT in TestFloatTypes
-        zmin = FT(-1.0)
-        zmax = FT(0.0)
-        xlim = FT.((0.0, 10.0))
-        ylim = FT.((0.0, 1.0))
-        zlim = FT.((zmin, zmax))
-        nelements = (1, 1, 10)
-        radius = FT(100)
-        depth = FT(30)
-        n_elements_sphere = (6, 20)
-        npoly_sphere = 3
-        # Spherical Shell
-        shell = SphericalShell(;
-            radius = radius,
-            depth = depth,
-            nelements = n_elements_sphere,
-            npolynomial = npoly_sphere,
-        )
-        @test shell.radius == radius
-        @test shell.depth == depth
-        @test shell.nelements == n_elements_sphere
-        @test shell.npolynomial == npoly_sphere
-        shell_coords = coordinates(shell).subsurface
-        @test eltype(shell_coords) == ClimaCore.Geometry.LatLongZPoint{FT}
-        @test typeof(shell_coords) <: ClimaCore.Fields.Field
-        @test typeof(shell.space.subsurface.horizontal_space) <:
-              ClimaCore.Spaces.SpectralElementSpace2D
-        @test typeof(shell.space.subsurface) <:
-              ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace
-        @test typeof(shell.space.surface) <:
-              ClimaCore.Spaces.SpectralElementSpace2D
-        @test obtain_surface_space(shell.space.subsurface) ==
-              shell.space.surface
-        @test obtain_surface_domain(shell) == SphericalSurface{FT}(
-            radius,
-            n_elements_sphere[1],
-            npoly_sphere,
-            (; surface = shell.space.surface),
-        )
-        shell_stretch = SphericalShell(;
-            radius = radius,
-            depth = FT(1.0),
-            dz_tuple = FT.((0.3, 0.03)),
-            nelements = (6, 10),
-            npolynomial = 3,
-        )
-        shell_coords_stretch = coordinates(shell_stretch).subsurface
-        dz =
-            parent(shell_coords_stretch.z)[:, 1, 4, 1, 216][2:end] .-
-            parent(shell_coords_stretch.z)[:, 1, 4, 1, 216][1:(end - 1)]
-        @test abs(dz[1] - 0.3) < 1e-1
-        @test abs(dz[end] - 0.03) < 1e-2
-
-        # Spherical Surface
-        shell_surface = SphericalSurface(;
-            radius = radius,
-            nelements = n_elements_sphere[1],
-            npolynomial = npoly_sphere,
-        )
-        @test shell_surface.radius == radius
-        @test shell_surface.nelements == n_elements_sphere[1]
-        @test shell_surface.npolynomial == npoly_sphere
-        shell_surface_coords = coordinates(shell_surface).surface
-        @test eltype(shell_surface_coords) ==
-              ClimaCore.Geometry.LatLongPoint{FT}
-        @test typeof(shell_surface_coords) <: ClimaCore.Fields.Field
-        @test typeof(shell_surface.space.surface) <:
-              ClimaCore.Spaces.SpectralElementSpace2D
+    # Spherical Surface
+    shell_surface = SphericalSurface(;
+        radius = radius,
+        nelements = n_elements_sphere[1],
+        npolynomial = npoly_sphere,
+    )
+    @test shell_surface.radius == radius
+    @test shell_surface.nelements == n_elements_sphere[1]
+    @test shell_surface.npolynomial == npoly_sphere
+    shell_surface_coords = coordinates(shell_surface).surface
+    @test eltype(shell_surface_coords) == ClimaCore.Geometry.LatLongPoint{FT}
+    @test typeof(shell_surface_coords) <: ClimaCore.Fields.Field
+    @test typeof(shell_surface.space.surface) <:
+          ClimaCore.Spaces.SpectralElementSpace2D
 
 
-        # HybridBox
-        xyz_column_box = HybridBox(;
-            xlim = xlim,
-            ylim = ylim,
-            zlim = zlim,
-            nelements = nelements,
-            npolynomial = 0,
-        )
-        box_coords = coordinates(xyz_column_box).subsurface
-        @test eltype(box_coords) == ClimaCore.Geometry.XYZPoint{FT}
-        @test typeof(box_coords) <: ClimaCore.Fields.Field
-        @test xyz_column_box.xlim == FT.(xlim)
-        @test xyz_column_box.ylim == FT.(ylim)
-        @test xyz_column_box.zlim == FT.(zlim)
-        @test xyz_column_box.nelements == nelements
-        @test xyz_column_box.npolynomial == 0
-        @test xyz_column_box.periodic == (true, true)
-        @test typeof(xyz_column_box.space.subsurface.horizontal_space) <:
-              ClimaCore.Spaces.SpectralElementSpace2D
-        @test typeof(xyz_column_box.space.subsurface) <:
-              ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace
-        @test typeof(xyz_column_box.space.surface) <:
-              ClimaCore.Spaces.SpectralElementSpace2D
-        @test obtain_surface_space(xyz_column_box.space.subsurface) ==
-              xyz_column_box.space.surface
-        @test obtain_surface_domain(xyz_column_box) == Plane{FT}(
-            xlim,
-            ylim,
-            nelements[1:2],
-            (true, true),
-            0,
-            (; surface = xyz_column_box.space.surface),
-        )
+    # HybridBox
+    xyz_column_box = HybridBox(;
+        xlim = xlim,
+        ylim = ylim,
+        zlim = zlim,
+        nelements = nelements,
+        npolynomial = 0,
+    )
+    box_coords = coordinates(xyz_column_box).subsurface
+    @test eltype(box_coords) == ClimaCore.Geometry.XYZPoint{FT}
+    @test typeof(box_coords) <: ClimaCore.Fields.Field
+    @test xyz_column_box.xlim == FT.(xlim)
+    @test xyz_column_box.ylim == FT.(ylim)
+    @test xyz_column_box.zlim == FT.(zlim)
+    @test xyz_column_box.nelements == nelements
+    @test xyz_column_box.npolynomial == 0
+    @test xyz_column_box.periodic == (true, true)
+    @test typeof(xyz_column_box.space.subsurface.horizontal_space) <:
+          ClimaCore.Spaces.SpectralElementSpace2D
+    @test typeof(xyz_column_box.space.subsurface) <:
+          ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace
+    @test typeof(xyz_column_box.space.surface) <:
+          ClimaCore.Spaces.SpectralElementSpace2D
+    @test obtain_surface_space(xyz_column_box.space.subsurface) ==
+          xyz_column_box.space.surface
+    @test obtain_surface_domain(xyz_column_box) == Plane{FT}(
+        xlim,
+        ylim,
+        nelements[1:2],
+        (true, true),
+        0,
+        (; surface = xyz_column_box.space.surface),
+    )
 
-        xyz_stretch_column_box = HybridBox(;
-            xlim = xlim,
-            ylim = ylim,
-            zlim = zlim,
-            dz_tuple = FT.((0.3, 0.03)),
-            nelements = nelements,
-            npolynomial = 0,
-        )
-        box_coords_stretch = coordinates(xyz_stretch_column_box).subsurface
-        dz =
-            parent(box_coords_stretch.z)[:][2:end] .-
-            parent(box_coords_stretch.z)[:][1:(end - 1)]
-        @test abs(dz[1] - 0.3) < 1e-1
-        @test abs(dz[end] - 0.03) < 1e-2
+    xyz_stretch_column_box = HybridBox(;
+        xlim = xlim,
+        ylim = ylim,
+        zlim = zlim,
+        dz_tuple = FT.((0.3, 0.03)),
+        nelements = nelements,
+        npolynomial = 0,
+    )
+    box_coords_stretch = coordinates(xyz_stretch_column_box).subsurface
+    dz =
+        parent(box_coords_stretch.z)[:][2:end] .-
+        parent(box_coords_stretch.z)[:][1:(end - 1)]
+    @test abs(dz[1] - 0.3) < 1e-1
+    @test abs(dz[end] - 0.03) < 1e-2
 
-        # Plane
-        xy_plane = Plane(;
-            xlim = xlim,
-            ylim = ylim,
-            nelements = nelements[1:2],
-            periodic = (true, true),
-            npolynomial = 0,
-        )
-        plane_coords = coordinates(xy_plane).surface
-        @test eltype(plane_coords) == ClimaCore.Geometry.XYPoint{FT}
-        @test typeof(plane_coords) <: ClimaCore.Fields.Field
-        @test xy_plane.xlim == FT.(xlim)
-        @test xy_plane.ylim == FT.(ylim)
-        @test xy_plane.nelements == nelements[1:2]
-        @test xy_plane.npolynomial == 0
-        @test xy_plane.periodic == (true, true)
-        @test typeof(xy_plane.space.surface) <:
-              ClimaCore.Spaces.SpectralElementSpace2D
+    # Plane
+    xy_plane = Plane(;
+        xlim = xlim,
+        ylim = ylim,
+        nelements = nelements[1:2],
+        periodic = (true, true),
+        npolynomial = 0,
+    )
+    plane_coords = coordinates(xy_plane).surface
+    @test eltype(plane_coords) == ClimaCore.Geometry.XYPoint{FT}
+    @test typeof(plane_coords) <: ClimaCore.Fields.Field
+    @test xy_plane.xlim == FT.(xlim)
+    @test xy_plane.ylim == FT.(ylim)
+    @test xy_plane.nelements == nelements[1:2]
+    @test xy_plane.npolynomial == 0
+    @test xy_plane.periodic == (true, true)
+    @test typeof(xy_plane.space.surface) <:
+          ClimaCore.Spaces.SpectralElementSpace2D
 
 
-        # Column
+    # Column
 
-        z_column = Column(; zlim = zlim, nelements = nelements[3])
-        column_coords = coordinates(z_column).subsurface
-        @test z_column.zlim == FT.(zlim)
-        @test z_column.nelements[1] == nelements[3]
-        @test eltype(column_coords) == ClimaCore.Geometry.ZPoint{FT}
-        @test typeof(column_coords) <: ClimaCore.Fields.Field
-        @test typeof(z_column.space.subsurface) <:
-              ClimaCore.Spaces.CenterFiniteDifferenceSpace
-        @test typeof(z_column.space.surface) <: ClimaCore.Spaces.PointSpace
-        @test any(
-            parent(column_coords)[:][2:end] .-
-            parent(column_coords)[:][1:(end - 1)] .≈
-            (zmax - zmin) / nelements[3],
-        )
-        @test obtain_surface_space(z_column.space.subsurface) ==
-              z_column.space.surface
-        @test obtain_surface_domain(z_column) ==
-              Point{FT}(zlim[2], (; surface = z_column.space.surface))
-        z_column_stretch =
-            Column(; zlim = zlim, nelements = 10, dz_tuple = FT.((0.3, 0.03)))
-        column_coords = coordinates(z_column_stretch).subsurface
-        @test z_column_stretch.zlim == FT.(zlim)
-        dz =
-            parent(column_coords)[:][2:end] .-
-            parent(column_coords)[:][1:(end - 1)]
-        @test abs(dz[1] - 0.3) < 1e-1
-        @test abs(dz[end] - 0.03) < 1e-2
-    end
+    z_column = Column(; zlim = zlim, nelements = nelements[3])
+    column_coords = coordinates(z_column).subsurface
+    @test z_column.zlim == FT.(zlim)
+    @test z_column.nelements[1] == nelements[3]
+    @test eltype(column_coords) == ClimaCore.Geometry.ZPoint{FT}
+    @test typeof(column_coords) <: ClimaCore.Fields.Field
+    @test typeof(z_column.space.subsurface) <:
+          ClimaCore.Spaces.CenterFiniteDifferenceSpace
+    @test typeof(z_column.space.surface) <: ClimaCore.Spaces.PointSpace
+    @test any(
+        parent(column_coords)[:][2:end] .-
+        parent(column_coords)[:][1:(end - 1)] .≈ (zmax - zmin) / nelements[3],
+    )
+    @test obtain_surface_space(z_column.space.subsurface) ==
+          z_column.space.surface
+    @test obtain_surface_domain(z_column) ==
+          Point{FT}(zlim[2], (; surface = z_column.space.surface))
+    z_column_stretch =
+        Column(; zlim = zlim, nelements = 10, dz_tuple = FT.((0.3, 0.03)))
+    column_coords = coordinates(z_column_stretch).subsurface
+    @test z_column_stretch.zlim == FT.(zlim)
+    dz =
+        parent(column_coords)[:][2:end] .- parent(column_coords)[:][1:(end - 1)]
+    @test abs(dz[1] - 0.3) < 1e-1
+    @test abs(dz[end] - 0.03) < 1e-2
 end
 
-
-@testset "Point Domain" begin
-    for FT in TestFloatTypes
-        zmin = FT(1.0)
-        point = Point(; z_sfc = zmin)
-        @test point.z_sfc == zmin
-        point_space = point.space.surface
-        @test point_space isa ClimaCore.Spaces.PointSpace
-        coords = coordinates(point).surface
-        @test coords isa ClimaCore.Fields.Field
-        @test eltype(coords) == ClimaCore.Geometry.ZPoint{FT}
-        @test ClimaCore.Fields.field_values(coords)[] ==
-              ClimaCore.Geometry.ZPoint(zmin)
-    end
+@testset "Point Domain, FT = $FT" begin
+    zmin = FT(1.0)
+    point = Point(; z_sfc = zmin)
+    @test point.z_sfc == zmin
+    point_space = point.space.surface
+    @test point_space isa ClimaCore.Spaces.PointSpace
+    coords = coordinates(point).surface
+    @test coords isa ClimaCore.Fields.Field
+    @test eltype(coords) == ClimaCore.Geometry.ZPoint{FT}
+    @test ClimaCore.Fields.field_values(coords)[] ==
+          ClimaCore.Geometry.ZPoint(zmin)
 end

--- a/test/shared_utilities/file_reader.jl
+++ b/test/shared_utilities/file_reader.jl
@@ -24,392 +24,372 @@ isdir(regrid_dir_static) ? nothing : mkpath(regrid_dir_static)
 isdir(regrid_dir_temporal) ? nothing : mkpath(regrid_dir_temporal)
 
 
-for FT in (Float64, Float32)
-    @testset "test to_datetime for FT=$FT" begin
-        year = 2000
-        dt_noleap = DateTimeNoLeap(year)
-        @test FileReader.to_datetime(dt_noleap) == DateTime(year)
+FT = Float32
+@testset "test interpol, FT = $FT" begin
+    # Setup
+    t1 = FT(0)
+    t2 = FT(10)
+
+    f1 = FT(-1)
+    f2 = FT(1)
+
+    # Case 1: t1 < t < t2
+    t = FT(5)
+    @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == 0
+
+    # Case 2: t1 = t < t2
+    t = FT(0)
+    @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == f1
+
+    # Case 3: t1 < t = t2
+    t = FT(10)
+    @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == f2
+end
+
+@testset "test interpolate_data, FT = $FT" begin
+    # test interpolate_data with interpolation (default)
+    dummy_dates =
+        Vector(range(DateTime(1999, 1, 1); step = Day(1), length = 100))
+    date_idx0 = Int[1]
+    date_ref = dummy_dates[Int(date_idx0[1]) + 1]
+    t_start = FT(0)
+    date0 = date_ref + Dates.Second(t_start)
+
+    # these values give an `interp_fraction` of 0.5 in `interpol` for ease of testing
+    segment_length =
+        [Int(2) * ((date_ref - dummy_dates[Int(date_idx0[1])]).value)]
+
+    radius = FT(6731e3)
+    Nq = 4
+    domain_sphere = ClimaCore.Domains.SphereDomain(radius)
+    mesh = Meshes.EquiangularCubedSphere(domain_sphere, 4)
+    topology = Topologies.Topology2D(mesh)
+    quad = Spaces.Quadratures.GLL{Nq}()
+    surface_space_t = Spaces.SpectralElementSpace2D(topology, quad)
+    data_fields = (zeros(surface_space_t), ones(surface_space_t))
+
+    # create structs manually since we aren't reading from a data file
+    file_info = FileReader.FileInfo(
+        "",             # infile_path
+        "",             # regrid_dirpath
+        "",             # varname
+        "",             # outfile_root
+        dummy_dates,    # all_dates
+        date_idx0,      # date_idx0
+    )
+    file_state = FileReader.FileState(
+        data_fields,        # data_fields
+        copy(date_idx0),    # date_idx
+        segment_length,     # segment_length
+    )
+    sim_info = FileReader.SimInfo(
+        date_ref,       # date_ref
+        t_start,        # t_start
+    )
+
+    pd_args = (file_info, file_state, sim_info)
+    prescribed_data =
+        FileReader.PrescribedDataTemporal{typeof.(pd_args)...}(pd_args...)
+
+    # Note: we expect this to give a warning "No dates available in file..."
+    @test FileReader.interpolate_data(
+        prescribed_data,
+        date0,
+        surface_space_t,
+    ) == ones(surface_space_t) .* FT(0.5)
+end
+
+@testset "test to_datetime, FT = $FT" begin
+    year = 2000
+    dt_noleap = DateTimeNoLeap(year)
+    @test FileReader.to_datetime(dt_noleap) == DateTime(year)
+end
+
+@testset "test next_date_in_file, FT = $FT" begin
+    dummy_dates =
+        Vector(range(DateTime(1999, 1, 1); step = Day(1), length = 10))
+    date_ref = dummy_dates[1]
+    t_start = FT(0)
+    date0 = date_ref + Dates.Second(t_start)
+    date_idx0 =
+        [argmin(abs.(Dates.value(date0) .- Dates.value.(dummy_dates[:])))]
+
+    # manually create structs to avoid creating space for outer constructor
+    file_info = FileReader.FileInfo(
+        "",             # infile_path
+        "",             # regrid_dirpath
+        "",             # varname
+        "",             # outfile_root
+        dummy_dates,    # all_dates
+        date_idx0,      # date_idx0
+    )
+    file_state = FileReader.FileState(
+        nothing,            # data_fields
+        copy(date_idx0),    # date_idx
+        Int[],              # segment_length
+    )
+    sim_info = nothing
+
+    pd_args = (file_info, file_state, sim_info)
+    prescribed_data =
+        FileReader.PrescribedDataTemporal{typeof.(pd_args)...}(pd_args...)
+
+    # read in next dates, manually compare to `dummy_dates` array
+    idx = date_idx0[1]
+    next_date = date0
+    for i in 1:(length(dummy_dates) - 1)
+        current_date = next_date
+        next_date = FileReader.next_date_in_file(prescribed_data)
+
+        @test next_date == dummy_dates[idx + 1]
+
+        prescribed_data.file_state.date_idx[1] += 1
+        idx = date_idx0[1] + i
     end
+end
 
-    @testset "test next_date_in_file for FT=$FT" begin
-        dummy_dates =
-            Vector(range(DateTime(1999, 1, 1); step = Day(1), length = 10))
-        date_ref = dummy_dates[1]
-        t_start = FT(0)
-        date0 = date_ref + Dates.Second(t_start)
-        date_idx0 =
-            [argmin(abs.(Dates.value(date0) .- Dates.value.(dummy_dates[:])))]
+@testset "test PrescribedDataStatic construction, FT = $FT" begin
+    infile_path = albedo_temporal_data
+    varname = "sw_alb"
+    ps_data_spatial =
+        FileReader.PrescribedDataStatic(infile_path, regrid_dir_static, varname)
 
-        # manually create structs to avoid creating space for outer constructor
-        file_info = FileReader.FileInfo(
-            "",             # infile_path
-            "",             # regrid_dirpath
-            "",             # varname
-            "",             # outfile_root
-            dummy_dates,    # all_dates
-            date_idx0,      # date_idx0
-        )
-        file_state = FileReader.FileState(
-            nothing,            # data_fields
-            copy(date_idx0),    # date_idx
-            Int[],              # segment_length
-        )
-        sim_info = nothing
+    # test that created object exists
+    @test @isdefined(ps_data_spatial)
+    @test ps_data_spatial isa FileReader.AbstractPrescribedData
 
-        prescribed_data =
-            FileReader.PrescribedDataTemporal(file_info, file_state, sim_info)
+    # test fields that we've passed into constructor as args
+    @test ps_data_spatial.file_info.infile_path == infile_path
+    @test ps_data_spatial.file_info.regrid_dirpath == regrid_dir_static
+    @test ps_data_spatial.file_info.varname == varname
 
-        # read in next dates, manually compare to `dummy_dates` array
-        idx = date_idx0[1]
-        next_date = date0
-        for i in 1:(length(dummy_dates) - 1)
-            current_date = next_date
-            next_date = FileReader.next_date_in_file(prescribed_data)
+    # test fields which are set internally by constructor
+    @test ps_data_spatial.file_info.outfile_root == ""
+    @test ps_data_spatial.file_info.all_dates == []
+    @test ps_data_spatial.file_info.date_idx0 == []
+end
 
-            @test next_date == dummy_dates[idx + 1]
-
-            prescribed_data.file_state.date_idx[1] += 1
-            idx = date_idx0[1] + i
-        end
-    end
-
-    @testset "test interpol for FT=$FT" begin
-        # Setup
-        t1 = FT(0)
-        t2 = FT(10)
-
-        f1 = FT(-1)
-        f2 = FT(1)
-
-        # Case 1: t1 < t < t2
-        t = FT(5)
-        @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == 0
-
-        # Case 2: t1 = t < t2
-        t = FT(0)
-        @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == f1
-
-        # Case 3: t1 < t = t2
-        t = FT(10)
-        @test FileReader.interpol(f1, f2, t - t1, t2 - t1) == f2
-    end
-
-    @testset "test interpolate_data for FT=$FT" begin
-        # test interpolate_data with interpolation (default)
-        dummy_dates =
-            Vector(range(DateTime(1999, 1, 1); step = Day(1), length = 100))
-        date_idx0 = Int[1]
-        date_ref = dummy_dates[Int(date_idx0[1]) + 1]
-        t_start = FT(0)
-        date0 = date_ref + Dates.Second(t_start)
-
-        # these values give an `interp_fraction` of 0.5 in `interpol` for ease of testing
-        segment_length =
-            [Int(2) * ((date_ref - dummy_dates[Int(date_idx0[1])]).value)]
-
+# Add tests which use TempestRemap here -
+# TempestRemap is not built on Windows because of NetCDF support limitations
+# `PrescribedDataTemporal` uses TR via a call to `hdwrite_regridfile_rll_to_cgll`
+if !Sys.iswindows()
+    @testset "test PrescribedDataTemporal construction, FT = $FT" begin
+        # setup for test
         radius = FT(6731e3)
         Nq = 4
-        domain_sphere = ClimaCore.Domains.SphereDomain(radius)
-        mesh = Meshes.EquiangularCubedSphere(domain_sphere, 4)
+        domain = ClimaCore.Domains.SphereDomain(radius)
+        mesh = Meshes.EquiangularCubedSphere(domain, 4)
         topology = Topologies.Topology2D(mesh)
         quad = Spaces.Quadratures.GLL{Nq}()
         surface_space_t = Spaces.SpectralElementSpace2D(topology, quad)
-        data_fields = (zeros(surface_space_t), ones(surface_space_t))
 
-        # create structs manually since we aren't reading from a data file
-        file_info = FileReader.FileInfo(
-            "",             # infile_path
-            "",             # regrid_dirpath
-            "",             # varname
-            "",             # outfile_root
-            dummy_dates,    # all_dates
-            date_idx0,      # date_idx0
-        )
-        file_state = FileReader.FileState(
-            data_fields,        # data_fields
-            copy(date_idx0),    # date_idx
-            segment_length,     # segment_length
-        )
-        sim_info = FileReader.SimInfo(
-            date_ref,       # date_ref
-            t_start,        # t_start
-        )
-
-        prescribed_data = FileReader.PrescribedDataTemporal(
-            file_info,      # file_info
-            file_state,     # file_state
-            sim_info,       # sim_info
-        )
-
-        # Note: we expect this to give a warning "No dates available in file..."
-        @test FileReader.interpolate_data(
-            prescribed_data,
-            date0,
-            surface_space_t,
-        ) == ones(surface_space_t) .* FT(0.5)
-    end
-
-    @testset "test PrescribedDataStatic construction for FT=$FT" begin
         infile_path = albedo_temporal_data
         varname = "sw_alb"
-        ps_data_spatial = FileReader.PrescribedDataStatic(
+        date_idx0 = Int[1]
+        date_ref = DateTime(1800, 1, 1)
+        t_start = FT(0)
+
+        ps_data_temp = FileReader.PrescribedDataTemporal{FT}(
+            regrid_dir_temporal,
             infile_path,
-            regrid_dir_static,
             varname,
+            date_ref,
+            t_start,
+            surface_space_t,
         )
 
         # test that created object exists
-        @test @isdefined(ps_data_spatial)
-        @test ps_data_spatial isa FileReader.AbstractPrescribedData
+        @test @isdefined(ps_data_temp)
+        @test ps_data_temp isa FileReader.AbstractPrescribedData
 
         # test fields that we've passed into constructor as args
-        @test ps_data_spatial.file_info.infile_path == infile_path
-        @test ps_data_spatial.file_info.regrid_dirpath == regrid_dir_static
-        @test ps_data_spatial.file_info.varname == varname
+        @test ps_data_temp.file_info.regrid_dirpath == regrid_dir_temporal
+        @test ps_data_temp.file_info.varname == varname
+        @test ps_data_temp.file_info.date_idx0 == date_idx0
+        @test ps_data_temp.file_state.date_idx == date_idx0
+        @test ps_data_temp.sim_info.date_ref == date_ref
+        @test ps_data_temp.sim_info.t_start == t_start
 
         # test fields which are set internally by constructor
-        @test ps_data_spatial.file_info.outfile_root == ""
-        @test ps_data_spatial.file_info.all_dates == []
-        @test ps_data_spatial.file_info.date_idx0 == []
+        @test ps_data_temp.file_info.outfile_root != ""
+        @test !isnothing(ps_data_temp.file_info.all_dates)
+        @test !isnothing(ps_data_temp.file_state.data_fields)
+        @test !isnothing(ps_data_temp.file_state.segment_length)
     end
 
-    # Add tests which use TempestRemap here -
-    # TempestRemap is not built on Windows because of NetCDF support limitations
-    # `PrescribedDataTemporal` uses TR via a call to `hdwrite_regridfile_rll_to_cgll`
-    if !Sys.iswindows()
-        @testset "test PrescribedDataTemporal construction for FT=$FT" begin
-            # setup for test
-            radius = FT(6731e3)
-            Nq = 4
-            domain = ClimaCore.Domains.SphereDomain(radius)
-            mesh = Meshes.EquiangularCubedSphere(domain, 4)
-            topology = Topologies.Topology2D(mesh)
-            quad = Spaces.Quadratures.GLL{Nq}()
-            surface_space_t = Spaces.SpectralElementSpace2D(topology, quad)
+    @testset "test read_data_fields!, FT = $FT" begin
+        # setup for test
+        datafile_rll = albedo_temporal_data
+        varname = "sw_alb"
 
-            infile_path = albedo_temporal_data
-            varname = "sw_alb"
-            date_idx0 = Int[1]
-            date_ref = DateTime(1800, 1, 1)
-            t_start = FT(0)
+        # Start with first date in data file
+        date0 = NCDataset(datafile_rll) do ds
+            ds["time"][1]
+        end
+        date0 = FileReader.to_datetime(date0)
+        dates = collect(date0:Day(10):(date0 + Day(100))) # includes both endpoints
+        date_ref = date0
+        t_start = FT(0)
 
-            ps_data_temp = FileReader.PrescribedDataTemporal(
-                regrid_dir_temporal,
-                infile_path,
-                varname,
-                date_ref,
-                t_start,
-                surface_space_t,
-            )
+        radius = FT(6731e3)
+        Nq = 4
+        domain = ClimaCore.Domains.SphereDomain(radius)
+        mesh = Meshes.EquiangularCubedSphere(domain, 4)
+        topology = Topologies.DistributedTopology2D(
+            comms_ctx,
+            mesh,
+            Topologies.spacefillingcurve(mesh),
+        )
+        quad = Spaces.Quadratures.GLL{Nq}()
+        surface_space_t = Spaces.SpectralElementSpace2D(topology, quad)
 
-            # test that created object exists
-            @test @isdefined(ps_data_temp)
-            @test ps_data_temp isa FileReader.AbstractPrescribedData
+        prescribed_data = FileReader.PrescribedDataTemporal{FT}(
+            regrid_dir_temporal,
+            albedo_temporal_data,
+            varname,
+            date_ref,
+            t_start,
+            surface_space_t,
+        )
 
-            # test fields that we've passed into constructor as args
-            @test ps_data_temp.file_info.regrid_dirpath == regrid_dir_temporal
-            @test ps_data_temp.file_info.varname == varname
-            @test ps_data_temp.file_info.date_idx0 == date_idx0
-            @test ps_data_temp.file_state.date_idx == date_idx0
-            @test ps_data_temp.sim_info.date_ref == date_ref
-            @test ps_data_temp.sim_info.t_start == t_start
+        # Test each case (1-4)
+        current_fields =
+            Fields.zeros(FT, surface_space_t), Fields.zeros(FT, surface_space_t)
 
-            # test fields which are set internally by constructor
-            @test ps_data_temp.file_info.outfile_root != ""
-            @test !isnothing(ps_data_temp.file_info.all_dates)
-            @test !isnothing(ps_data_temp.file_state.data_fields)
-            @test !isnothing(ps_data_temp.file_state.segment_length)
+        # Use this function to reset values between test cases
+        function reset_ps_data(ps_data)
+            ps_data.file_state.data_fields[1] .= current_fields[1]
+            ps_data.file_state.data_fields[2] .= current_fields[2]
+            ps_data.file_state.segment_length[1] =
+                ps_data.file_state.date_idx[1] =
+                    ps_data.file_info.date_idx0[1] = Int(1)
         end
 
-        @testset "test read_data_fields! for FT=$FT" begin
-            # setup for test
-            datafile_rll = albedo_temporal_data
-            varname = "sw_alb"
+        # Case 1: test initial date - aligned with first date of albedo file
+        # This case should not print any warnings
+        reset_ps_data(prescribed_data)
+        prescribed_data_copy = prescribed_data
+        FileReader.read_data_fields!(prescribed_data, date0, surface_space_t)
 
-            # Start with first date in data file
-            date0 = NCDataset(datafile_rll) do ds
-                ds["time"][1]
-            end
-            date0 = FileReader.to_datetime(date0)
-            dates = collect(date0:Day(10):(date0 + Day(100))) # includes both endpoints
-            date_ref = date0
-            t_start = FT(0)
+        # Test that both data fields store the same data
+        # Remove NaNs and missings before comparison
+        (; data_fields) = prescribed_data.file_state
+        replace!(parent(data_fields[1]), NaN => 0)
+        replace!(parent(data_fields[1]), missing => 0)
+        replace!(parent(data_fields[2]), NaN => 0)
+        replace!(parent(data_fields[2]), missing => 0)
 
-            radius = FT(6731e3)
-            Nq = 4
-            domain = ClimaCore.Domains.SphereDomain(radius)
-            mesh = Meshes.EquiangularCubedSphere(domain, 4)
-            topology = Topologies.DistributedTopology2D(
-                comms_ctx,
-                mesh,
-                Topologies.spacefillingcurve(mesh),
-            )
-            quad = Spaces.Quadratures.GLL{Nq}()
-            surface_space_t = Spaces.SpectralElementSpace2D(topology, quad)
-
-            prescribed_data = FileReader.PrescribedDataTemporal(
-                regrid_dir_temporal,
-                albedo_temporal_data,
-                varname,
-                date_ref,
-                t_start,
-                surface_space_t,
-            )
-
-            # Test each case (1-4)
-            current_fields = Fields.zeros(FT, surface_space_t),
-            Fields.zeros(FT, surface_space_t)
-
-            # Use this function to reset values between test cases
-            function reset_ps_data(ps_data)
-                ps_data.file_state.data_fields[1] .= current_fields[1]
-                ps_data.file_state.data_fields[2] .= current_fields[2]
-                ps_data.file_state.segment_length[1] =
-                    ps_data.file_state.date_idx[1] =
-                        ps_data.file_info.date_idx0[1] = Int(1)
-            end
-
-            # Case 1: test initial date - aligned with first date of albedo file
-            # This case should not print any warnings
-            reset_ps_data(prescribed_data)
-            prescribed_data_copy = prescribed_data
-            FileReader.read_data_fields!(
-                prescribed_data,
-                date0,
-                surface_space_t,
-            )
-
-            # Test that both data fields store the same data
-            # Remove NaNs and missings before comparison
-            (; data_fields) = prescribed_data.file_state
-            replace!(parent(data_fields[1]), NaN => 0)
-            replace!(parent(data_fields[1]), missing => 0)
-            replace!(parent(data_fields[2]), NaN => 0)
-            replace!(parent(data_fields[2]), missing => 0)
-
-            @test prescribed_data.file_state.data_fields[1] ==
-                  prescribed_data.file_state.data_fields[2]
-            # date_idx and date_idx0 should be unchanged
-            @test prescribed_data.file_state.segment_length == Int[0]
-            @test prescribed_data.file_state.date_idx[1] ==
-                  prescribed_data_copy.file_state.date_idx[1]
-            @test prescribed_data.file_info.date_idx0[1] ==
-                  prescribed_data_copy.file_info.date_idx0[1]
+        @test prescribed_data.file_state.data_fields[1] ==
+              prescribed_data.file_state.data_fields[2]
+        # date_idx and date_idx0 should be unchanged
+        @test prescribed_data.file_state.segment_length == Int[0]
+        @test prescribed_data.file_state.date_idx[1] ==
+              prescribed_data_copy.file_state.date_idx[1]
+        @test prescribed_data.file_info.date_idx0[1] ==
+              prescribed_data_copy.file_info.date_idx0[1]
 
 
-            # Case 2: test date after dates in file
-            # This case should print 1 warning "this time period is after input data..."
-            reset_ps_data(prescribed_data)
-            date_after = prescribed_data.file_info.all_dates[end] + Dates.Day(1)
-            prescribed_data_copy = prescribed_data
-            FileReader.read_data_fields!(
-                prescribed_data,
-                date_after,
-                surface_space_t,
-            )
+        # Case 2: test date after dates in file
+        # This case should print 1 warning "this time period is after input data..."
+        reset_ps_data(prescribed_data)
+        date_after = prescribed_data.file_info.all_dates[end] + Dates.Day(1)
+        prescribed_data_copy = prescribed_data
+        FileReader.read_data_fields!(
+            prescribed_data,
+            date_after,
+            surface_space_t,
+        )
 
-            # Test that both data fields store the same data
-            @test prescribed_data.file_state.segment_length == Int[0]
+        # Test that both data fields store the same data
+        @test prescribed_data.file_state.segment_length == Int[0]
 
-            # Remove NaNs and missings before comparison
-            replace!(
-                parent(prescribed_data.file_state.data_fields[1]),
-                NaN => 0,
-            )
-            replace!(
-                parent(prescribed_data.file_state.data_fields[1]),
-                missing => 0,
-            )
-            replace!(
-                parent(prescribed_data.file_state.data_fields[2]),
-                NaN => 0,
-            )
-            replace!(
-                parent(prescribed_data.file_state.data_fields[2]),
-                missing => 0,
-            )
-            @test prescribed_data.file_state.data_fields[1] ==
-                  prescribed_data.file_state.data_fields[2]
+        # Remove NaNs and missings before comparison
+        replace!(parent(prescribed_data.file_state.data_fields[1]), NaN => 0)
+        replace!(
+            parent(prescribed_data.file_state.data_fields[1]),
+            missing => 0,
+        )
+        replace!(parent(prescribed_data.file_state.data_fields[2]), NaN => 0)
+        replace!(
+            parent(prescribed_data.file_state.data_fields[2]),
+            missing => 0,
+        )
+        @test prescribed_data.file_state.data_fields[1] ==
+              prescribed_data.file_state.data_fields[2]
 
-            # Case 3: loop over simulation dates (general case)
-            # This case should print 3 warnings "updating data files: ..."
-            data_saved = []
-            updating_dates = []
+        # Case 3: loop over simulation dates (general case)
+        # This case should print 3 warnings "updating data files: ..."
+        data_saved = []
+        updating_dates = []
 
-            # Read in data fields over dummy times
-            # With the current test setup, read_data_fields! should get called 3 times
-            for date in dates
-                callback_date = FileReader.next_date_in_file(prescribed_data)
+        # Read in data fields over dummy times
+        # With the current test setup, read_data_fields! should get called 3 times
+        for date in dates
+            callback_date = FileReader.next_date_in_file(prescribed_data)
 
-                if (date >= callback_date)
-                    FileReader.read_data_fields!(
-                        prescribed_data,
-                        date,
-                        surface_space_t,
-                    )
-                    push!(
-                        data_saved,
-                        deepcopy(prescribed_data.file_state.data_fields[1]),
-                    )
-                    push!(updating_dates, deepcopy(date))
-                end
-            end
-
-            # Replace NaNs and missings for testing
-            for ds in data_saved
-                replace!(parent(ds), NaN => 0)
-                replace!(parent(ds), missing => 0)
-            end
-
-            # Manually read in data from HDF5
-            f = prescribed_data.file_state.data_fields[1]
-            data_manual = [similar(f), similar(f), similar(f)]
-            (; regrid_dirpath, outfile_root, varname, all_dates) =
-                prescribed_data.file_info
-            for i in eachindex(data_saved)
-                data_manual[i] = Regridder.swap_space!(
-                    Regridder.read_from_hdf5(
-                        regrid_dirpath,
-                        outfile_root,
-                        all_dates[i + 1],
-                        varname,
-                        comms_ctx,
-                    ),
+            if (date >= callback_date)
+                FileReader.read_data_fields!(
+                    prescribed_data,
+                    date,
                     surface_space_t,
                 )
-                # Replace NaNs and missings for testing comparison
-                replace!(parent(data_manual[i]), NaN => 0)
-                replace!(parent(data_manual[i]), missing => 0)
-
-                @test parent(data_saved[i]) == parent(data_manual[i])
+                push!(
+                    data_saved,
+                    deepcopy(prescribed_data.file_state.data_fields[1]),
+                )
+                push!(updating_dates, deepcopy(date))
             end
+        end
 
-            # Test that the data_saved array was modified
-            @test length(data_saved) > 0
-            # Check that the final saved date is as expected (midmonth day of last month)
-            midmonth_end = DateTime(
-                year(dates[end]),
-                month(dates[end]),
-                15,
-                hour(dates[end]),
-            )
-            @test updating_dates[end] == midmonth_end
+        # Replace NaNs and missings for testing
+        for ds in data_saved
+            replace!(parent(ds), NaN => 0)
+            replace!(parent(ds), missing => 0)
+        end
 
-            # Case 4: everything else
-            reset_ps_data(prescribed_data)
-            prescribed_data.file_state.date_idx[1] =
-                prescribed_data.file_info.date_idx0[1] + Int(1)
-            date =
-                prescribed_data.file_info.all_dates[prescribed_data.file_state.date_idx[1]] -
-                Dates.Day(1)
-
-            @test_throws ErrorException FileReader.read_data_fields!(
-                prescribed_data,
-                date,
+        # Manually read in data from HDF5
+        f = prescribed_data.file_state.data_fields[1]
+        data_manual = [similar(f), similar(f), similar(f)]
+        (; regrid_dirpath, outfile_root, varname, all_dates) =
+            prescribed_data.file_info
+        for i in eachindex(data_saved)
+            data_manual[i] = Regridder.swap_space!(
+                Regridder.read_from_hdf5(
+                    regrid_dirpath,
+                    outfile_root,
+                    all_dates[i + 1],
+                    varname,
+                    comms_ctx,
+                ),
                 surface_space_t,
             )
+            # Replace NaNs and missings for testing comparison
+            replace!(parent(data_manual[i]), NaN => 0)
+            replace!(parent(data_manual[i]), missing => 0)
 
+            @test parent(data_saved[i]) == parent(data_manual[i])
         end
+
+        # Test that the data_saved array was modified
+        @test length(data_saved) > 0
+        # Check that the final saved date is as expected (midmonth day of last month)
+        midmonth_end =
+            DateTime(year(dates[end]), month(dates[end]), 15, hour(dates[end]))
+        @test updating_dates[end] == midmonth_end
+
+        # Case 4: everything else
+        reset_ps_data(prescribed_data)
+        prescribed_data.file_state.date_idx[1] =
+            prescribed_data.file_info.date_idx0[1] + Int(1)
+        date =
+            prescribed_data.file_info.all_dates[prescribed_data.file_state.date_idx[1]] -
+            Dates.Day(1)
+
+        @test_throws ErrorException FileReader.read_data_fields!(
+            prescribed_data,
+            date,
+            surface_space_t,
+        )
     end
 end
 

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -11,185 +11,187 @@ import ClimaLSM.Parameters as LSMP
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
-@testset "Richards Jacobian entries, Moisture BC" begin
-    FT = Float64
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(1.43)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.124)
-    zmax = FT(0)
-    zmin = FT(-1.5)
-    nelems = 150
-    soil_domains = [
-        Column(; zlim = (zmin, zmax), nelements = nelems),
-        HybridBox(;
-            xlim = (0.0, 1.0),
-            ylim = (0.0, 1.0),
-            zlim = (zmin, zmax),
-            nelements = (1, 1, nelems),
-            npolynomial = 3,
-        ),
-    ]
-    top_state_bc = MoistureStateBC((p, t) -> eltype(t)(ν - 1e-3))
-    bot_flux_bc = FreeDrainage()
-    sources = ()
-    boundary_states =
-        (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
-    params = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+for FT in (Float32, Float64)
+    @testset "Richards Jacobian entries, Moisture BC, FT = $FT" begin
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(1.43)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.124)
+        zmax = FT(0)
+        zmin = FT(-1.5)
+        nelems = 150
+        soil_domains = [
+            Column(; zlim = (zmin, zmax), nelements = nelems),
+            HybridBox(;
+                xlim = FT.((0, 1)),
+                ylim = FT.((0, 1)),
+                zlim = (zmin, zmax),
+                nelements = (1, 1, nelems),
+                npolynomial = 3,
+            ),
+        ]
+        top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
+        bot_flux_bc = FreeDrainage()
+        sources = ()
+        boundary_states =
+            (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+        params =
+            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
 
-    for domain in soil_domains
-        soil = Soil.RichardsModel{FT}(;
-            parameters = params,
-            domain = domain,
-            boundary_conditions = boundary_states,
-            sources = sources,
-        )
+        for domain in soil_domains
+            soil = Soil.RichardsModel{FT}(;
+                parameters = params,
+                domain = domain,
+                boundary_conditions = boundary_states,
+                sources = sources,
+            )
 
-        Y, p, coords = initialize(soil)
-        Y.soil.ϑ_l .= FT(0.24)
-        # We do not set the initial aux state here because
-        # we want to test that it is updated correctly in
-        # the jacobian correctly.
-        W = RichardsTridiagonalW(Y)
-        Wfact! = make_tendency_jacobian(soil)
-        dtγ = FT(1.0)
-        Wfact!(W, Y, p, dtγ, FT(0.0))
+            Y, p, coords = initialize(soil)
+            Y.soil.ϑ_l .= FT(0.24)
+            # We do not set the initial aux state here because
+            # we want to test that it is updated correctly in
+            # the jacobian correctly.
+            W = RichardsTridiagonalW(Y)
+            Wfact! = make_tendency_jacobian(soil)
+            dtγ = FT(1.0)
+            Wfact!(W, Y, p, dtγ, FT(0.0))
 
-        K_ic = hydraulic_conductivity(
-            hcm,
-            K_sat,
-            effective_saturation(ν, FT(0.24), θ_r),
-        )
-        dz = FT(0.01)
-        dψdϑ_ic = dψdϑ(hcm, FT(0.24), ν, θ_r, S_s)
+            K_ic = hydraulic_conductivity(
+                hcm,
+                K_sat,
+                effective_saturation(ν, FT(0.24), θ_r),
+            )
+            dz = FT(0.01)
+            dψdϑ_ic = dψdϑ(hcm, FT(0.24), ν, θ_r, S_s)
 
-        @test all(parent(W.temp2) .== FT(0.0))
-        @test all(parent(W.temp2) .== FT(0.0))
-        @test W.transform == false
-        @test typeof(W.W_column_arrays) <:
-              Vector{LinearAlgebra.Tridiagonal{Float64, Vector{Float64}}}
-        @test length(W.W_column_arrays) == 1
-        if typeof(domain) <: Column
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end] .≈
-                parent(W.∂ϑₜ∂ϑ.coefs.:3)[1:(end - 1)],
-            )
-            @test parent(W.∂ϑₜ∂ϑ.coefs.:1)[1] == FT(0)
-            @test parent(W.∂ϑₜ∂ϑ.coefs.:3)[end] == FT(0)
-            @test all(parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end] .≈ K_ic / dz^2 * dψdϑ_ic)
-            @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[1] .≈ -K_ic / dz^2 * dψdϑ_ic
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1)] .≈
-                -2 * K_ic / dz^2 * dψdϑ_ic,
-            )
-            @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[end] .≈
-                  -K_ic / dz^2 * dψdϑ_ic - K_ic / (dz * dz / 2) * dψdϑ_ic
-        elseif typeof(domain) <: HybridBox
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end, :, 1, 1, 1] .≈
-                parent(W.∂ϑₜ∂ϑ.coefs.:3)[1:(end - 1), :, 1, 1, 1],
-            )
-            @test all(parent(W.∂ϑₜ∂ϑ.coefs.:1)[1, :, 1, 1, 1] .== FT(0))
-            @test all(parent(W.∂ϑₜ∂ϑ.coefs.:3)[end, :, 1, 1, 1] .== FT(0))
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end, :, 1, 1, 1] .≈
-                K_ic / dz^2 * dψdϑ_ic,
-            )
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[1, :, 1, 1, 1] .≈
-                -K_ic / dz^2 * dψdϑ_ic,
-            )
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1), :, 1, 1, 1] .≈
-                -2 * K_ic / dz^2 * dψdϑ_ic,
-            )
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[end, :, 1, 1, 1] .≈
-                -K_ic / dz^2 * dψdϑ_ic - K_ic / (dz * dz / 2) * dψdϑ_ic,
-            )
+            @test all(parent(W.temp2) .== FT(0.0))
+            @test all(parent(W.temp2) .== FT(0.0))
+            @test W.transform == false
+            @test typeof(W.W_column_arrays) <:
+                  Vector{LinearAlgebra.Tridiagonal{FT, Vector{FT}}}
+            @test length(W.W_column_arrays) == 1
+            if typeof(domain) <: Column
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end] .≈
+                    parent(W.∂ϑₜ∂ϑ.coefs.:3)[1:(end - 1)],
+                )
+                @test parent(W.∂ϑₜ∂ϑ.coefs.:1)[1] == FT(0)
+                @test parent(W.∂ϑₜ∂ϑ.coefs.:3)[end] == FT(0)
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end] .≈ K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[1] .≈ -K_ic / dz^2 * dψdϑ_ic
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1)] .≈
+                    -2 * K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[end] .≈
+                      -K_ic / dz^2 * dψdϑ_ic - K_ic / (dz * dz / 2) * dψdϑ_ic
+            elseif typeof(domain) <: HybridBox
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end, :, 1, 1, 1] .≈
+                    parent(W.∂ϑₜ∂ϑ.coefs.:3)[1:(end - 1), :, 1, 1, 1],
+                )
+                @test all(parent(W.∂ϑₜ∂ϑ.coefs.:1)[1, :, 1, 1, 1] .== FT(0))
+                @test all(parent(W.∂ϑₜ∂ϑ.coefs.:3)[end, :, 1, 1, 1] .== FT(0))
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:1)[2:end, :, 1, 1, 1] .≈
+                    K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[1, :, 1, 1, 1] .≈
+                    -K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1), :, 1, 1, 1] .≈
+                    -2 * K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[end, :, 1, 1, 1] .≈
+                    -K_ic / dz^2 * dψdϑ_ic - K_ic / (dz * dz / 2) * dψdϑ_ic,
+                )
+            end
+
         end
-
     end
-end
 
+    @testset "Richards Jacobian entries, Flux BC, FT = $FT" begin
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(1.43)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.124)
+        zmax = FT(0)
+        zmin = FT(-1.5)
+        nelems = 150
+        soil_domains = [
+            Column(; zlim = (zmin, zmax), nelements = nelems),
+            HybridBox(;
+                xlim = FT.((0, 1)),
+                ylim = FT.((0, 1)),
+                zlim = (zmin, zmax),
+                nelements = (1, 1, nelems),
+                npolynomial = 3,
+            ),
+        ]
+        top_flux_bc = FluxBC((p, t) -> -K_sat)
+        bot_flux_bc = FreeDrainage()
+        sources = ()
+        boundary_states =
+            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        params =
+            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        for domain in soil_domains
+            soil = Soil.RichardsModel{FT}(;
+                parameters = params,
+                domain = domain,
+                boundary_conditions = boundary_states,
+                sources = sources,
+            )
 
-@testset "Richards Jacobian entries, Flux BC" begin
-    FT = Float64
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(1.43)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.124)
-    zmax = FT(0)
-    zmin = FT(-1.5)
-    nelems = 150
-    soil_domains = [
-        Column(; zlim = (zmin, zmax), nelements = nelems),
-        HybridBox(;
-            xlim = (0.0, 1.0),
-            ylim = (0.0, 1.0),
-            zlim = (zmin, zmax),
-            nelements = (1, 1, nelems),
-            npolynomial = 3,
-        ),
-    ]
-    top_flux_bc = FluxBC((p, t) -> eltype(t)(-K_sat))
-    bot_flux_bc = FreeDrainage()
-    sources = ()
-    boundary_states =
-        (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
-    params = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
-    for domain in soil_domains
-        soil = Soil.RichardsModel{FT}(;
-            parameters = params,
-            domain = domain,
-            boundary_conditions = boundary_states,
-            sources = sources,
-        )
+            Y, p, coords = initialize(soil)
+            Y.soil.ϑ_l .= FT(0.24)
+            # We do not set the initial aux state here because
+            # we want to test that it is updated correctly in
+            # the jacobian correctly.
+            W = RichardsTridiagonalW(Y)
+            Wfact! = make_tendency_jacobian(soil)
+            dtγ = FT(1.0)
+            Wfact!(W, Y, p, dtγ, FT(0.0))
 
-        Y, p, coords = initialize(soil)
-        Y.soil.ϑ_l .= FT(0.24)
-        # We do not set the initial aux state here because
-        # we want to test that it is updated correctly in
-        # the jacobian correctly.
-        W = RichardsTridiagonalW(Y)
-        Wfact! = make_tendency_jacobian(soil)
-        dtγ = FT(1.0)
-        Wfact!(W, Y, p, dtγ, FT(0.0))
-
-        K_ic = hydraulic_conductivity(
-            hcm,
-            K_sat,
-            effective_saturation(ν, FT(0.24), θ_r),
-        )
-        dz = FT(0.01)
-        dψdϑ_ic = dψdϑ(hcm, FT(0.24), ν, θ_r, S_s)
-        if typeof(domain) <: Column
-            @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[1] .≈ -K_ic / dz^2 * dψdϑ_ic
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1)] .≈
-                -2 * K_ic / dz^2 * dψdϑ_ic,
+            K_ic = hydraulic_conductivity(
+                hcm,
+                K_sat,
+                effective_saturation(ν, FT(0.24), θ_r),
             )
-            @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[end] .≈ -K_ic / dz^2 * dψdϑ_ic
-        elseif typeof(domain) <: HybridBox
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[1, :, 1, 1, 1] .≈
-                -K_ic / dz^2 * dψdϑ_ic,
-            )
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1), :, 1, 1, 1] .≈
-                -2 * K_ic / dz^2 * dψdϑ_ic,
-            )
-            @test all(
-                parent(W.∂ϑₜ∂ϑ.coefs.:2)[end, :, 1, 1, 1] .≈
-                -K_ic / dz^2 * dψdϑ_ic,
-            )
+            dz = FT(0.01)
+            dψdϑ_ic = dψdϑ(hcm, FT(0.24), ν, θ_r, S_s)
+            if typeof(domain) <: Column
+                @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[1] .≈ -K_ic / dz^2 * dψdϑ_ic
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1)] .≈
+                    -2 * K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test parent(W.∂ϑₜ∂ϑ.coefs.:2)[end] .≈ -K_ic / dz^2 * dψdϑ_ic
+            elseif typeof(domain) <: HybridBox
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[1, :, 1, 1, 1] .≈
+                    -K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[2:(end - 1), :, 1, 1, 1] .≈
+                    -2 * K_ic / dz^2 * dψdϑ_ic,
+                )
+                @test all(
+                    parent(W.∂ϑₜ∂ϑ.coefs.:2)[end, :, 1, 1, 1] .≈
+                    -K_ic / dz^2 * dψdϑ_ic,
+                )
+            end
         end
-
     end
 end

--- a/test/shared_utilities/regridder.jl
+++ b/test/shared_utilities/regridder.jl
@@ -10,9 +10,9 @@ using ClimaComms
 using ClimaCore
 using Test
 
+FT = Float32
+@testset "Spatially varying map - regrid to field, FT = $FT" begin
 
-@testset "Spatially varying map - regrid to field" begin
-    FT = Float32
     path = bareground_albedo_dataset_path()
     regrid_dirpath =
         joinpath(pkgdir(ClimaLSM), "test/standalone/Bucket/regridder_tmpfiles")
@@ -44,5 +44,4 @@ using Test
     )
     @test p.bucket.α_sfc == field
     rm(regrid_dirpath, recursive = true)
-
 end

--- a/test/shared_utilities/utilities.jl
+++ b/test/shared_utilities/utilities.jl
@@ -3,244 +3,230 @@ using ClimaCore: Spaces, Geometry, Fields
 using ClimaLSM
 using ClimaLSM: Domains, condition, SavingAffect, saving_initialize
 
-TestFloatTypes = (Float32, Float64)
-
 ## Callback tests
 mutable struct Integrator{FT}
-    t::FT
+    t::Any
     p::Array{FT}
 end
 
-function upd_integrator(integrator::Integrator{FT}, dt::FT) where {FT}
+function upd_integrator(integrator::Integrator{FT}, dt) where {FT}
     integrator.t += dt
     integrator.p .+= FT(1)
 end
 
-@testset "callback cond, affect! test" begin
-    for FT in TestFloatTypes
-        t0 = FT(0)
-        dt = FT(10)
-        tf = FT(100)
-        t_range = collect(t0:dt:tf)
+FT = Float32
+@testset "callback cond, affect! test, FT = $FT" begin
+    t0 = FT(0)
+    dt = FT(10)
+    tf = FT(100)
+    t_range = collect(t0:dt:tf)
 
-        # specify when to save in the callback (test different dts)
-        saveats = (
-            collect(t0:dt:tf),
-            collect(t0:(2 * dt):tf),
-            collect(t0:(tf - t0):tf),
-            collect(t0:(0.5 * dt):tf),
-        )
-        for saveat in saveats
-            # note: delete non-multiples of dt in saveat before calling callback
-            deleteat!(saveat, findall(x -> (x - t0) % dt != 0, saveat))
+    # specify when to save in the callback (test different dts)
+    saveats = (
+        collect(t0:dt:tf),
+        collect(t0:(2 * dt):tf),
+        collect(t0:(tf - t0):tf),
+        collect(t0:(0.5 * dt):tf),
+    )
+    for saveat in saveats
+        # note: delete non-multiples of dt in saveat before calling callback
+        deleteat!(saveat, findall(x -> (x - t0) % dt != 0, saveat))
 
-            saved_values = (;
-                t = Array{FT}(undef, length(saveat)),
-                saveval = Array{Array{FT}}(undef, length(saveat)),
-            )
-
-            # set up components of callback
-            cond = condition(saveat)
-            saveiter = 0
-            affect! = SavingAffect(saved_values, saveat, saveiter)
-
-            p_init = copy(t_range)
-            integrator = Integrator{FT}(t0, p_init)
-
-            # use this to manually save `integrator` at various `t`
-            integ_saved = (;
-                t = Array{FT}(undef, length(saveat)),
-                p = Array{Array{FT}}(undef, length(saveat)),
-            )
-
-            # simulate callback behavior
-            saveiter = 0
-            for t in t_range
-                if cond(0, t, 0)
-                    affect!(integrator)
-
-                    # save the current state of `integrator`
-                    saveiter += 1
-                    integ_saved.t[saveiter] = integrator.t
-                    integ_saved.p[saveiter] = copy(integrator.p)
-                end
-                upd_integrator(integrator, dt)
-            end
-
-            @test affect!.saved_values.t == integ_saved.t
-            @test affect!.saved_values.saveval == integ_saved.p
-        end
-    end
-end
-
-@testset "callback saving_initialize test" begin
-    for FT in TestFloatTypes
-        t0 = FT(0)
-        dt = FT(10)
-        tf = FT(100)
-
-        # we're only testing the save at t0 so one saveat range is sufficient
-        saveat = collect(t0:dt:tf)
         saved_values = (;
             t = Array{FT}(undef, length(saveat)),
             saveval = Array{Array{FT}}(undef, length(saveat)),
         )
 
+        # set up components of callback
+        cond = condition(saveat)
         saveiter = 0
         affect! = SavingAffect(saved_values, saveat, saveiter)
-        cb = (; affect! = affect!)
 
-        p_init = collect(t0:dt:tf)
+        p_init = copy(t_range)
         integrator = Integrator{FT}(t0, p_init)
 
-        # case 1: t not in saveat
-        t1 = FT(-1)
-        @test saving_initialize(cb, 0, t1, integrator) == false
-        @test cb.affect!.saved_values.t != integrator.t
-        @test cb.affect!.saved_values.saveval != integrator.p[1]
+        # use this to manually save `integrator` at various `t`
+        integ_saved = (;
+            t = Array{FT}(undef, length(saveat)),
+            p = Array{Array{FT}}(undef, length(saveat)),
+        )
 
-        # case 2: t in saveat
-        t2 = t0
-        saving_initialize(cb, 0, t2, integrator)
-        @test cb.affect!.saved_values.t[1] == integrator.t[1]
-        @test cb.affect!.saved_values.saveval[1] == integrator.p
+        # simulate callback behavior
+        saveiter = 0
+        for t in t_range
+            if cond(0, t, 0)
+                affect!(integrator)
+
+                # save the current state of `integrator`
+                saveiter += 1
+                integ_saved.t[saveiter] = integrator.t
+                integ_saved.p[saveiter] = copy(integrator.p)
+            end
+            upd_integrator(integrator, dt)
+        end
+
+        @test affect!.saved_values.t == integ_saved.t
+        @test affect!.saved_values.saveval == integ_saved.p
     end
+end
+
+@testset "callback saving_initialize test, FT = $FT" begin
+    t0 = FT(0)
+    dt = FT(10)
+    tf = FT(100)
+
+    # we're only testing the save at t0 so one saveat range is sufficient
+    saveat = collect(t0:dt:tf)
+    saved_values = (;
+        t = Array{FT}(undef, length(saveat)),
+        saveval = Array{Array{FT}}(undef, length(saveat)),
+    )
+
+    saveiter = 0
+    affect! = SavingAffect(saved_values, saveat, saveiter)
+    cb = (; affect! = affect!)
+
+    p_init = collect(t0:dt:tf)
+    integrator = Integrator{FT}(t0, p_init)
+
+    # case 1: t not in saveat
+    t1 = FT(-1)
+    @test saving_initialize(cb, 0, t1, integrator) == false
+    @test cb.affect!.saved_values.t != integrator.t
+    @test cb.affect!.saved_values.saveval != integrator.p[1]
+
+    # case 2: t in saveat
+    t2 = t0
+    saving_initialize(cb, 0, t2, integrator)
+    @test cb.affect!.saved_values.t[1] == integrator.t[1]
+    @test cb.affect!.saved_values.saveval[1] == integrator.p
 end
 
 
 ## DSS 0D/1D tests
-@testset "dss! - 0D/1D spaces" begin
-    for FT in TestFloatTypes
-        # Test for Spaces.PointSpace and Spaces.FiniteDifferenceSpace
-        domain1 = ClimaLSM.Domains.Point(; z_sfc = FT(0))
-        domain2 =
-            ClimaLSM.Domains.Column(; zlim = FT.((-1.0, 0.0)), nelements = (5))
-        domains = (domain1, domain2, domain2)
-        spaces = (
-            domain1.space.surface,
-            domain2.space.subsurface,
-            domain2.space.surface,
-        )
-        for (domain, space) in zip(domains, spaces)
-            field = Fields.coordinate_field(space)
-            subfield1 = similar(field)
-            parent(subfield1) .= parent(copy(field)) .+ FT(1)
+@testset "dss! - 0D/1D spaces, FT = $FT" begin
+    # Test for Spaces.PointSpace and Spaces.FiniteDifferenceSpace
+    domain1 = ClimaLSM.Domains.Point(; z_sfc = FT(0))
+    domain2 =
+        ClimaLSM.Domains.Column(; zlim = FT.((-1.0, 0.0)), nelements = (5))
+    domains = (domain1, domain2, domain2)
+    spaces =
+        (domain1.space.surface, domain2.space.subsurface, domain2.space.surface)
+    for (domain, space) in zip(domains, spaces)
+        field = Fields.coordinate_field(space)
+        subfield1 = similar(field)
+        parent(subfield1) .= parent(copy(field)) .+ FT(1)
 
-            Y = Fields.FieldVector(
-                field = field,
-                subfields = (subfield1 = subfield1),
-            )
-            Y_copy = copy(Y)
-            p = (;)
-            ClimaLSM.dss!(Y, p, FT(0))
-            @test p == (;)
-            @test ClimaLSM.add_dss_buffer_to_aux(p, domain) == p
-            # On a 1D space, we expect dss! to do nothing
-            @test Y == Y_copy
-        end
+        Y = Fields.FieldVector(
+            field = field,
+            subfields = (subfield1 = subfield1),
+        )
+        Y_copy = copy(Y)
+        p = (;)
+        ClimaLSM.dss!(Y, p, FT(0))
+        @test p == (;)
+        @test ClimaLSM.add_dss_buffer_to_aux(p, domain) == p
+        # On a 1D space, we expect dss! to do nothing
+        @test Y == Y_copy
     end
 end
 
-@testset "dss! - 2D spaces" begin
-    for FT in TestFloatTypes
-        # Test for Spaces.SpectralElementSpace2D
-        domain1 = ClimaLSM.Domains.Plane(;
-            xlim = FT.((0.0, 1.0)),
-            ylim = FT.((0.0, 1.0)),
-            nelements = (2, 2),
-            periodic = (true, true),
-            npolynomial = 1,
-        )
-        domain2 = ClimaLSM.Domains.SphericalSurface(;
-            radius = FT(2),
-            nelements = 10,
-            npolynomial = 3,
-        )
+@testset "dss! - 2D spaces, FT = $FT" begin
+    # Test for Spaces.SpectralElementSpace2D
+    domain1 = ClimaLSM.Domains.Plane(;
+        xlim = FT.((0.0, 1.0)),
+        ylim = FT.((0.0, 1.0)),
+        nelements = (2, 2),
+        periodic = (true, true),
+        npolynomial = 1,
+    )
+    domain2 = ClimaLSM.Domains.SphericalSurface(;
+        radius = FT(2),
+        nelements = 10,
+        npolynomial = 3,
+    )
 
-        domains = (domain1, domain2)
-        for domain in domains
-            space = domain.space.surface
-            field = Fields.zeros(space)
-            subfield1 = Fields.zeros(space)
-            subfield2 = Fields.zeros(space)
+    domains = (domain1, domain2)
+    for domain in domains
+        space = domain.space.surface
+        field = Fields.zeros(space)
+        subfield1 = Fields.zeros(space)
+        subfield2 = Fields.zeros(space)
 
-            # make fields non-constant in order to check the
-            # impact of the dss step
-            for i in eachindex(parent(field))
-                parent(field)[i] = sin(i)
-                parent(subfield1)[i] = cos(i)
-                parent(subfield2)[i] = sin(i) * cos(i)
-            end
-
-            Y = Fields.FieldVector(
-                field = field,
-                subfields = (subfield1 = subfield1, subfield2 = subfield2),
-            )
-            Y_copy = copy(Y)
-            p = (;)
-            p = ClimaLSM.add_dss_buffer_to_aux(p, domain)
-            @test typeof(p.dss_buffer_2d) ==
-                  typeof(Spaces.create_dss_buffer(Fields.zeros(space)))
-            ClimaLSM.dss!(Y, p, FT(0))
-
-            # On a 2D space, we expect dss! to change Y
-            @test Y.field != Y_copy.field
-            @test Y.subfields.subfield1 != Y_copy.subfields.subfield1
-            @test Y.subfields.subfield2 != Y_copy.subfields.subfield2
+        # make fields non-constant in order to check the
+        # impact of the dss step
+        for i in eachindex(parent(field))
+            parent(field)[i] = sin(i)
+            parent(subfield1)[i] = cos(i)
+            parent(subfield2)[i] = sin(i) * cos(i)
         end
+
+        Y = Fields.FieldVector(
+            field = field,
+            subfields = (subfield1 = subfield1, subfield2 = subfield2),
+        )
+        Y_copy = copy(Y)
+        p = (;)
+        p = ClimaLSM.add_dss_buffer_to_aux(p, domain)
+        @test typeof(p.dss_buffer_2d) ==
+              typeof(Spaces.create_dss_buffer(Fields.zeros(space)))
+        ClimaLSM.dss!(Y, p, FT(0))
+
+        # On a 2D space, we expect dss! to change Y
+        @test Y.field != Y_copy.field
+        @test Y.subfields.subfield1 != Y_copy.subfields.subfield1
+        @test Y.subfields.subfield2 != Y_copy.subfields.subfield2
     end
 end
 
-@testset "dss! - 3D spaces" begin
-    for FT in TestFloatTypes
-        domain1 = ClimaLSM.Domains.HybridBox(;
-            xlim = FT.((0.0, 1.0)),
-            ylim = FT.((0.0, 1.0)),
-            zlim = FT.((0.0, 1.0)),
-            nelements = (2, 2, 2),
-            periodic = (true, true),
-            npolynomial = 1,
-        )
-        domain2 = ClimaLSM.Domains.SphericalShell(;
-            radius = FT(2),
-            depth = FT(1.0),
-            nelements = (10, 5),
-            npolynomial = 3,
-        )
+@testset "dss! - 3D spaces, FT = $FT" begin
+    domain1 = ClimaLSM.Domains.HybridBox(;
+        xlim = FT.((0.0, 1.0)),
+        ylim = FT.((0.0, 1.0)),
+        zlim = FT.((0.0, 1.0)),
+        nelements = (2, 2, 2),
+        periodic = (true, true),
+        npolynomial = 1,
+    )
+    domain2 = ClimaLSM.Domains.SphericalShell(;
+        radius = FT(2),
+        depth = FT(1.0),
+        nelements = (10, 5),
+        npolynomial = 3,
+    )
 
-        domains = (domain1, domain2)
-        for domain in domains
-            space = domain.space.subsurface
-            field = Fields.zeros(space)
-            subfield1 = Fields.zeros(space)
-            subfield2 = Fields.zeros(space)
+    domains = (domain1, domain2)
+    for domain in domains
+        space = domain.space.subsurface
+        field = Fields.zeros(space)
+        subfield1 = Fields.zeros(space)
+        subfield2 = Fields.zeros(space)
 
-            # make fields non-constant in order to check
-            # the impact of the dss step
-            for i in eachindex(parent(field))
-                parent(field)[i] = sin(i)
-                parent(subfield1)[i] = cos(i)
-                parent(subfield2)[i] = sin(i) * cos(i)
-            end
-
-            Y = Fields.FieldVector(
-                field = field,
-                subfields = (subfield1 = subfield1, subfield2 = subfield2),
-            )
-            Y_copy = copy(Y)
-            p = (;)
-            p = ClimaLSM.add_dss_buffer_to_aux(p, domain)
-            @test typeof(p.dss_buffer_3d) ==
-                  typeof(Spaces.create_dss_buffer(Fields.zeros(space)))
-            @test typeof(p.dss_buffer_2d) == typeof(
-                Spaces.create_dss_buffer(Fields.zeros(domain.space.surface)),
-            )
-            ClimaLSM.dss!(Y, p, FT(0))
-
-            # On a 3D space, we expect dss! to change Y
-            @test Y.field != Y_copy.field
-            @test Y.subfields.subfield1 != Y_copy.subfields.subfield1
-            @test Y.subfields.subfield2 != Y_copy.subfields.subfield2
+        # make fields non-constant in order to check
+        # the impact of the dss step
+        for i in eachindex(parent(field))
+            parent(field)[i] = sin(i)
+            parent(subfield1)[i] = cos(i)
+            parent(subfield2)[i] = sin(i) * cos(i)
         end
+
+        Y = Fields.FieldVector(
+            field = field,
+            subfields = (subfield1 = subfield1, subfield2 = subfield2),
+        )
+        Y_copy = copy(Y)
+        p = (;)
+        p = ClimaLSM.add_dss_buffer_to_aux(p, domain)
+        @test typeof(p.dss_buffer_3d) ==
+              typeof(Spaces.create_dss_buffer(Fields.zeros(space)))
+        @test typeof(p.dss_buffer_2d) == typeof(
+            Spaces.create_dss_buffer(Fields.zeros(domain.space.surface)),
+        )
+        ClimaLSM.dss!(Y, p, FT(0))
+
+        # On a 3D space, we expect dss! to change Y
+        @test Y.field != Y_copy.field
+        @test Y.subfields.subfield1 != Y_copy.subfields.subfield1
+        @test Y.subfields.subfield2 != Y_copy.subfields.subfield2
     end
 end

--- a/test/shared_utilities/variable_types.jl
+++ b/test/shared_utilities/variable_types.jl
@@ -17,9 +17,10 @@ using ClimaLSM.Domains: HybridBox, Column, Point
 using ClimaLSM.Domains: coordinates
 using ClimaLSM.Canopy: AbstractCanopyComponent
 
-@testset "Default model" begin
+FT = Float32
+@testset "Default model, FT = $FT" begin
     struct DefaultModel{FT} <: AbstractModel{FT} end
-    dm = DefaultModel{Float32}()
+    dm = DefaultModel{FT}()
     @test ClimaLSM.prognostic_vars(dm) == ()
     @test ClimaLSM.prognostic_types(dm) == ()
     @test ClimaLSM.prognostic_domain_names(dm) == ()
@@ -49,9 +50,9 @@ using ClimaLSM.Canopy: AbstractCanopyComponent
     @test x == [0, 1, 2, 3]
 end
 
-@testset "Default ImEx model" begin
+@testset "Default ImEx model, FT = $FT" begin
     struct DefaultImExModel{FT} <: AbstractImExModel{FT} end
-    dm_imex = DefaultImExModel{Float32}()
+    dm_imex = DefaultImExModel{FT}()
 
     x = [0, 1, 2, 3]
     dm_imp_tendency! = make_imp_tendency(dm_imex)
@@ -65,8 +66,9 @@ end
 end
 
 @testset "Default canopy component" begin
+    FT = Float64
     struct DefaultCanopyComponent{FT} <: AbstractCanopyComponent{FT} end
-    dcc = DefaultCanopyComponent{Float32}()
+    dcc = DefaultCanopyComponent{FT}()
     @test ClimaLSM.prognostic_vars(dcc) == ()
     @test ClimaLSM.prognostic_types(dcc) == ()
     @test ClimaLSM.prognostic_domain_names(dcc) == ()
@@ -83,7 +85,7 @@ end
     @test_throws MethodError make_compute_imp_tendency(dcc)
 end
 
-@testset "Variables" begin
+@testset "Variables, FT = $FT" begin
     struct Model{FT, D} <: AbstractModel{FT}
         domain::D
     end
@@ -97,7 +99,6 @@ end
     ClimaLSM.prognostic_domain_names(m::Model) = (:surface, :surface)
     ClimaLSM.auxiliary_domain_names(m::Model) = (:surface, :subsurface)
 
-    FT = Float64
     zmin = FT(1.0)
     zmax = FT(2.0)
     zlim = (zmin, zmax)

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -18,168 +18,287 @@ using ClimaLSM:
     PrescribedAtmosphere,
     PrescribedRadiativeFluxes
 
-FT = Float64
-
 # Bucket model parameters
 import ClimaLSM
 import ClimaLSM.Parameters as LSMP
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-earth_param_set = create_lsm_parameters(FT)
-α_sfc = (coordinate_point) -> FT(0.2) # surface albedo, spatially constant
-α_snow = FT(0.8) # snow albedo
-albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc)
-σS_c = FT(0.2)
-W_f = FT(0.15)
-z_0m = FT(1e-2)
-z_0b = FT(1e-3)
-κ_soil = FT(1.5)
-ρc_soil = FT(2e6)
 
-# Model domain
-bucket_domains = [
-    Column(; zlim = (-100.0, 0.0), nelements = 10),
-    HybridBox(;
-        xlim = (-1.0, 0.0),
-        ylim = (-1.0, 0.0),
-        zlim = (-100.0, 0.0),
-        nelements = (2, 2, 10),
-        npolynomial = 1,
-        periodic = (true, true),
-    ),
-    SphericalShell(;
-        radius = 100.0,
-        depth = 3.5,
-        nelements = (1, 10),
-        npolynomial = 1,
-    ),
-]
-init_temp(z::FT, value::FT) where {FT} = FT(value)
-orbital_data = Insolation.OrbitalData()
-for i in 1:3
-    @testset "Conservation of water and energy I (snow present)" begin
-        "Radiation"
-        ref_time = DateTime(2005)
-        SW_d = (t) -> eltype(t)(20.0)
-        LW_d = (t) -> eltype(t)(20.0)
-        bucket_rad =
-            PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time; orbital_data)
-        "Atmos"
-        liquid_precip = (t) -> eltype(t)(1e-8) # precipitation
-        snow_precip = (t) -> eltype(t)(1e-7) # precipitation
+for FT in (Float32, Float64)
+    earth_param_set = create_lsm_parameters(FT)
+    α_sfc = (coordinate_point) -> FT(0.2) # surface albedo, spatially constant
+    α_snow = FT(0.8) # snow albedo
+    albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc)
+    σS_c = FT(0.2)
+    W_f = FT(0.15)
+    z_0m = FT(1e-2)
+    z_0b = FT(1e-3)
+    κ_soil = FT(1.5)
+    ρc_soil = FT(2e6)
 
-        T_atmos = (t) -> eltype(t)(280.0)
-        u_atmos = (t) -> eltype(t)(10.0)
-        q_atmos = (t) -> eltype(t)(0.03)
-        h_atmos = FT(3)
-        P_atmos = (t) -> eltype(t)(101325) # Pa
-        bucket_atmos = PrescribedAtmosphere(
-            liquid_precip,
-            snow_precip,
-            T_atmos,
-            u_atmos,
-            q_atmos,
-            P_atmos,
-            ref_time,
-            h_atmos,
-        )
-        Δt = FT(1.0)
-        τc = FT(10.0)
-        bucket_parameters = BucketModelParameters(
-            κ_soil,
-            ρc_soil,
-            albedo,
-            σS_c,
-            W_f,
-            z_0m,
-            z_0b,
-            τc,
-            earth_param_set,
-        )
-        model = BucketModel(
-            parameters = bucket_parameters,
-            domain = bucket_domains[i],
-            atmosphere = bucket_atmos,
-            radiation = bucket_rad,
-        )
-
-        # run for some time
-        Y, p, coords = initialize(model)
-        Y.bucket.T .= init_temp.(coords.subsurface.z, 274.0)
-        Y.bucket.W .= 0.0 # no moisture
-        Y.bucket.Ws .= 0.0 # no runoff
-        Y.bucket.σS .= 0.5
-        t0 = FT(0.0)
-        dY = similar(Y)
-
-        exp_tendency! = make_exp_tendency(model)
-        set_initial_aux_state! = make_set_initial_aux_state(model)
-        set_initial_aux_state!(p, Y, t0)
-        exp_tendency!(dY, Y, p, t0)
-        _LH_f0 = LSMP.LH_f0(model.parameters.earth_param_set)
-        _ρ_liq = LSMP.ρ_cloud_liq(model.parameters.earth_param_set)
-        _ρLH_f0 = _ρ_liq * _LH_f0 # Latent heat per unit volume
-        _T_freeze = LSMP.T_freeze(model.parameters.earth_param_set)
-        snow_cover_fraction(σS) = σS > eps(FT) ? FT(1.0) : FT(0.0)
-
-        partitioned_fluxes =
-            partition_surface_fluxes.(
-                Y.bucket.σS,
-                p.bucket.T_sfc,
-                model.parameters.τc,
-                snow_cover_fraction.(Y.bucket.σS),
-                p.bucket.evaporation,
-                p.bucket.turbulent_energy_flux .+ p.bucket.R_n,
-                _ρLH_f0,
-                _T_freeze,
+    # Model domain
+    bucket_domains = [
+        Column(; zlim = (FT(-100), FT(0)), nelements = 10),
+        HybridBox(;
+            xlim = (FT(-1), FT(0)),
+            ylim = (FT(-1), FT(0)),
+            zlim = (FT(-100), FT(0)),
+            nelements = (2, 2, 10),
+            npolynomial = 1,
+            periodic = (true, true),
+        ),
+        SphericalShell(;
+            radius = FT(100),
+            depth = FT(3.5),
+            nelements = (1, 10),
+            npolynomial = 1,
+        ),
+    ]
+    init_temp(z::FT, value::FT) where {FT} = FT(value)
+    orbital_data = Insolation.OrbitalData()
+    for i in 1:3
+        @testset "Conservation of water and energy I (snow present), FT = $FT" begin
+            "Radiation"
+            ref_time = DateTime(2005)
+            SW_d = (t) -> 20
+            LW_d = (t) -> 20
+            bucket_rad = PrescribedRadiativeFluxes(
+                FT,
+                SW_d,
+                LW_d,
+                ref_time;
+                orbital_data,
             )
-        F_melt = partitioned_fluxes.F_melt
-        F_into_snow =
-            partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* snow_precip(t0)
-        G = partitioned_fluxes.G
-        F_sfc =
-            p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
-            _ρLH_f0 .* snow_precip(t0)
-        F_water_sfc =
-            liquid_precip(t0) + snow_precip(t0) .- p.bucket.evaporation
+            "Atmos"
+            liquid_precip = (t) -> 1e-8 # precipitation
+            snow_precip = (t) -> 1e-7 # precipitation
+
+            T_atmos = (t) -> 280.0
+            u_atmos = (t) -> 10.0
+            q_atmos = (t) -> 0.03
+            h_atmos = FT(3)
+            P_atmos = (t) -> 101325 # Pa
+            bucket_atmos = PrescribedAtmosphere(
+                liquid_precip,
+                snow_precip,
+                T_atmos,
+                u_atmos,
+                q_atmos,
+                P_atmos,
+                ref_time,
+                h_atmos,
+            )
+            Δt = FT(1.0)
+            τc = FT(10.0)
+            bucket_parameters = BucketModelParameters(
+                κ_soil,
+                ρc_soil,
+                albedo,
+                σS_c,
+                W_f,
+                z_0m,
+                z_0b,
+                τc,
+                earth_param_set,
+            )
+            model = BucketModel(
+                parameters = bucket_parameters,
+                domain = bucket_domains[i],
+                atmosphere = bucket_atmos,
+                radiation = bucket_rad,
+            )
+
+            # run for some time
+            Y, p, coords = initialize(model)
+            Y.bucket.T .= init_temp.(coords.subsurface.z, FT(274.0))
+            Y.bucket.W .= 0.0 # no moisture
+            Y.bucket.Ws .= 0.0 # no runoff
+            Y.bucket.σS .= 0.5
+            t0 = FT(0.0)
+            dY = similar(Y)
+
+            exp_tendency! = make_exp_tendency(model)
+            set_initial_aux_state! = make_set_initial_aux_state(model)
+            set_initial_aux_state!(p, Y, t0)
+            exp_tendency!(dY, Y, p, t0)
+            _LH_f0 = LSMP.LH_f0(model.parameters.earth_param_set)
+            _ρ_liq = LSMP.ρ_cloud_liq(model.parameters.earth_param_set)
+            _ρLH_f0 = _ρ_liq * _LH_f0 # Latent heat per unit volume
+            _T_freeze = LSMP.T_freeze(model.parameters.earth_param_set)
+            snow_cover_fraction(σS) = σS > eps(FT) ? FT(1.0) : FT(0.0)
+
+            partitioned_fluxes =
+                partition_surface_fluxes.(
+                    Y.bucket.σS,
+                    p.bucket.T_sfc,
+                    model.parameters.τc,
+                    snow_cover_fraction.(Y.bucket.σS),
+                    p.bucket.evaporation,
+                    p.bucket.turbulent_energy_flux .+ p.bucket.R_n,
+                    _ρLH_f0,
+                    _T_freeze,
+                )
+            F_melt = partitioned_fluxes.F_melt
+            F_into_snow =
+                partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* FT(snow_precip(t0))
+            G = partitioned_fluxes.G
+            F_sfc =
+                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
+                _ρLH_f0 .* FT(snow_precip(t0))
+            F_water_sfc =
+                FT(liquid_precip(t0)) + FT(snow_precip(t0)) .-
+                p.bucket.evaporation
 
 
-        if i == 1
-            A_point = sum(ones(bucket_domains[i].space.surface))
-        else
-            A_point = 1
+            if i == 1
+                A_point = sum(ones(bucket_domains[i].space.surface))
+            else
+                A_point = 1
+            end
+
+            dIsnow = -_ρLH_f0 .* dY.bucket.σS
+            @test sum(dIsnow) / A_point ≈ sum(-1 .* F_into_snow) / A_point
+
+            de_soil = dY.bucket.T .* ρc_soil
+            @test sum(de_soil) ≈ sum(-1 .* G) / A_point
+
+            dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
+            @test sum(dWL) / A_point ≈ sum(F_water_sfc) / A_point
+
+            dIL = sum(dIsnow) / A_point .+ sum(de_soil)
+            @test dIL ≈ sum(-1 .* F_sfc) / A_point
         end
-
-        dIsnow = -_ρLH_f0 .* dY.bucket.σS
-        @test sum(dIsnow) / A_point ≈ sum(-1 .* F_into_snow) / A_point
-
-        de_soil = dY.bucket.T .* ρc_soil
-        @test sum(de_soil) ≈ sum(-1 .* G) / A_point
-
-        dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
-        @test sum(dWL) / A_point ≈ sum(F_water_sfc) / A_point
-
-        dIL = sum(dIsnow) / A_point .+ sum(de_soil)
-        @test dIL ≈ sum(-1 .* F_sfc) / A_point
     end
-end
 
-for i in 1:3
-    @testset "Conservation of water and energy II (no snow to start)" begin
+    for i in 1:3
+        @testset "Conservation of water and energy II (no snow to start), FT = $FT" begin
+            "Radiation"
+            ref_time = DateTime(2005)
+            SW_d = (t) -> 20
+            LW_d = (t) -> 20
+            bucket_rad = PrescribedRadiativeFluxes(
+                FT,
+                SW_d,
+                LW_d,
+                ref_time;
+                orbital_data,
+            )
+            "Atmos"
+            liquid_precip = (t) -> 1e-8 # precipitation
+            snow_precip = (t) -> 1e-7 # precipitation
+
+            T_atmos = (t) -> 280
+            u_atmos = (t) -> 10
+            q_atmos = (t) -> 0.03
+            h_atmos = FT(3)
+            P_atmos = (t) -> 101325 # Pa
+            bucket_atmos = PrescribedAtmosphere(
+                liquid_precip,
+                snow_precip,
+                T_atmos,
+                u_atmos,
+                q_atmos,
+                P_atmos,
+                ref_time,
+                h_atmos,
+            )
+            Δt = FT(1.0)
+            τc = FT(10.0)
+            bucket_parameters = BucketModelParameters(
+                κ_soil,
+                ρc_soil,
+                albedo,
+                σS_c,
+                W_f,
+                z_0m,
+                z_0b,
+                τc,
+                earth_param_set,
+            )
+            model = BucketModel(
+                parameters = bucket_parameters,
+                domain = bucket_domains[i],
+                atmosphere = bucket_atmos,
+                radiation = bucket_rad,
+            )
+
+            # run for some time
+            Y, p, coords = initialize(model)
+            Y.bucket.T .= init_temp.(coords.subsurface.z, FT(274.0))
+            Y.bucket.W .= 0.0 # no moisture
+            Y.bucket.Ws .= 0.0 # no runoff
+            Y.bucket.σS .= 0.0
+            t0 = FT(0.0)
+            dY = similar(Y)
+
+            exp_tendency! = make_exp_tendency(model)
+            set_initial_aux_state! = make_set_initial_aux_state(model)
+            set_initial_aux_state!(p, Y, t0)
+            exp_tendency!(dY, Y, p, t0)
+            _LH_f0 = LSMP.LH_f0(model.parameters.earth_param_set)
+            _ρ_liq = LSMP.ρ_cloud_liq(model.parameters.earth_param_set)
+            _ρLH_f0 = _ρ_liq * _LH_f0 # Latent heat per unit volume
+            _T_freeze = LSMP.T_freeze(model.parameters.earth_param_set)
+            snow_cover_fraction(σS) = σS > eps(FT) ? FT(1.0) : FT(0.0)
+
+            partitioned_fluxes =
+                partition_surface_fluxes.(
+                    Y.bucket.σS,
+                    p.bucket.T_sfc,
+                    model.parameters.τc,
+                    snow_cover_fraction.(Y.bucket.σS),
+                    p.bucket.evaporation,
+                    p.bucket.turbulent_energy_flux .+ p.bucket.R_n,
+                    _ρLH_f0,
+                    _T_freeze,
+                )
+            F_melt = partitioned_fluxes.F_melt
+            F_into_snow =
+                partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* FT(snow_precip(t0))
+            G = partitioned_fluxes.G
+            F_sfc =
+                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
+                _ρLH_f0 .* FT(snow_precip(t0))
+            F_water_sfc =
+                FT(liquid_precip(t0)) + FT(snow_precip(t0)) .-
+                p.bucket.evaporation
+
+            if i == 1
+                A_point = sum(ones(bucket_domains[i].space.surface))
+            else
+                A_point = 1
+            end
+
+            dIsnow = -_ρLH_f0 .* dY.bucket.σS
+            @test sum(dIsnow) / A_point ≈ sum(-1 .* F_into_snow) / A_point
+
+            de_soil = dY.bucket.T .* ρc_soil
+            @test sum(de_soil) ≈ sum(-1 .* G) / A_point
+
+            dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
+            @test sum(dWL) / A_point ≈ sum(F_water_sfc) / A_point
+
+            dIL = sum(dIsnow) / A_point .+ sum(de_soil)
+            @test dIL ≈ sum(-1 .* F_sfc) / A_point
+        end
+    end
+
+    @testset "Conservation of water and energy - nonuniform evaporation, FT = $FT" begin
+        i = 3
         "Radiation"
         ref_time = DateTime(2005)
-        SW_d = (t) -> eltype(t)(20.0)
-        LW_d = (t) -> eltype(t)(20.0)
+        SW_d = (t) -> 20
+        LW_d = (t) -> 20
         bucket_rad =
             PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time; orbital_data)
         "Atmos"
-        liquid_precip = (t) -> eltype(t)(1e-8) # precipitation
-        snow_precip = (t) -> eltype(t)(1e-7) # precipitation
+        liquid_precip = (t) -> 1e-8 # precipitation
+        snow_precip = (t) -> 1e-7 # precipitation
 
-        T_atmos = (t) -> eltype(t)(280.0)
-        u_atmos = (t) -> eltype(t)(10.0)
-        q_atmos = (t) -> eltype(t)(0.03)
+        T_atmos = (t) -> 280
+        u_atmos = (t) -> 10
+        q_atmos = (t) -> 0.03
         h_atmos = FT(3)
-        P_atmos = (t) -> eltype(t)(101325) # Pa
+        P_atmos = (t) -> 101325 # Pa
         bucket_atmos = PrescribedAtmosphere(
             liquid_precip,
             snow_precip,
@@ -212,17 +331,20 @@ for i in 1:3
 
         # run for some time
         Y, p, coords = initialize(model)
-        Y.bucket.T .= init_temp.(coords.subsurface.z, 274.0)
+        Y.bucket.T .= init_temp.(coords.subsurface.z, FT(274.0))
         Y.bucket.W .= 0.0 # no moisture
         Y.bucket.Ws .= 0.0 # no runoff
         Y.bucket.σS .= 0.0
         t0 = FT(0.0)
         dY = similar(Y)
 
-        exp_tendency! = make_exp_tendency(model)
+        compute_exp_tendency! = ClimaLSM.make_compute_exp_tendency(model)
         set_initial_aux_state! = make_set_initial_aux_state(model)
         set_initial_aux_state!(p, Y, t0)
-        exp_tendency!(dY, Y, p, t0)
+        random = zeros(bucket_domains[i].space.surface)
+        parent(random) .= rand(FT, size(parent(random)))
+        p.bucket.evaporation .= random .* 1e-7
+        compute_exp_tendency!(dY, Y, p, t0)
         _LH_f0 = LSMP.LH_f0(model.parameters.earth_param_set)
         _ρ_liq = LSMP.ρ_cloud_liq(model.parameters.earth_param_set)
         _ρLH_f0 = _ρ_liq * _LH_f0 # Latent heat per unit volume
@@ -242,133 +364,24 @@ for i in 1:3
             )
         F_melt = partitioned_fluxes.F_melt
         F_into_snow =
-            partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* snow_precip(t0)
+            partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* FT(snow_precip(t0))
         G = partitioned_fluxes.G
         F_sfc =
             p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
-            _ρLH_f0 .* snow_precip(t0)
+            _ρLH_f0 .* FT(snow_precip(t0))
         F_water_sfc =
-            liquid_precip(t0) + snow_precip(t0) .- p.bucket.evaporation
-
-        if i == 1
-            A_point = sum(ones(bucket_domains[i].space.surface))
-        else
-            A_point = 1
-        end
+            FT(liquid_precip(t0)) + FT(snow_precip(t0)) .- p.bucket.evaporation
 
         dIsnow = -_ρLH_f0 .* dY.bucket.σS
-        @test sum(dIsnow) / A_point ≈ sum(-1 .* F_into_snow) / A_point
+        @test sum(dIsnow) ≈ sum(-1 .* F_into_snow)
 
         de_soil = dY.bucket.T .* ρc_soil
-        @test sum(de_soil) ≈ sum(-1 .* G) / A_point
+        @test sum(de_soil) ≈ sum(-1 .* G)
 
         dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
-        @test sum(dWL) / A_point ≈ sum(F_water_sfc) / A_point
+        @test sum(dWL) ≈ sum(F_water_sfc)
 
-        dIL = sum(dIsnow) / A_point .+ sum(de_soil)
-        @test dIL ≈ sum(-1 .* F_sfc) / A_point
+        dIL = sum(dIsnow) .+ sum(de_soil)
+        @test dIL ≈ sum(-1 .* F_sfc)
     end
-end
-
-
-
-@testset "Conservation of water and energy - nonuniform evaporation" begin
-    i = 3
-    "Radiation"
-    ref_time = DateTime(2005)
-    SW_d = (t) -> eltype(t)(20.0)
-    LW_d = (t) -> eltype(t)(20.0)
-    bucket_rad =
-        PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time; orbital_data)
-    "Atmos"
-    liquid_precip = (t) -> eltype(t)(1e-8) # precipitation
-    snow_precip = (t) -> eltype(t)(1e-7) # precipitation
-
-    T_atmos = (t) -> eltype(t)(280.0)
-    u_atmos = (t) -> eltype(t)(10.0)
-    q_atmos = (t) -> eltype(t)(0.03)
-    h_atmos = FT(3)
-    P_atmos = (t) -> eltype(t)(101325) # Pa
-    bucket_atmos = PrescribedAtmosphere(
-        liquid_precip,
-        snow_precip,
-        T_atmos,
-        u_atmos,
-        q_atmos,
-        P_atmos,
-        ref_time,
-        h_atmos,
-    )
-    Δt = FT(1.0)
-    τc = FT(10.0)
-    bucket_parameters = BucketModelParameters(
-        κ_soil,
-        ρc_soil,
-        albedo,
-        σS_c,
-        W_f,
-        z_0m,
-        z_0b,
-        τc,
-        earth_param_set,
-    )
-    model = BucketModel(
-        parameters = bucket_parameters,
-        domain = bucket_domains[i],
-        atmosphere = bucket_atmos,
-        radiation = bucket_rad,
-    )
-
-    # run for some time
-    Y, p, coords = initialize(model)
-    Y.bucket.T .= init_temp.(coords.subsurface.z, 274.0)
-    Y.bucket.W .= 0.0 # no moisture
-    Y.bucket.Ws .= 0.0 # no runoff
-    Y.bucket.σS .= 0.0
-    t0 = FT(0.0)
-    dY = similar(Y)
-
-    compute_exp_tendency! = ClimaLSM.make_compute_exp_tendency(model)
-    set_initial_aux_state! = make_set_initial_aux_state(model)
-    set_initial_aux_state!(p, Y, t0)
-    random = zeros(bucket_domains[i].space.surface)
-    parent(random) .= rand(FT, size(parent(random)))
-    p.bucket.evaporation .= random .* 1e-7
-    compute_exp_tendency!(dY, Y, p, t0)
-    _LH_f0 = LSMP.LH_f0(model.parameters.earth_param_set)
-    _ρ_liq = LSMP.ρ_cloud_liq(model.parameters.earth_param_set)
-    _ρLH_f0 = _ρ_liq * _LH_f0 # Latent heat per unit volume
-    _T_freeze = LSMP.T_freeze(model.parameters.earth_param_set)
-    snow_cover_fraction(σS) = σS > eps(FT) ? FT(1.0) : FT(0.0)
-
-    partitioned_fluxes =
-        partition_surface_fluxes.(
-            Y.bucket.σS,
-            p.bucket.T_sfc,
-            model.parameters.τc,
-            snow_cover_fraction.(Y.bucket.σS),
-            p.bucket.evaporation,
-            p.bucket.turbulent_energy_flux .+ p.bucket.R_n,
-            _ρLH_f0,
-            _T_freeze,
-        )
-    F_melt = partitioned_fluxes.F_melt
-    F_into_snow = partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* snow_precip(t0)
-    G = partitioned_fluxes.G
-    F_sfc =
-        p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
-        _ρLH_f0 .* snow_precip(t0)
-    F_water_sfc = liquid_precip(t0) + snow_precip(t0) .- p.bucket.evaporation
-
-    dIsnow = -_ρLH_f0 .* dY.bucket.σS
-    @test sum(dIsnow) ≈ sum(-1 .* F_into_snow)
-
-    de_soil = dY.bucket.T .* ρc_soil
-    @test sum(de_soil) ≈ sum(-1 .* G)
-
-    dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
-    @test sum(dWL) ≈ sum(F_water_sfc)
-
-    dIL = sum(dIsnow) .+ sum(de_soil)
-    @test dIL ≈ sum(-1 .* F_sfc)
 end

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -15,202 +15,212 @@ using ClimaLSM:
     PrescribedAtmosphere,
     PrescribedRadiativeFluxes
 
-
-FT = Float64
-
 # Bucket model parameters
 import ClimaLSM
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-earth_param_set = create_lsm_parameters(FT)
 
-α_sfc = (coordinate_point) -> FT(0.2) # surface albedo, spatially constant
-α_snow = FT(0.8) # snow albedo
-albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc)
-σS_c = FT(0.2)
-W_f = FT(0.15)
-z_0m = FT(1e-2)
-z_0b = FT(1e-3)
-κ_soil = FT(1.5)
-ρc_soil = FT(2e6)
+for FT in (Float32, Float64)
+    earth_param_set = create_lsm_parameters(FT)
+    α_sfc = (coordinate_point) -> FT(0.2) # surface albedo, spatially constant
+    α_snow = FT(0.8) # snow albedo
+    albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc)
+    σS_c = FT(0.2)
+    W_f = FT(0.15)
+    z_0m = FT(1e-2)
+    z_0b = FT(1e-3)
+    κ_soil = FT(1.5)
+    ρc_soil = FT(2e6)
 
-# Model domain
-bucket_domains = [
-    Column(; zlim = (-100.0, 0.0), nelements = 10),
-    HybridBox(;
-        xlim = (-1.0, 0.0),
-        ylim = (-1.0, 0.0),
-        zlim = (-100.0, 0.0),
-        nelements = (2, 2, 10),
-        npolynomial = 1,
-        periodic = (true, true),
-    ),
-    SphericalShell(;
-        radius = 100.0,
-        depth = 3.5,
-        nelements = (1, 10),
-        npolynomial = 1,
-    ),
-]
-orbital_data = Insolation.OrbitalData()
-init_temp(z::FT, value::FT) where {FT} = FT(value)
-for bucket_domain in bucket_domains
-    @testset "Zero flux tendency" begin
-        # Radiation
-        ref_time = DateTime(2005)
-        SW_d = (t) -> eltype(t)(0.0)
-        LW_d = (t) -> eltype(t)(5.67e-8 * 280.0^4.0)
-        bucket_rad =
-            PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time; orbital_data)
-        # Atmos
-        precip = (t) -> eltype(t)(0) # no precipitation
-        T_atmos = (t) -> eltype(t)(280.0)
-        u_atmos = (t) -> eltype(t)(1.0)
-        q_atmos = (t) -> eltype(t)(0.0) # no atmos water
-        h_atmos = FT(1e-8)
-        P_atmos = (t) -> eltype(t)(101325)
-        bucket_atmos = PrescribedAtmosphere(
-            precip,
-            precip,
-            T_atmos,
-            u_atmos,
-            q_atmos,
-            P_atmos,
-            ref_time,
-            h_atmos,
-        )
-        Δt = FT(1.0)
-        bucket_parameters = BucketModelParameters(
-            κ_soil,
-            ρc_soil,
-            albedo,
-            σS_c,
-            W_f,
-            z_0m,
-            z_0b,
-            Δt,
-            earth_param_set,
-        )
-
-        model = BucketModel(
-            parameters = bucket_parameters,
-            domain = bucket_domain,
-            atmosphere = bucket_atmos,
-            radiation = bucket_rad,
-        )
-        # Initial conditions with no moisture
-        Y, p, coords = initialize(model)
-        # test if the correct dss buffers were added to aux.
-        # We only need to add a dss buffer when there is a horizontal
-        # space (spectral element space). So, we check that it is added
-        # in the case of the HybridBox and SphericalShell domains,
-        # and check that it is not added in the single column case.
-        if typeof(model.domain) <:
-           Union{ClimaLSM.Domains.HybridBox, ClimaLSM.Domains.SphericalShell}
-            @test typeof(p.dss_buffer_3d) == typeof(
-                ClimaCore.Spaces.create_dss_buffer(
-                    ClimaCore.Fields.zeros(bucket_domain.space.subsurface),
-                ),
+    # Model domain
+    bucket_domains = [
+        Column(; zlim = (FT(-100), FT(0)), nelements = 10),
+        HybridBox(;
+            xlim = (FT(-1), FT(0)),
+            ylim = (FT(-1), FT(0)),
+            zlim = (FT(-100), FT(0)),
+            nelements = (2, 2, 10),
+            npolynomial = 1,
+            periodic = (true, true),
+        ),
+        SphericalShell(;
+            radius = FT(100),
+            depth = FT(3.5),
+            nelements = (1, 10),
+            npolynomial = 1,
+        ),
+    ]
+    orbital_data = Insolation.OrbitalData()
+    init_temp(z::FT, value::FT) where {FT} = FT(value)
+    for bucket_domain in bucket_domains
+        @testset "Zero flux tendency, FT = $FT" begin
+            # Radiation
+            ref_time = DateTime(2005)
+            SW_d = (t) -> 0
+            LW_d = (t) -> 5.67e-8 * 280.0^4.0
+            bucket_rad = PrescribedRadiativeFluxes(
+                FT,
+                SW_d,
+                LW_d,
+                ref_time;
+                orbital_data,
             )
-            @test typeof(p.dss_buffer_2d) == typeof(
-                ClimaCore.Spaces.create_dss_buffer(
-                    ClimaCore.Fields.zeros(bucket_domain.space.surface),
-                ),
+            # Atmos
+            precip = (t) -> 0 # no precipitation
+            T_atmos = (t) -> 280.0
+            u_atmos = (t) -> 1.0
+            q_atmos = (t) -> 0.0 # no atmos water
+            h_atmos = FT(1e-8)
+            P_atmos = (t) -> 101325
+            bucket_atmos = PrescribedAtmosphere(
+                precip,
+                precip,
+                T_atmos,
+                u_atmos,
+                q_atmos,
+                P_atmos,
+                ref_time,
+                h_atmos,
             )
-        else
-            @test propertynames(p) == (:bucket,)
+            Δt = FT(1.0)
+            bucket_parameters = BucketModelParameters(
+                κ_soil,
+                ρc_soil,
+                albedo,
+                σS_c,
+                W_f,
+                z_0m,
+                z_0b,
+                Δt,
+                earth_param_set,
+            )
+
+            model = BucketModel(
+                parameters = bucket_parameters,
+                domain = bucket_domain,
+                atmosphere = bucket_atmos,
+                radiation = bucket_rad,
+            )
+            # Initial conditions with no moisture
+            Y, p, coords = initialize(model)
+            # test if the correct dss buffers were added to aux.
+            # We only need to add a dss buffer when there is a horizontal
+            # space (spectral element space). So, we check that it is added
+            # in the case of the HybridBox and SphericalShell domains,
+            # and check that it is not added in the single column case.
+            if typeof(model.domain) <: Union{
+                ClimaLSM.Domains.HybridBox,
+                ClimaLSM.Domains.SphericalShell,
+            }
+                @test typeof(p.dss_buffer_3d) == typeof(
+                    ClimaCore.Spaces.create_dss_buffer(
+                        ClimaCore.Fields.zeros(bucket_domain.space.subsurface),
+                    ),
+                )
+                @test typeof(p.dss_buffer_2d) == typeof(
+                    ClimaCore.Spaces.create_dss_buffer(
+                        ClimaCore.Fields.zeros(bucket_domain.space.surface),
+                    ),
+                )
+            else
+                @test propertynames(p) == (:bucket,)
+            end
+
+
+            Y.bucket.T .= init_temp.(coords.subsurface.z, FT(280))
+            Y.bucket.W .= 0.0 # no moisture
+            Y.bucket.Ws .= 0.0 # no runoff
+            Y.bucket.σS .= 0.0
+
+            exp_tendency! = make_exp_tendency(model)
+            set_initial_aux_state! = make_set_initial_aux_state(model)
+            set_initial_aux_state!(p, Y, 0.0)
+            dY = similar(Y)
+            # init to nonzero numbers
+            dY.bucket.T .= init_temp.(coords.subsurface.z, FT(1.0))
+            dY.bucket.W .= 1.0
+            dY.bucket.Ws .= 1.0
+            dY.bucket.σS .= 0.0
+            exp_tendency!(dY, Y, p, 0.0)
+            @test mean(parent(dY.bucket.T)) < eps(FT)
+            @test mean(parent(dY.bucket.W)) < eps(FT)
+            @test mean(parent(dY.bucket.Ws)) < eps(FT)
+            @test mean(parent(dY.bucket.σS)) < eps(FT)
         end
 
 
-        Y.bucket.T .= init_temp.(coords.subsurface.z, 280.0)
-        Y.bucket.W .= 0.0 # no moisture
-        Y.bucket.Ws .= 0.0 # no runoff
-        Y.bucket.σS .= 0.0
+        @testset "Energy + Moisture Conservation, FT = $FT" begin
+            "Radiation"
+            ref_time = DateTime(2005)
+            SW_d = (t) -> 10
+            LW_d = (t) -> 300
+            bucket_rad = PrescribedRadiativeFluxes(
+                FT,
+                SW_d,
+                LW_d,
+                ref_time;
+                orbital_data,
+            )
+            "Atmos"
+            precip = (t) -> 1e-6
+            precip_snow = (t) -> 0
+            T_atmos = (t) -> 298
+            u_atmos = (t) -> 4
+            q_atmos = (t) -> 0.01
+            h_atmos = FT(30)
+            P_atmos = (t) -> 101325
+            bucket_atmos = PrescribedAtmosphere(
+                precip,
+                precip_snow,
+                T_atmos,
+                u_atmos,
+                q_atmos,
+                P_atmos,
+                ref_time,
+                h_atmos,
+            )
+            Δt = FT(100.0)
+            bucket_parameters = BucketModelParameters(
+                κ_soil,
+                ρc_soil,
+                albedo,
+                σS_c,
+                W_f,
+                z_0m,
+                z_0b,
+                Δt,
+                earth_param_set,
+            )
+            model = BucketModel(
+                parameters = bucket_parameters,
+                domain = bucket_domain,
+                atmosphere = bucket_atmos,
+                radiation = bucket_rad,
+            )
 
-        exp_tendency! = make_exp_tendency(model)
-        set_initial_aux_state! = make_set_initial_aux_state(model)
-        set_initial_aux_state!(p, Y, 0.0)
-        dY = similar(Y)
-        # init to nonzero numbers
-        dY.bucket.T .= init_temp.(coords.subsurface.z, 1.0)
-        dY.bucket.W .= 1.0
-        dY.bucket.Ws .= 1.0
-        dY.bucket.σS .= 0.0
-        exp_tendency!(dY, Y, p, 0.0)
-        @test mean(parent(dY.bucket.T)) < eps(FT)
-        @test mean(parent(dY.bucket.W)) < eps(FT)
-        @test mean(parent(dY.bucket.Ws)) < eps(FT)
-        @test mean(parent(dY.bucket.σS)) < eps(FT)
-    end
+            # Initial conditions with no moisture
+            Y, p, coords = initialize(model)
+            Y.bucket.T .= init_temp.(coords.subsurface.z, FT(280.0))
+            Y.bucket.W .= 0.149
+            Y.bucket.Ws .= 0.0
+            Y.bucket.σS .= 0.0
+            exp_tendency! = make_exp_tendency(model)
+            t0 = FT(0.0)
+            set_initial_aux_state! = make_set_initial_aux_state(model)
+            set_initial_aux_state!(p, Y, t0)
+            dY = similar(Y)
+            exp_tendency!(dY, Y, p, t0)
+            F_water_sfc = FT(precip(t0)) .- p.bucket.evaporation
+            F_sfc = -1 .* (p.bucket.turbulent_energy_flux .+ p.bucket.R_n)
+            surface_space = model.domain.space.surface
+            A_sfc = sum(ones(surface_space))
+            # For the point space, we actually want the flux itself, since our variables are per unit area.
+            # Divide by A_sfc
+            if typeof(model.domain.space.surface) <: ClimaCore.Spaces.PointSpace
+                F_sfc .= F_sfc ./ A_sfc
+            end
 
-
-    @testset "Energy + Moisture Conservation" begin
-        "Radiation"
-        ref_time = DateTime(2005)
-        SW_d = (t) -> eltype(t)(10.0)
-        LW_d = (t) -> eltype(t)(300.0)
-        bucket_rad =
-            PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time; orbital_data)
-        "Atmos"
-        precip = (t) -> eltype(t)(1e-6)
-        T_atmos = (t) -> eltype(t)(298.0)
-        u_atmos = (t) -> eltype(t)(4.0)
-        q_atmos = (t) -> eltype(t)(0.01)
-        h_atmos = FT(30)
-        P_atmos = (t) -> eltype(t)(101325)
-        bucket_atmos = PrescribedAtmosphere(
-            precip,
-            (t) -> eltype(t)(0.0),
-            T_atmos,
-            u_atmos,
-            q_atmos,
-            P_atmos,
-            ref_time,
-            h_atmos,
-        )
-        Δt = FT(100.0)
-        bucket_parameters = BucketModelParameters(
-            κ_soil,
-            ρc_soil,
-            albedo,
-            σS_c,
-            W_f,
-            z_0m,
-            z_0b,
-            Δt,
-            earth_param_set,
-        )
-        model = BucketModel(
-            parameters = bucket_parameters,
-            domain = bucket_domain,
-            atmosphere = bucket_atmos,
-            radiation = bucket_rad,
-        )
-
-        # Initial conditions with no moisture
-        Y, p, coords = initialize(model)
-        Y.bucket.T .= init_temp.(coords.subsurface.z, 280.0)
-        Y.bucket.W .= 0.149
-        Y.bucket.Ws .= 0.0
-        Y.bucket.σS .= 0.0
-        exp_tendency! = make_exp_tendency(model)
-        t0 = 0.0
-        set_initial_aux_state! = make_set_initial_aux_state(model)
-        set_initial_aux_state!(p, Y, t0)
-        dY = similar(Y)
-        exp_tendency!(dY, Y, p, t0)
-        F_water_sfc = precip(t0) .- p.bucket.evaporation
-        F_sfc = -1 .* (p.bucket.turbulent_energy_flux .+ p.bucket.R_n)
-        surface_space = model.domain.space.surface
-        A_sfc = sum(ones(surface_space))
-        # For the point space, we actually want the flux itself, since our variables are per unit area.
-        # Divide by A_sfc
-        if typeof(model.domain.space.surface) <: ClimaCore.Spaces.PointSpace
-            F_sfc .= F_sfc ./ A_sfc
+            @test sum(F_water_sfc) ≈ sum(dY.bucket.W .+ dY.bucket.Ws)
+            @test sum(F_sfc) ≈ sum(dY.bucket.T .* ρc_soil)
         end
-
-        @test sum(F_water_sfc) ≈ sum(dY.bucket.W .+ dY.bucket.Ws)
-        @test sum(F_sfc) ≈ sum(dY.bucket.T .* ρc_soil)
-
     end
-
 end

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -5,87 +5,88 @@ import ClimaLSM
 import ClimaLSM.Parameters as LSMP
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
-@testset "Snow Parameterizations" begin
-    FT = Float32
-    param_set = create_lsm_parameters(FT)
+for FT in (Float32, Float64)
+    @testset "Snow Parameterizations, FT = $FT" begin
+        param_set = create_lsm_parameters(FT)
 
-    # Density of liquid water (kg/m``^3``)
-    _ρ_l = FT(LSMP.ρ_cloud_liq(param_set))
-    # Density of ice water (kg/m``^3``)
-    _ρ_i = FT(LSMP.ρ_cloud_ice(param_set))
-    _cp_l = FT(LSMP.cp_l(param_set))
-    _cp_i = FT(LSMP.cp_i(param_set))
-    # Reference temperature (K)
-    _T_ref = FT(LSMP.T_0(param_set))
-    # Freezing temperature (K)
-    _T_freeze = FT(LSMP.T_freeze(param_set))
-    # Latent heat of fusion at ``T_0`` (J/kg)
-    _LH_f0 = FT(LSMP.LH_f0(param_set))
-    # Thermal conductivity of dry air
-    κ_air = FT(LSMP.K_therm(param_set))
+        # Density of liquid water (kg/m``^3``)
+        _ρ_l = FT(LSMP.ρ_cloud_liq(param_set))
+        # Density of ice water (kg/m``^3``)
+        _ρ_i = FT(LSMP.ρ_cloud_ice(param_set))
+        _cp_l = FT(LSMP.cp_l(param_set))
+        _cp_i = FT(LSMP.cp_i(param_set))
+        # Reference temperature (K)
+        _T_ref = FT(LSMP.T_0(param_set))
+        # Freezing temperature (K)
+        _T_freeze = FT(LSMP.T_freeze(param_set))
+        # Latent heat of fusion at ``T_0`` (J/kg)
+        _LH_f0 = FT(LSMP.LH_f0(param_set))
+        # Thermal conductivity of dry air
+        κ_air = FT(LSMP.K_therm(param_set))
 
-    ρ_snow = FT(200)
-    z_0m = FT(0.0024)
-    z_0b = FT(0.00024)
-    α_snow = FT(0.8)
-    ϵ_snow = FT(0.99)
-    θ_r = FT(0.08)
-    Ksat = FT(1e-3)
-    κ_ice = FT(2.21)
-    Δt = FT(180.0)
-    parameters = SnowParameters{FT}(Δt; earth_param_set = param_set)
-    @test parameters.ρ_snow == ρ_snow
-    @test typeof(parameters.ρ_snow) == FT
-    @test parameters.z_0m == z_0m
-    @test typeof(parameters.z_0m) == FT
-    @test parameters.z_0b == z_0b
-    @test typeof(parameters.z_0b) == FT
-    @test parameters.α_snow == α_snow
-    @test typeof(parameters.α_snow) == FT
-    @test parameters.ϵ_snow == ϵ_snow
-    @test typeof(parameters.ϵ_snow) == FT
-    @test parameters.Ksat == Ksat
-    @test typeof(parameters.Ksat) == FT
-    @test parameters.θ_r == θ_r
-    @test typeof(parameters.θ_r) == FT
-    @test parameters.κ_ice == κ_ice
-    @test typeof(parameters.κ_ice) == FT
-
-
-
-    T = FT.([275.0, 272, _T_freeze])
-    @test snow_surface_temperature.(T) ≈ T
-    @test all(
-        maximum_liquid_mass_fraction.(T, ρ_snow, Ref(parameters)) .==
-        [FT(0), θ_r * _ρ_l / ρ_snow, θ_r * _ρ_l / ρ_snow],
-    )
-
-    SWE = cat(FT.(rand(100) .+ 0.2), FT(0), dims = 1)
-    z = snow_depth.(SWE, ρ_snow, _ρ_l)
-    @test all(z .== SWE * _ρ_l ./ ρ_snow)
-    @test specific_heat_capacity(FT(1.0), parameters) == _cp_l
-    @test specific_heat_capacity(FT(0.0), parameters) == _cp_i
-    @test snow_thermal_conductivity(ρ_snow, parameters) ==
-          κ_air +
-          (FT(7.75e-5) * ρ_snow + FT(1.105e-6) * ρ_snow^2) * (κ_ice - κ_air)
-    @test runoff_timescale.(z, Ksat, Δt) ≈ max.(Δt, z ./ Ksat)
+        ρ_snow = FT(200)
+        z_0m = FT(0.0024)
+        z_0b = FT(0.00024)
+        α_snow = FT(0.8)
+        ϵ_snow = FT(0.99)
+        θ_r = FT(0.08)
+        Ksat = FT(1e-3)
+        κ_ice = FT(2.21)
+        Δt = FT(180.0)
+        parameters = SnowParameters{FT}(Δt; earth_param_set = param_set)
+        @test parameters.ρ_snow == ρ_snow
+        @test typeof(parameters.ρ_snow) == FT
+        @test parameters.z_0m == z_0m
+        @test typeof(parameters.z_0m) == FT
+        @test parameters.z_0b == z_0b
+        @test typeof(parameters.z_0b) == FT
+        @test parameters.α_snow == α_snow
+        @test typeof(parameters.α_snow) == FT
+        @test parameters.ϵ_snow == ϵ_snow
+        @test typeof(parameters.ϵ_snow) == FT
+        @test parameters.Ksat == Ksat
+        @test typeof(parameters.Ksat) == FT
+        @test parameters.θ_r == θ_r
+        @test typeof(parameters.θ_r) == FT
+        @test parameters.κ_ice == κ_ice
+        @test typeof(parameters.κ_ice) == FT
 
 
-    U = cat(FT.(Array(LinRange(-1e8, 1e7, 100))), FT(0), dims = 1)
-    q_l = snow_liquid_mass_fraction.(U, SWE, Ref(parameters))
-    T_bulk = snow_bulk_temperature.(U, SWE, q_l, Ref(parameters))
 
-    @test all(q_l[T_bulk .< _T_freeze] .< eps(FT))
-    @test all(q_l[T_bulk .> _T_freeze] .≈ FT(1))
-    @test all(q_l[T_bulk .== _T_freeze] .> FT(0.0)) &&
-          all(q_l[T_bulk .== _T_freeze] .< FT(1.1))
-    Upred =
-        _ρ_l .* max.(SWE, eps(FT)) .* (
-            specific_heat_capacity.(q_l, Ref(parameters)) .*
-            (T_bulk .- _T_ref) .- (1.0f0 .- q_l) .* _LH_f0
+        T = FT.([275.0, 272, _T_freeze])
+        @test snow_surface_temperature.(T) ≈ T
+        @test all(
+            maximum_liquid_mass_fraction.(T, ρ_snow, Ref(parameters)) .==
+            [FT(0), θ_r * _ρ_l / ρ_snow, θ_r * _ρ_l / ρ_snow],
         )
-    q_lpred = snow_liquid_mass_fraction.(Upred, SWE, Ref(parameters))
-    T_pred = snow_bulk_temperature.(Upred, SWE, q_lpred, Ref(parameters))
-    @test all(q_lpred .≈ q_l)
-    @test all(T_pred .≈ T_bulk)
+
+        SWE = cat(FT.(rand(100) .+ 0.2), FT(0), dims = 1)
+        z = snow_depth.(SWE, ρ_snow, _ρ_l)
+        @test all(z .== SWE * _ρ_l ./ ρ_snow)
+        @test specific_heat_capacity(FT(1.0), parameters) == _cp_l
+        @test specific_heat_capacity(FT(0.0), parameters) == _cp_i
+        @test snow_thermal_conductivity(ρ_snow, parameters) ==
+              κ_air +
+              (FT(7.75e-5) * ρ_snow + FT(1.105e-6) * ρ_snow^2) * (κ_ice - κ_air)
+        @test runoff_timescale.(z, Ksat, Δt) ≈ max.(Δt, z ./ Ksat)
+
+
+        U = cat(FT.(Array(LinRange(-1e8, 1e7, 100))), FT(0), dims = 1)
+        q_l = snow_liquid_mass_fraction.(U, SWE, Ref(parameters))
+        T_bulk = snow_bulk_temperature.(U, SWE, q_l, Ref(parameters))
+
+        @test all(q_l[T_bulk .< _T_freeze] .< eps(FT))
+        @test all(q_l[T_bulk .> _T_freeze] .≈ FT(1))
+        @test all(q_l[T_bulk .== _T_freeze] .> FT(0.0)) &&
+              all(q_l[T_bulk .== _T_freeze] .< FT(1.1))
+        Upred =
+            _ρ_l .* max.(SWE, eps(FT)) .* (
+                specific_heat_capacity.(q_l, Ref(parameters)) .*
+                (T_bulk .- _T_ref) .- (1.0f0 .- q_l) .* _LH_f0
+            )
+        q_lpred = snow_liquid_mass_fraction.(Upred, SWE, Ref(parameters))
+        T_pred = snow_bulk_temperature.(Upred, SWE, q_lpred, Ref(parameters))
+        @test all(q_lpred .≈ q_l)
+        @test all(T_pred .≈ T_bulk)
+    end
 end

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -10,141 +10,147 @@ import ClimaLSM.Parameters as LSMP
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
-@testset "Soil co2 biogeochemistry sources" begin
-    FT = Float64
-    earth_param_set = create_lsm_parameters(FT)
-    # Prognostic variables
-    P_sfc = (t) -> 101e3
-    T_soil = (z, t) -> eltype(t)(303)
-    θ_l = (z, t) -> eltype(t)(0.3)
-    θ_i = (z, t) -> eltype(t)(0.0)
-    Csom = (z, t) -> eltype(t)(5.0) # 3 [kg C m-3] soil organic C content at depth z
-    D_ref = FT(0.0)
-    parameters = SoilCO2ModelParameters{FT}(;
-        D_ref = D_ref,
-        earth_param_set = earth_param_set,
-    )
+for FT in (Float32, Float64)
+    @testset "Soil co2 biogeochemistry sources, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        # Prognostic variables
+        P_sfc = (t) -> 101e3
+        T_soil = (z, t) -> eltype(z)(t)
+        θ_l = (z, t) -> eltype(z)(0.3)
+        θ_i = (z, t) -> eltype(z)(0)
+        Csom = (z, t) -> eltype(z)(5.0) # 3 [kg C m-3] soil organic C content at depth z
+        D_ref = FT(0.0)
+        parameters = SoilCO2ModelParameters{FT}(;
+            D_ref = D_ref,
+            earth_param_set = earth_param_set,
+        )
 
-    nelems = 50 # number of layers in the vertical
-    zmin = FT(-1) # 0 to 1 m depth
-    zmax = FT(0.0)
-    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    top_bc = SoilCO2StateBC((p, t) -> eltype(t)(3000.0))
-    bot_bc = SoilCO2StateBC((p, t) -> eltype(t)(100.0))
-    sources = (MicrobeProduction{FT}(),)
-    boundary_conditions = (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
+        nelems = 50 # number of layers in the vertical
+        zmin = FT(-1) # 0 to 1 m depth
+        zmax = FT(0.0)
+        soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+        top_bc = SoilCO2StateBC((p, t) -> 3000.0)
+        bot_bc = SoilCO2StateBC((p, t) -> 100.0)
+        sources = (MicrobeProduction{FT}(),)
+        boundary_conditions =
+            (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
 
-    # Make a PrescribedAtmosphere - we only care about atmos_p though
-    precipitation_function = (t) -> 1.0
-    snow_precip = (t) -> 1.0
-    atmos_T = (t) -> 1.0
-    atmos_u = (t) -> 1.0
-    atmos_q = (t) -> 1.0
-    atmos_p = (t) -> 100000.0
-    UTC_DATETIME = Dates.now()
-    atmos_h = FT(30)
-    atmos_co2 = (t) -> 1.0
+        # Make a PrescribedAtmosphere - we only care about atmos_p though
+        precipitation_function = (t) -> 1.0
+        snow_precip = (t) -> 1.0
+        atmos_T = (t) -> 1.0
+        atmos_u = (t) -> 1.0
+        atmos_q = (t) -> 1.0
+        atmos_p = (t) -> 100000.0
+        UTC_DATETIME = Dates.now()
+        atmos_h = FT(30)
+        atmos_co2 = (t) -> 1.0
 
-    atmos = ClimaLSM.PrescribedAtmosphere(
-        precipitation_function,
-        snow_precip,
-        atmos_T,
-        atmos_u,
-        atmos_q,
-        atmos_p,
-        UTC_DATETIME,
-        atmos_h;
-        c_co2 = atmos_co2,
-    )
+        atmos = ClimaLSM.PrescribedAtmosphere(
+            precipitation_function,
+            snow_precip,
+            atmos_T,
+            atmos_u,
+            atmos_q,
+            atmos_p,
+            UTC_DATETIME,
+            atmos_h;
+            c_co2 = atmos_co2,
+        )
 
-    soil_drivers =
-        SoilDrivers(PrescribedMet(T_soil, θ_l), PrescribedSOC(Csom), atmos)
+        soil_drivers = SoilDrivers(
+            PrescribedMet{FT}(T_soil, θ_l),
+            PrescribedSOC{FT}(Csom),
+            atmos,
+        )
 
-    model = SoilCO2Model{FT}(;
-        parameters = parameters,
-        domain = soil_domain,
-        sources = sources,
-        boundary_conditions = boundary_conditions,
-        drivers = soil_drivers,
-    )
+        model = SoilCO2Model{FT}(;
+            parameters = parameters,
+            domain = soil_domain,
+            sources = sources,
+            boundary_conditions = boundary_conditions,
+            drivers = soil_drivers,
+        )
 
-    Y, p, coords = initialize(model)
-    dY = similar(Y)
-    exp_tendency! = make_exp_tendency(model)
-    t = FT(1)
-    Y.soilco2.C .= FT(4)
-    set_initial_aux_state! = make_set_initial_aux_state(model)
-    set_initial_aux_state!(p, Y, t)
-    exp_tendency!(dY, Y, p, t)
-    @test dY.soilco2.C ≈ p.soilco2.Sm
-end
+        Y, p, coords = initialize(model)
+        dY = similar(Y)
+        exp_tendency! = make_exp_tendency(model)
+        t = FT(1)
+        Y.soilco2.C .= FT(4)
+        set_initial_aux_state! = make_set_initial_aux_state(model)
+        set_initial_aux_state!(p, Y, t)
+        exp_tendency!(dY, Y, p, t)
+        @test dY.soilco2.C ≈ p.soilco2.Sm
+    end
 
 
-@testset "Soil co2 biogeochemistry diffusion" begin
-    FT = Float64
-    earth_param_set = create_lsm_parameters(FT)
-    # Prognostic variables
-    P_sfc = (t) -> 101e3
-    T_soil = (z, t) -> eltype(t)(303)
-    θ_l = (z, t) -> eltype(t)(0.3)
-    θ_i = (z, t) -> eltype(t)(0.0)
-    Csom = (z, t) -> eltype(t)(5.0) # 3 [kg C m-3] soil organic C content at depth z
+    @testset "Soil co2 biogeochemistry diffusion, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        # Prognostic variables
+        P_sfc = (t) -> 101e3
+        T_soil = (z, t) -> eltype(z)(303)
+        θ_l = (z, t) -> eltype(z)(0.3)
+        θ_i = (z, t) -> eltype(z)(0.0)
+        Csom = (z, t) -> eltype(z)(5.0) # 3 [kg C m-3] soil organic C content at depth z
 
-    parameters = SoilCO2ModelParameters{FT}(; earth_param_set = earth_param_set)
-    C = FT(4)
-    nelems = 50 # number of layers in the vertical
-    zmin = FT(-1) # 0 to 1 m depth
-    zmax = FT(0.0)
-    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    top_bc = SoilCO2StateBC((p, t) -> eltype(t)(C))
-    bot_bc = SoilCO2StateBC((p, t) -> eltype(t)(C))
-    sources = ()
-    boundary_conditions = (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
+        parameters =
+            SoilCO2ModelParameters{FT}(; earth_param_set = earth_param_set)
+        C = FT(4)
+        nelems = 50 # number of layers in the vertical
+        zmin = FT(-1) # 0 to 1 m depth
+        zmax = FT(0.0)
+        soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+        top_bc = SoilCO2StateBC((p, t) -> C)
+        bot_bc = SoilCO2StateBC((p, t) -> C)
+        sources = ()
+        boundary_conditions =
+            (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
 
-    # Make a PrescribedAtmosphere - we only care about atmos_p though
-    precipitation_function = (t) -> 1.0
-    snow_precip = (t) -> 1.0
-    atmos_T = (t) -> 1.0
-    atmos_u = (t) -> 1.0
-    atmos_q = (t) -> 1.0
-    atmos_p = (t) -> 100000.0
-    UTC_DATETIME = Dates.now()
-    atmos_h = FT(30)
-    atmos_co2 = (t) -> 1.0
+        # Make a PrescribedAtmosphere - we only care about atmos_p though
+        precipitation_function = (t) -> 1.0
+        snow_precip = (t) -> 1.0
+        atmos_T = (t) -> 1.0
+        atmos_u = (t) -> 1.0
+        atmos_q = (t) -> 1.0
+        atmos_p = (t) -> 100000.0
+        UTC_DATETIME = Dates.now()
+        atmos_h = FT(30)
+        atmos_co2 = (t) -> 1.0
 
-    atmos = ClimaLSM.PrescribedAtmosphere(
-        precipitation_function,
-        snow_precip,
-        atmos_T,
-        atmos_u,
-        atmos_q,
-        atmos_p,
-        UTC_DATETIME,
-        atmos_h;
-        c_co2 = atmos_co2,
-    )
+        atmos = ClimaLSM.PrescribedAtmosphere(
+            precipitation_function,
+            snow_precip,
+            atmos_T,
+            atmos_u,
+            atmos_q,
+            atmos_p,
+            UTC_DATETIME,
+            atmos_h;
+            c_co2 = atmos_co2,
+        )
 
-    soil_drivers = SoilDrivers(
-        PrescribedMet(T_soil, θ_l),
-        PrescribedSOC(Csom),
-        atmos, # need to create some functions
-    )
+        soil_drivers = SoilDrivers(
+            PrescribedMet{FT}(T_soil, θ_l),
+            PrescribedSOC{FT}(Csom),
+            atmos, # need to create some functions
+        )
 
-    model = SoilCO2Model{FT}(;
-        parameters = parameters,
-        domain = soil_domain,
-        sources = sources,
-        boundary_conditions = boundary_conditions,
-        drivers = soil_drivers,
-    )
+        model = SoilCO2Model{FT}(;
+            parameters = parameters,
+            domain = soil_domain,
+            sources = sources,
+            boundary_conditions = boundary_conditions,
+            drivers = soil_drivers,
+        )
 
-    Y, p, coords = initialize(model)
-    dY = similar(Y)
-    exp_tendency! = make_exp_tendency(model)
-    t = FT(1)
-    Y.soilco2.C .= FT(C)
-    set_initial_aux_state! = make_set_initial_aux_state(model)
-    set_initial_aux_state!(p, Y, t)
-    exp_tendency!(dY, Y, p, t)
-    @test sum(dY.soilco2.C) ≈ FT(0.0)
+        Y, p, coords = initialize(model)
+        dY = similar(Y)
+        exp_tendency! = make_exp_tendency(model)
+        t = FT(1)
+        Y.soilco2.C .= FT(C)
+        set_initial_aux_state! = make_set_initial_aux_state(model)
+        set_initial_aux_state!(p, Y, t)
+        exp_tendency!(dY, Y, p, t)
+        @test sum(dY.soilco2.C) ≈ FT(0.0)
+    end
 end

--- a/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
+++ b/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
@@ -7,63 +7,65 @@ import ClimaLSM.Parameters as LSMP
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
-@testset "Soil CO2 production and transport" begin
-    FT = Float64
-    earth_param_set = create_lsm_parameters(FT)
-    # Parameters should be supplied in m/kg/s (Pa... etc)
-    D_liq = FT(3.17)
-    ν = FT(0.556)
-    θ_a100 = FT(0.1846)
-    D_ref = FT(1.39e-5)
-    b = FT(4.547)
-    α_sx = FT(194e3)
-    Ea_sx = FT(61e3)
-    kM_sx = FT(5e-3)
-    kM_o2 = FT(0.004)
-    O2_a = FT(0.209)
-    D_oa = FT(1.67)
-    p_sx = FT(0.024)
-    # Prognostic variables
-    P_sfc = FT(101e3)
-    T_soil = FT(303)
-    θ_l = FT(0.3)
-    θ_i = FT(0.0)
-    θ_w = θ_l + θ_i
-    Csom = FT(5.0)
-    T_ref = FT(LSMP.T_0(earth_param_set))
-    R = FT(LSMP.gas_constant(earth_param_set))
+for FT in (Float32, Float64)
+    @testset "Soil CO2 production and transport, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        # Parameters should be supplied in m/kg/s (Pa... etc)
+        D_liq = FT(3.17)
+        ν = FT(0.556)
+        θ_a100 = FT(0.1846)
+        D_ref = FT(1.39e-5)
+        b = FT(4.547)
+        α_sx = FT(194e3)
+        Ea_sx = FT(61e3)
+        kM_sx = FT(5e-3)
+        kM_o2 = FT(0.004)
+        O2_a = FT(0.209)
+        D_oa = FT(1.67)
+        p_sx = FT(0.024)
+        # Prognostic variables
+        P_sfc = FT(101e3)
+        T_soil = FT(303)
+        θ_l = FT(0.3)
+        θ_i = FT(0.0)
+        θ_w = θ_l + θ_i
+        Csom = FT(5.0)
+        T_ref = FT(LSMP.T_0(earth_param_set))
+        R = FT(LSMP.gas_constant(earth_param_set))
 
-    parameters = SoilCO2ModelParameters{FT}(;
-        D_liq = D_liq,
-        ν = ν,
-        θ_a100 = θ_a100,
-        D_ref = D_ref,
-        b = b,
-        earth_param_set = earth_param_set,
-    )
+        parameters = SoilCO2ModelParameters{FT}(;
+            D_liq = D_liq,
+            ν = ν,
+            θ_a100 = θ_a100,
+            D_ref = D_ref,
+            b = b,
+            earth_param_set = earth_param_set,
+        )
 
-    # Test that parameterizations functions are working properly
-    θ_a = volumetric_air_content(θ_w, parameters)
-    @test θ_a == parameters.ν - θ_w
-    @test typeof(θ_a) == FT
+        # Test that parameterizations functions are working properly
+        θ_a = volumetric_air_content(θ_w, parameters)
+        @test θ_a == parameters.ν - θ_w
+        @test typeof(θ_a) == FT
 
-    D = co2_diffusivity(T_soil, θ_w, P_sfc, parameters)
-    @test D ==
-          (
-              parameters.D_ref *
-              (T_soil / T_ref)^FT(1.75) *
-              (FT(LSMP.P_ref(parameters.earth_param_set)) / P_sfc)
-          ) *
-          (FT(2)parameters.θ_a100^FT(3) + FT(0.04)parameters.θ_a100) *
-          (θ_a / parameters.θ_a100)^(FT(2) + FT(3) / parameters.b)
-    @test typeof(D) == FT
+        D = co2_diffusivity(T_soil, θ_w, P_sfc, parameters)
+        @test D ==
+              (
+                  parameters.D_ref *
+                  (T_soil / T_ref)^FT(1.75) *
+                  (FT(LSMP.P_ref(parameters.earth_param_set)) / P_sfc)
+              ) *
+              (FT(2)parameters.θ_a100^FT(3) + FT(0.04)parameters.θ_a100) *
+              (θ_a / parameters.θ_a100)^(FT(2) + FT(3) / parameters.b)
+        @test typeof(D) == FT
 
-    ms = microbe_source(T_soil, θ_l, Csom, parameters)
-    # check that the value is correct
-    MM_sx = p_sx * Csom * D_liq * θ_l^3 / (kM_sx + p_sx * Csom * D_liq * θ_l^3)
-    MM_o2 =
-        D_oa * O2_a * ((ν - θ_l)^(FT(4 / 3))) /
-        (kM_o2 + D_oa * O2_a * ((ν - θ_l)^(FT(4 / 3))))
-    @test ms == α_sx * exp(-Ea_sx / (R * T_soil)) * MM_sx * MM_o2
-    @test typeof(ms) == FT
+        ms = microbe_source(T_soil, θ_l, Csom, parameters)
+        # check that the value is correct
+        MM_sx =
+            p_sx * Csom * D_liq * θ_l^3 / (kM_sx + p_sx * Csom * D_liq * θ_l^3)
+        MM_o2 =
+            D_oa * O2_a * ((ν - θ_l)^(FT(4 / 3))) /
+            (kM_o2 + D_oa * O2_a * ((ν - θ_l)^(FT(4 / 3))))
+        @test ms == α_sx * exp(-Ea_sx / (R * T_soil)) * MM_sx * MM_o2
+        @test typeof(ms) == FT
+    end
 end

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -9,229 +9,244 @@ import ClimaLSM.Parameters as LSMP
 using Insolation
 using Dates
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-@testset "Surface fluxes and radiation for soil" begin
-    FT = Float32
-    earth_param_set = create_lsm_parameters(FT)
 
-    soil_domains = [
-        ClimaLSM.Domains.Column(; zlim = FT.((-100.0, 0.0)), nelements = 10),
-        ClimaLSM.Domains.HybridBox(;
-            xlim = FT.((-1.0, 0.0)),
-            ylim = FT.((-1.0, 0.0)),
-            zlim = FT.((-100.0, 0.0)),
-            nelements = (2, 2, 10),
-            npolynomial = 1,
-            periodic = (true, true),
-        ),
-    ]
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    vg_m = FT(1) - FT(1) / vg_n
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.1)
-    S_c = hcm.S_c
-    @test Soil.dry_soil_layer_thickness(FT(1), S_c, FT(1)) == FT(0)
-    @test Soil.dry_soil_layer_thickness(FT(0), S_c, FT(1)) == FT(1)
+for FT in (Float32, Float64)
+    @testset "Surface fluxes and radiation for soil, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
 
-
-
-    ν_ss_om = FT(0.0)
-    ν_ss_quartz = FT(1.0)
-    ν_ss_gravel = FT(0.0)
-    κ_minerals = FT(2.5)
-    κ_om = FT(0.25)
-    κ_quartz = FT(8.0)
-    κ_air = FT(0.025)
-    κ_ice = FT(2.21)
-    κ_liq = FT(0.57)
-    ρp = FT(2.66 / 1e3 * 1e6)
-    ρc_ds = FT(2e6 * (1.0 - ν))
-    κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-    κ_dry_soil = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-    κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
-    emissivity = FT(0.99)
-    PAR_albedo = FT(0.2)
-    NIR_albedo = FT(0.4)
-    z_0m = FT(0.001)
-    z_0b = z_0m
-    # Radiation
-    ref_time = DateTime(2005)
-    SW_d = (t) -> eltype(t)(500)
-    LW_d = (t) -> eltype(t)(5.67e-8 * 280.0^4.0)
-    radiation = PrescribedRadiativeFluxes(
-        FT,
-        SW_d,
-        LW_d,
-        ref_time;
-        orbital_data = Insolation.OrbitalData(),
-    )
-    # Atmos
-    precip = (t) -> eltype(t)(1e-8)
-    T_atmos = (t) -> eltype(t)(285.0)
-    u_atmos = (t) -> eltype(t)(3.0)
-    q_atmos = (t) -> eltype(t)(0.005)
-    h_atmos = FT(3)
-    P_atmos = (t) -> eltype(t)(101325)
-    atmos = PrescribedAtmosphere(
-        precip,
-        (t) -> eltype(t)(0),
-        T_atmos,
-        u_atmos,
-        q_atmos,
-        P_atmos,
-        ref_time,
-        h_atmos,
-    )
-    @test atmos.gustiness == FT(1)
-    top_bc = ClimaLSM.Soil.AtmosDrivenFluxBC(atmos, radiation)
-    zero_flux = FluxBC((p, t) -> eltype(t)(0.0))
-    boundary_fluxes =
-        (; top = top_bc, bottom = (water = zero_flux, heat = zero_flux))
-    params = ClimaLSM.Soil.EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry_soil,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        PAR_albedo = PAR_albedo,
-        NIR_albedo = NIR_albedo,
-        emissivity = emissivity,
-        z_0m = z_0m,
-        z_0b = z_0b,
-        earth_param_set = earth_param_set,
-    )
-
-    for domain in soil_domains
-
-        model = Soil.EnergyHydrology{FT}(;
-            parameters = params,
-            domain = domain,
-            boundary_conditions = boundary_fluxes,
-            sources = (),
-        )
-
-        Y, p, coords = initialize(model)
-        function init_soil!(Y, z, params)
-            ν = params.ν
-            FT = typeof(ν)
-            Y.soil.ϑ_l .= ν / 2
-            Y.soil.θ_i .= 0
-            T = FT(280)
-            ρc_s = Soil.volumetric_heat_capacity(ν / 2, FT(0), params)
-            Y.soil.ρe_int =
-                Soil.volumetric_internal_energy.(FT(0), ρc_s, T, Ref(params))
-        end
-
-        t = FT(0)
-        init_soil!(Y, coords.subsurface.z, model.parameters)
-        set_initial_aux_state! = make_set_initial_aux_state(model)
-        set_initial_aux_state!(p, Y, t)
-
-
-        face_space =
-            ClimaLSM.Domains.obtain_face_space(model.domain.space.subsurface)
-        N = ClimaCore.Spaces.nlevels(face_space)
-        surface_space = model.domain.space.surface
-        z_sfc = ClimaCore.Fields.Field(
-            ClimaCore.Fields.field_values(
-                ClimaCore.Fields.level(
-                    ClimaCore.Fields.coordinate_field(face_space).z,
-                    ClimaCore.Utilities.PlusHalf(N - 1),
-                ),
+        soil_domains = [
+            ClimaLSM.Domains.Column(;
+                zlim = FT.((-100.0, 0.0)),
+                nelements = 10,
             ),
-            surface_space,
+            ClimaLSM.Domains.HybridBox(;
+                xlim = FT.((-1.0, 0.0)),
+                ylim = FT.((-1.0, 0.0)),
+                zlim = FT.((-100.0, 0.0)),
+                nelements = (2, 2, 10),
+                npolynomial = 1,
+                periodic = (true, true),
+            ),
+        ]
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        vg_m = FT(1) - FT(1) / vg_n
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.1)
+        S_c = hcm.S_c
+        @test Soil.dry_soil_layer_thickness(FT(1), S_c, FT(1)) == FT(0)
+        @test Soil.dry_soil_layer_thickness(FT(0), S_c, FT(1)) == FT(1)
+
+
+        ν_ss_om = FT(0.0)
+        ν_ss_quartz = FT(1.0)
+        ν_ss_gravel = FT(0.0)
+        κ_minerals = FT(2.5)
+        κ_om = FT(0.25)
+        κ_quartz = FT(8.0)
+        κ_air = FT(0.025)
+        κ_ice = FT(2.21)
+        κ_liq = FT(0.57)
+        ρp = FT(2.66 / 1e3 * 1e6)
+        ρc_ds = FT(2e6 * (1.0 - ν))
+        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+        κ_dry_soil = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
+        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
+        emissivity = FT(0.99)
+        PAR_albedo = FT(0.2)
+        NIR_albedo = FT(0.4)
+        z_0m = FT(0.001)
+        z_0b = z_0m
+        # Radiation
+        ref_time = DateTime(2005)
+        SW_d = (t) -> 500
+        LW_d = (t) -> 5.67e-8 * 280.0^4.0
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            SW_d,
+            LW_d,
+            ref_time;
+            orbital_data = Insolation.OrbitalData(),
         )
-        T_sfc = ClimaCore.Fields.zeros(surface_space) .+ FT(280.0)
-        @test ClimaLSM.surface_emissivity(model, Y, p) == emissivity
-        @test ClimaLSM.surface_evaporative_scaling(model, Y, p) == FT(1)
-        @test ClimaLSM.surface_height(model, Y, p) == z_sfc
-        @test ClimaLSM.surface_albedo(model, Y, p) ==
-              PAR_albedo / 2 + NIR_albedo / 2
-        @test ClimaLSM.surface_temperature(model, Y, p, t) == T_sfc
+        # Atmos
+        precip = (t) -> 1e-8
+        precip_snow = (t) -> 0
+        T_atmos = (t) -> 285
+        u_atmos = (t) -> 3
+        q_atmos = (t) -> 0.005
+        h_atmos = FT(3)
+        P_atmos = (t) -> 101325
+        atmos = PrescribedAtmosphere(
+            precip,
+            precip_snow,
+            T_atmos,
+            u_atmos,
+            q_atmos,
+            P_atmos,
+            ref_time,
+            h_atmos,
+        )
+        @test atmos.gustiness == FT(1)
+        top_bc = ClimaLSM.Soil.AtmosDrivenFluxBC(atmos, radiation)
+        zero_flux = FluxBC((p, t) -> 0.0)
+        boundary_fluxes =
+            (; top = top_bc, bottom = (water = zero_flux, heat = zero_flux))
+        params = ClimaLSM.Soil.EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry_soil,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            PAR_albedo = PAR_albedo,
+            NIR_albedo = NIR_albedo,
+            emissivity = emissivity,
+            z_0m = z_0m,
+            z_0b = z_0b,
+            earth_param_set = earth_param_set,
+        )
 
-        thermo_params =
-            LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-        ts_in = construct_atmos_ts(atmos, t, thermo_params)
-        ρ_sfc = compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
-        @test ClimaLSM.surface_air_density(
-            model.boundary_conditions.top.atmos,
-            model,
-            Y,
-            p,
-            t,
-            T_sfc,
-        ) == ρ_sfc
+        for domain in soil_domains
+            model = Soil.EnergyHydrology{FT}(;
+                parameters = params,
+                domain = domain,
+                boundary_conditions = boundary_fluxes,
+                sources = (),
+            )
 
-        q_sat =
-            Thermodynamics.q_vap_saturation_generic.(
-                Ref(thermo_params),
+            Y, p, coords = initialize(model)
+            function init_soil!(Y, z, params)
+                ν = params.ν
+                FT = eltype(ν)
+                Y.soil.ϑ_l .= ν / 2
+                Y.soil.θ_i .= 0
+                T = FT(280)
+                ρc_s = Soil.volumetric_heat_capacity(ν / 2, FT(0), params)
+                Y.soil.ρe_int =
+                    Soil.volumetric_internal_energy.(
+                        FT(0),
+                        ρc_s,
+                        T,
+                        Ref(params),
+                    )
+            end
+
+            t = FT(0)
+            init_soil!(Y, coords.subsurface.z, model.parameters)
+            set_initial_aux_state! = make_set_initial_aux_state(model)
+            set_initial_aux_state!(p, Y, t)
+
+
+            face_space = ClimaLSM.Domains.obtain_face_space(
+                model.domain.space.subsurface,
+            )
+            N = ClimaCore.Spaces.nlevels(face_space)
+            surface_space = model.domain.space.surface
+            z_sfc = ClimaCore.Fields.Field(
+                ClimaCore.Fields.field_values(
+                    ClimaCore.Fields.level(
+                        ClimaCore.Fields.coordinate_field(face_space).z,
+                        ClimaCore.Utilities.PlusHalf(N - 1),
+                    ),
+                ),
+                surface_space,
+            )
+            T_sfc = ClimaCore.Fields.zeros(surface_space) .+ FT(280.0)
+            @test ClimaLSM.surface_emissivity(model, Y, p) == emissivity
+            @test ClimaLSM.surface_evaporative_scaling(model, Y, p) == FT(1)
+            @test ClimaLSM.surface_height(model, Y, p) == z_sfc
+            @test ClimaLSM.surface_albedo(model, Y, p) ==
+                  PAR_albedo / 2 + NIR_albedo / 2
+            @test ClimaLSM.surface_temperature(model, Y, p, t) == T_sfc
+
+            thermo_params =
+                LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
+            ts_in = construct_atmos_ts(atmos, t, thermo_params)
+            ρ_sfc = compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
+            @test ClimaLSM.surface_air_density(
+                model.boundary_conditions.top.atmos,
+                model,
+                Y,
+                p,
+                t,
+                T_sfc,
+            ) == ρ_sfc
+
+            q_sat =
+                Thermodynamics.q_vap_saturation_generic.(
+                    Ref(thermo_params),
+                    T_sfc,
+                    ρ_sfc,
+                    Ref(Thermodynamics.Liquid()),
+                )
+            g = LSMP.grav(model.parameters.earth_param_set)
+            M_w = LSMP.molar_mass_water(model.parameters.earth_param_set)
+            R = LSMP.gas_constant(model.parameters.earth_param_set)
+            ψ_sfc =
+                parent(p.soil.ψ)[end] .+ ClimaCore.Fields.zeros(surface_space)
+            q_sfc = @. (q_sat * exp(g * ψ_sfc * M_w / (R * T_sfc)))
+            @test ClimaLSM.surface_specific_humidity(
+                model,
+                Y,
+                p,
                 T_sfc,
                 ρ_sfc,
-                Ref(Thermodynamics.Liquid()),
-            )
-        g = LSMP.grav(model.parameters.earth_param_set)
-        M_w = LSMP.molar_mass_water(model.parameters.earth_param_set)
-        R = LSMP.gas_constant(model.parameters.earth_param_set)
-        ψ_sfc = parent(p.soil.ψ)[end] .+ ClimaCore.Fields.zeros(surface_space)
-        q_sfc = @. (q_sat * exp(g * ψ_sfc * M_w / (R * T_sfc)))
-        @test ClimaLSM.surface_specific_humidity(model, Y, p, T_sfc, ρ_sfc) ==
-              q_sfc
+            ) == q_sfc
 
-        conditions = ClimaLSM.surface_fluxes(
-            model.boundary_conditions.top.atmos,
-            model,
-            Y,
-            p,
-            t,
-        )
-        R_n = ClimaLSM.net_radiation(
-            model.boundary_conditions.top.radiation,
-            model,
-            Y,
-            p,
-            t,
-        )
-
-        (computed_water_flux, computed_energy_flux) =
-            ClimaLSM.Soil.soil_boundary_fluxes(
-                top_bc,
-                ClimaLSM.TopBoundary(),
+            conditions = ClimaLSM.surface_fluxes(
+                model.boundary_conditions.top.atmos,
                 model,
-                nothing,
+                Y,
+                p,
+                t,
+            )
+            R_n = ClimaLSM.net_radiation(
+                model.boundary_conditions.top.radiation,
+                model,
                 Y,
                 p,
                 t,
             )
 
-        (; ν, θ_r, d_ds) = model.parameters
-        _D_vapor = FT(LSMP.D_vapor(model.parameters.earth_param_set))
-        S_l_sfc = ClimaLSM.Domains.top_center_to_surface(
-            Soil.effective_saturation.(ν, Y.soil.ϑ_l, θ_r),
-        )
-        τ_a = ClimaLSM.Domains.top_center_to_surface(
-            @. (ν - p.soil.θ_l - Y.soil.θ_i)^(FT(5 / 2)) / ν
-        )
-        dsl = Soil.dry_soil_layer_thickness.(S_l_sfc, S_c, d_ds)
-        r_soil = @. dsl / (_D_vapor * τ_a) # [s\m]
-        r_ae = conditions.r_ae
-        expected_water_flux = @. atmos.liquid_precip(t) .+
-           conditions.vapor_flux * r_ae / (r_soil + r_ae)
-        @test computed_water_flux == expected_water_flux
-        expected_energy_flux =
-            @. R_n + conditions.lhf * r_ae / (r_soil + r_ae) + conditions.shf
-        @test computed_energy_flux == expected_energy_flux
+            (computed_water_flux, computed_energy_flux) =
+                ClimaLSM.Soil.soil_boundary_fluxes(
+                    top_bc,
+                    ClimaLSM.TopBoundary(),
+                    model,
+                    nothing,
+                    Y,
+                    p,
+                    t,
+                )
 
+            (; ν, θ_r, d_ds) = model.parameters
+            _D_vapor = FT(LSMP.D_vapor(model.parameters.earth_param_set))
+            S_l_sfc = ClimaLSM.Domains.top_center_to_surface(
+                Soil.effective_saturation.(ν, Y.soil.ϑ_l, θ_r),
+            )
+            τ_a = ClimaLSM.Domains.top_center_to_surface(
+                @. (ν - p.soil.θ_l - Y.soil.θ_i)^(FT(5 / 2)) / ν
+            )
+            dsl = Soil.dry_soil_layer_thickness.(S_l_sfc, S_c, d_ds)
+            r_soil = @. dsl / (_D_vapor * τ_a) # [s\m]
+            r_ae = conditions.r_ae
+            expected_water_flux = @. FT(atmos.liquid_precip(t)) .+
+               conditions.vapor_flux * r_ae / (r_soil + r_ae)
+            @test computed_water_flux == expected_water_flux
+            expected_energy_flux = @. R_n +
+               conditions.lhf * r_ae / (r_soil + r_ae) +
+               conditions.shf
+            @test computed_energy_flux == expected_energy_flux
+        end
     end
-
 end

--- a/test/standalone/Soil/runoff.jl
+++ b/test/standalone/Soil/runoff.jl
@@ -1,14 +1,14 @@
 using ClimaLSM
 using Test
 
-@testset "Base runoff functionality" begin
+FT = Float32
+@testset "Base runoff functionality, FT = $FT" begin
     runoff = ClimaLSM.Soil.NoRunoff()
     precip = 5.0
     @test ClimaLSM.Soil.soil_surface_infiltration(runoff, precip) == precip
     @test ClimaLSM.Soil.subsurface_runoff_source(runoff) == nothing
-    struct Foo{Float64} <: ClimaLSM.Soil.AbstractSoilSource{Float64} end
+    struct Foo{FT} <: ClimaLSM.Soil.AbstractSoilSource{FT} end
     srcs = (1, 2, 3)
     @test ClimaLSM.Soil.append_source(nothing, srcs) == srcs
-    @test ClimaLSM.Soil.append_source(Foo{Float64}(), srcs) ==
-          (srcs..., Foo{Float64}())
+    @test ClimaLSM.Soil.append_source(Foo{FT}(), srcs) == (srcs..., Foo{FT}())
 end

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -6,195 +6,195 @@ using ClimaLSM.Soil
 using ClimaLSM.Domains: HybridBox, SphericalShell, Column
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-FT = Float64
 
-@testset "WVector usage in gradient" begin
-    # In our tendency, we want to set a boundary condition on flux, which is a gradient
-    # of a scalar. This should be a covariant vector. In the case of no topography,
-    # the Wvector points in the same direction as the covariant vector.
+for FT in (Float32, Float64)
+    @testset "WVector usage in gradient, FT = $FT" begin
+        # In our tendency, we want to set a boundary condition on flux, which is a gradient
+        # of a scalar. This should be a covariant vector. In the case of no topography,
+        # the Wvector points in the same direction as the covariant vector.
 
-    # However, they are scaled differently. Check here that supplying a WVector
-    # to Operators.DivergenceF2C(top = Operators.SetValue...,) works - i.e.
-    # that it is converted internally to a Covariant Vector, and we get the
-    # correct output.
+        # However, they are scaled differently. Check here that supplying a WVector
+        # to Operators.DivergenceF2C(top = Operators.SetValue...,) works - i.e.
+        # that it is converted internally to a Covariant Vector, and we get the
+        # correct output.
 
-    domain = SphericalShell(;
-        radius = FT(1.0),
-        depth = FT(1.0),
-        nelements = (1, 2),
-        npolynomial = 3,
-    )
-
-    coords = ClimaLSM.Domains.coordinates(domain) # center coordinates
-    ϕ = (FT(90) .- coords.subsurface.lat)
-    θ = coords.subsurface.long
-    r = coords.subsurface.z .+ FT(1.0)
-
-    #=
-    # For my own sanity, convert lat/lon to usual spherical coords, to cartesian components,
-    # and make sure that agrees with CC.
-    scalar_x = @.  r*cos(θ*π/180)*sin(ϕ*π/180)
-    scalar_y = @.  r*sin(θ*π/180)*sin(ϕ*π/180)
-    scalar_z = @. r* cos(ϕ*π/180)
-    geom = ClimaCore.Geometry.SphericalGlobalGeometry{FT}(FT(1.0))
-    #\vec{r} = r r^
-    cartesian = @. ClimaCore.Geometry.CartesianVector(ClimaCore.Geometry.UVWVector(0.0,0.0, r))
-    cartesian_points = ClimaCore.Geometry.CartesianPoint.(coords, Ref(geom))
-    =#
-
-    scalar = @. r^3 / 1e6
-    Δr = 0.5
-    upper_bc = ClimaCore.Geometry.Covariant3Vector(2.0 * Δr) # r r^
-    lower_bc = ClimaCore.Geometry.Covariant3Vector(1.0 * Δr) # r r^
-    gradc2f = ClimaCore.Operators.GradientC2F(
-        top = ClimaCore.Operators.SetGradient(upper_bc),
-        bottom = ClimaCore.Operators.SetGradient(lower_bc),
-    )
-    foo = @. gradc2f(scalar)
-    divf2c = ClimaCore.Operators.DivergenceF2C()
-
-    div_cov = @. (divf2c(foo))
-
-
-    upper_bc = ClimaCore.Geometry.Contravariant3Vector(2.0 / Δr) # r r^
-    lower_bc = ClimaCore.Geometry.Contravariant3Vector(1.0 / Δr) # r r^
-    gradc2f = ClimaCore.Operators.GradientC2F(
-        top = ClimaCore.Operators.SetGradient(upper_bc),
-        bottom = ClimaCore.Operators.SetGradient(lower_bc),
-    )
-    foo = @. gradc2f(scalar)
-    divf2c = ClimaCore.Operators.DivergenceF2C()
-
-    div_con = @. (divf2c(foo))
-
-    upper_bc = ClimaCore.Geometry.WVector(2.0) # r r^
-    lower_bc = ClimaCore.Geometry.WVector(1.0) # r r^
-    gradc2f = ClimaCore.Operators.GradientC2F(
-        top = ClimaCore.Operators.SetGradient(upper_bc),
-        bottom = ClimaCore.Operators.SetGradient(lower_bc),
-    )
-    foo = @. gradc2f(scalar)
-    divf2c = ClimaCore.Operators.DivergenceF2C()
-
-    div_w = @. (divf2c(foo))
-    @test parent(div_w) == parent(div_cov)
-    @test parent(div_cov) == parent(div_con)
-
-
-    # Unclear why this does not work!
-    # upper_bc =ClimaCore.Geometry.Covariant3Vector(2.0*Δr) # r r^
-    # lower_bc =ClimaCore.Geometry.Covariant3Vector(1.0*Δr) # r r^
-    # gradc2f = ClimaCore.Operators.GradientC2F()
-    # divf2c = ClimaCore.Operators.DivergenceF2C(
-    #     top = ClimaCore.Operators.SetValue(upper_bc),
-    #     bottom = ClimaCore.Operators.SetValue(lower_bc),
-    # )
-
-    #div_rpt = unique(parent(@. (divf2c(gradc2f(scalar)))))
-end
-
-@testset "Test RRE state to flux BC calculations" begin
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0)
-    zmax = FT(0)
-    zmin = FT(-10)
-    nelems = 50
-    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
-    Δz = abs(zmax - zmin) / nelems / 2.0
-
-    top_Δz, bottom_Δz = get_Δz(z)
-    @test (mean(abs.(parent(top_Δz) .- Δz)) < 1e-13) &&
-          (mean(abs.(parent(bottom_Δz) .- Δz)) < 1e-13)
-
-    ϑ_bc = ν / 2
-    ϑ_c = ν / 3
-
-    K_c = hydraulic_conductivity(
-        hcm,
-        K_sat,
-        Soil.effective_saturation(ν, ϑ_c, θ_r),
-    )
-
-    ψ_bc = pressure_head(hcm, θ_r, ϑ_bc, ν, S_s)
-    ψ_c = pressure_head(hcm, θ_r, ϑ_c, ν, S_s)
-
-    flux_int = diffusive_flux(K_c, ψ_bc + Δz, ψ_c, Δz)
-    flux_expected = -K_c * ((ψ_bc - ψ_c + Δz) / Δz)
-
-    @test abs(flux_expected - flux_int) < 1e-13
-end
-
-@testset "Test heat state to flux BC calculations" begin
-    earth_param_set = create_lsm_parameters(FT)
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.1)
-    ν_ss_om = FT(0.0)
-    ν_ss_quartz = FT(1.0)
-    ν_ss_gravel = FT(0.0)
-    κ_minerals = FT(2.5)
-    κ_om = FT(0.25)
-    κ_quartz = FT(8.0)
-    κ_air = FT(0.025)
-    κ_ice = FT(2.21)
-    κ_liq = FT(0.57)
-    ρp = FT(2.66 / 1e3 * 1e6)
-    ρc_ds = FT(2e6 * (1.0 - ν))
-    κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-    κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-    κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
-
-    hyd_on_en_on = Soil.EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-
-    zmax = FT(0)
-    zmin = FT(-1)
-    nelems = 200
-    Δz = abs(zmax - zmin) / nelems
-
-    ϑ_bc = ν / 2
-    ϑ_c = ν / 3
-    θ_i = FT(0)
-    T_bc = 298
-    T_c = 290
-
-    κ_c =
-        thermal_conductivity.(
-            κ_dry,
-            kersten_number.(
-                θ_i,
-                relative_saturation.(ϑ_c, θ_i, ν),
-                Ref(hyd_on_en_on),
-            ),
-            κ_sat.(ϑ_c, θ_i, κ_sat_unfrozen, κ_sat_frozen),
+        domain = SphericalShell(;
+            radius = FT(1.0),
+            depth = FT(1.0),
+            nelements = (1, 2),
+            npolynomial = 3,
         )
 
-    flux_int = diffusive_flux(κ_c, T_bc, T_c, Δz)
-    flux_expected = -κ_c * (T_bc - T_c) / Δz
+        coords = ClimaLSM.Domains.coordinates(domain) # center coordinates
+        ϕ = (FT(90) .- coords.subsurface.lat)
+        θ = coords.subsurface.long
+        r = coords.subsurface.z .+ FT(1.0)
 
-    @test abs(flux_expected - flux_int) < 1e-13
+        #=
+        # For my own sanity, convert lat/lon to usual spherical coords, to cartesian components,
+        # and make sure that agrees with CC.
+        scalar_x = @.  r*cos(θ*π/180)*sin(ϕ*π/180)
+        scalar_y = @.  r*sin(θ*π/180)*sin(ϕ*π/180)
+        scalar_z = @. r* cos(ϕ*π/180)
+        geom = ClimaCore.Geometry.SphericalGlobalGeometry{FT}(FT(1.0))
+        #\vec{r} = r r^
+        cartesian = @. ClimaCore.Geometry.CartesianVector(ClimaCore.Geometry.UVWVector(0.0,0.0, r))
+        cartesian_points = ClimaCore.Geometry.CartesianPoint.(coords, Ref(geom))
+        =#
+
+        scalar = @. FT(r^3 / 1e6)
+        Δr = FT(0.5)
+        upper_bc = ClimaCore.Geometry.Covariant3Vector(FT(2.0 * Δr)) # r r^
+        lower_bc = ClimaCore.Geometry.Covariant3Vector(FT(1.0 * Δr)) # r r^
+        gradc2f = ClimaCore.Operators.GradientC2F(
+            top = ClimaCore.Operators.SetGradient(upper_bc),
+            bottom = ClimaCore.Operators.SetGradient(lower_bc),
+        )
+        foo = @. gradc2f(scalar)
+        divf2c = ClimaCore.Operators.DivergenceF2C()
+
+        div_cov = @. (divf2c(foo))
+
+
+        upper_bc = ClimaCore.Geometry.Contravariant3Vector(FT(2.0 * Δr)) # r r^
+        lower_bc = ClimaCore.Geometry.Contravariant3Vector(FT(1.0 * Δr)) # r r^
+        gradc2f = ClimaCore.Operators.GradientC2F(
+            top = ClimaCore.Operators.SetGradient(upper_bc),
+            bottom = ClimaCore.Operators.SetGradient(lower_bc),
+        )
+        foo = @. gradc2f(scalar)
+        divf2c = ClimaCore.Operators.DivergenceF2C()
+
+        div_con = @. (divf2c(foo))
+
+        upper_bc = ClimaCore.Geometry.WVector(FT(2.0)) # r r^
+        lower_bc = ClimaCore.Geometry.WVector(FT(1.0)) # r r^
+        gradc2f = ClimaCore.Operators.GradientC2F(
+            top = ClimaCore.Operators.SetGradient(upper_bc),
+            bottom = ClimaCore.Operators.SetGradient(lower_bc),
+        )
+        foo = @. gradc2f(scalar)
+        divf2c = ClimaCore.Operators.DivergenceF2C()
+
+        div_w = @. (divf2c(foo))
+        @test parent(div_w) == parent(div_cov)
+        @test all(abs.(parent(div_w) .- parent(div_cov)) .< eps(FT))
+
+        # Unclear why this does not work!
+        # upper_bc =ClimaCore.Geometry.Covariant3Vector(2.0*Δr) # r r^
+        # lower_bc =ClimaCore.Geometry.Covariant3Vector(1.0*Δr) # r r^
+        # gradc2f = ClimaCore.Operators.GradientC2F()
+        # divf2c = ClimaCore.Operators.DivergenceF2C(
+        #     top = ClimaCore.Operators.SetValue(upper_bc),
+        #     bottom = ClimaCore.Operators.SetValue(lower_bc),
+        # )
+
+        #div_rpt = unique(parent(@. (divf2c(gradc2f(scalar)))))
+    end
+
+    @testset "Test RRE state to flux BC calculations, FT = $FT" begin
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0)
+        zmax = FT(0)
+        zmin = FT(-10)
+        nelems = 50
+        soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+        z = ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z
+        Δz = FT(abs(zmax - zmin) / nelems / 2.0)
+
+        top_Δz, bottom_Δz = get_Δz(z)
+        @test (mean(abs.(parent(top_Δz) .- Δz)) < eps(FT))
+        @test (mean(abs.(parent(bottom_Δz) .- Δz)) < 2 * eps(FT))
+
+        ϑ_bc = FT(ν / 2)
+        ϑ_c = FT(ν / 3)
+
+        K_c = Soil.hydraulic_conductivity(
+            hcm,
+            K_sat,
+            Soil.effective_saturation(ν, ϑ_c, θ_r),
+        )
+
+        ψ_bc = pressure_head(hcm, θ_r, ϑ_bc, ν, S_s)
+        ψ_c = pressure_head(hcm, θ_r, ϑ_c, ν, S_s)
+
+        flux_int = diffusive_flux(K_c, ψ_bc + Δz, ψ_c, Δz)
+        flux_expected = -K_c * ((ψ_bc - ψ_c + Δz) / Δz)
+
+        @test abs(flux_expected - flux_int) < eps(FT)
+    end
+
+    @testset "Test heat state to flux BC calculations, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.1)
+        ν_ss_om = FT(0.0)
+        ν_ss_quartz = FT(1.0)
+        ν_ss_gravel = FT(0.0)
+        κ_minerals = FT(2.5)
+        κ_om = FT(0.25)
+        κ_quartz = FT(8.0)
+        κ_air = FT(0.025)
+        κ_ice = FT(2.21)
+        κ_liq = FT(0.57)
+        ρp = FT(2.66 / 1e3 * 1e6)
+        ρc_ds = FT(2e6 * (1.0 - ν))
+        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
+        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
+
+        hyd_on_en_on = Soil.EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
+        )
+
+        zmax = FT(0)
+        zmin = FT(-1)
+        nelems = 200
+        Δz = abs(zmax - zmin) / nelems
+
+        ϑ_bc = ν / 2
+        ϑ_c = ν / 3
+        θ_i = FT(0)
+        T_bc = FT(298)
+        T_c = FT(290)
+
+        κ_c =
+            thermal_conductivity.(
+                κ_dry,
+                kersten_number.(
+                    θ_i,
+                    relative_saturation.(ϑ_c, θ_i, ν),
+                    Ref(hyd_on_en_on),
+                ),
+                κ_sat.(ϑ_c, θ_i, κ_sat_unfrozen, κ_sat_frozen),
+            )
+
+        flux_int = diffusive_flux(κ_c, T_bc, T_c, Δz)
+        flux_expected = -κ_c * (T_bc - T_c) / Δz
+
+        @test abs(flux_expected - flux_int) < eps(FT)
+    end
 end

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -5,357 +5,367 @@ import ClimaLSM
 import ClimaLSM.Parameters as LSMP
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
-@testset "integrated Energy and Hydrology Parameterizations" begin
-    FT = Float64
-    param_set = create_lsm_parameters(FT)
+for FT in (Float32, Float64)
+    @testset "integrated Energy and Hydrology Parameterizations, FT = $FT" begin
+        param_set = create_lsm_parameters(FT)
 
-    # Density of liquid water (kg/m``^3``)
-    _ρ_l = FT(LSMP.ρ_cloud_liq(param_set))
-    # Density of ice water (kg/m``^3``)
-    _ρ_i = FT(LSMP.ρ_cloud_ice(param_set))
-    # Volum. isobaric heat capacity liquid water (J/m3/K)
-    _ρcp_l = FT(LSMP.cp_l(param_set) * _ρ_l)
-    # Volumetric isobaric heat capacity ice (J/m3/K)
-    _ρcp_i = FT(LSMP.cp_i(param_set) * _ρ_i)
-    # Reference temperature (K)
-    _T_ref = FT(LSMP.T_0(param_set))
-    # Latent heat of fusion at ``T_0`` (J/kg)
-    _LH_f0 = FT(LSMP.LH_f0(param_set))
-    # Thermal conductivity of dry air
-    κ_air = FT(LSMP.K_therm(param_set))
+        # Density of liquid water (kg/m``^3``)
+        _ρ_l = FT(LSMP.ρ_cloud_liq(param_set))
+        # Density of ice water (kg/m``^3``)
+        _ρ_i = FT(LSMP.ρ_cloud_ice(param_set))
+        # Volum. isobaric heat capacity liquid water (J/m3/K)
+        _ρcp_l = FT(LSMP.cp_l(param_set) * _ρ_l)
+        # Volumetric isobaric heat capacity ice (J/m3/K)
+        _ρcp_i = FT(LSMP.cp_i(param_set) * _ρ_i)
+        # Reference temperature (K)
+        _T_ref = FT(LSMP.T_0(param_set))
+        # Latent heat of fusion at ``T_0`` (J/kg)
+        _LH_f0 = FT(LSMP.LH_f0(param_set))
+        # Thermal conductivity of dry air
+        κ_air = FT(LSMP.K_therm(param_set))
 
-    ν = 0.2
-    S_s = 1e-3
-    θ_r = 0.1
-    vg_α = 2.0
-    vg_n = 1.4
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    K_sat = 1e-5
-    ν_ss_om = 0.1
-    ν_ss_gravel = 0.1
-    ν_ss_quartz = 0.1
-    ρc_ds = 1e6
-    κ_solid = 0.1
-    ρp = 1.0
-    κ_sat_unfrozen = 0.0
-    κ_sat_frozen = 0.0
-    κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    parameters = EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = param_set,
-    )
-    # Test that the preset params are set properly
-    (; α, β, Ω, hydrology_cm, γ, γT_ref) = parameters
-    @test α == 0.24
-    @test β == 18.3
-    @test γ == 2.64e-2
-    @test Ω == 7.0
-    @test γT_ref == 288.0
-    # Test derived parameters
-    @test hydrology_cm.m == 1.0 - 1.0 / vg_n
-    @test hydrology_cm.S_c ==
-          (1 + ((vg_n - 1) / vg_n)^(1 - 2 * vg_n))^(-hydrology_cm.m)
-    @test typeof.([α, β, γ, Ω, γT_ref]) == [FT, FT, FT, FT, FT]
+        ν = FT(0.2)
+        S_s = FT(1e-3)
+        θ_r = FT(0.1)
+        vg_α = FT(2.0)
+        vg_n = FT(1.4)
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        K_sat = FT(1e-5)
+        ν_ss_om = FT(0.1)
+        ν_ss_gravel = FT(0.1)
+        ν_ss_quartz = FT(0.1)
+        ρc_ds = FT(1e6)
+        κ_solid = FT(0.1)
+        ρp = FT(1)
+        κ_sat_unfrozen = FT(0)
+        κ_sat_frozen = FT(0)
+        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        parameters = EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = param_set,
+        )
+        # Test that the preset params are set properly
+        (; α, β, Ω, hydrology_cm, γ, γT_ref) = parameters
+        @test α == FT(0.24)
+        @test β == FT(18.3)
+        @test γ == FT(2.64e-2)
+        @test Ω == FT(7)
+        @test γT_ref == FT(288)
+        # Test derived parameters
+        @test hydrology_cm.m == FT(1.0 - 1.0 / vg_n)
+        @test hydrology_cm.S_c ==
+              FT(1 + ((vg_n - 1) / vg_n)^(1 - 2 * vg_n))^(-hydrology_cm.m)
+        @test typeof.([α, β, γ, Ω, γT_ref]) == [FT, FT, FT, FT, FT]
 
-    @test temperature_from_ρe_int(5.4e7, 0.05, 2.1415e6, parameters) ==
-          FT(_T_ref + (5.4e7 + 0.05 * _ρ_i * _LH_f0) / 2.1415e6)
+        @test temperature_from_ρe_int(
+            FT(5.4e7),
+            FT(0.05),
+            FT(2.1415e6),
+            parameters,
+        ) == FT(_T_ref + (5.4e7 + 0.05 * _ρ_i * _LH_f0) / 2.1415e6)
 
-    @test volumetric_heat_capacity(0.25, 0.05, parameters) ==
-          FT(1e6 + 0.25 * _ρcp_l + 0.05 * _ρcp_i)
+        @test volumetric_heat_capacity(FT(0.25), FT(0.05), parameters) ==
+              FT(1e6 + 0.25 * _ρcp_l + 0.05 * _ρcp_i)
 
-    @test volumetric_internal_energy(0.05, 2.1415e6, 300.0, parameters) ==
-          FT(2.1415e6 * (300.0 - _T_ref) - 0.05 * _ρ_i * _LH_f0)
+        @test volumetric_internal_energy(
+            FT(0.05),
+            FT(2.1415e6),
+            FT(300),
+            parameters,
+        ) == FT(2.1415e6 * (300.0 - _T_ref) - 0.05 * _ρ_i * _LH_f0)
 
-    @test κ_sat(0.25, 0.05, 0.57, 2.29) ==
-          FT(0.57^(0.25 / (0.05 + 0.25)) * 2.29^(0.05 / (0.05 + 0.25)))
+        @test κ_sat(FT(0.25), FT(0.05), FT(0.57), FT(2.29)) ≈
+              FT(0.57^(0.25 / (0.05 + 0.25)) * 2.29^(0.05 / (0.05 + 0.25)))
 
-    @test κ_sat(0.0, 0.0, 0.57, 2.29) == FT(0.5 * (0.57 + 2.29))
+        @test κ_sat(FT(0), FT(0), FT(0.57), FT(2.29)) == FT(0.5 * (0.57 + 2.29))
 
-    @test relative_saturation(0.25, 0.05, 0.4) == FT((0.25 + 0.05) / 0.4)
+        @test relative_saturation(FT(0.25), FT(0.05), FT(0.4)) ==
+              FT((0.25 + 0.05) / 0.4)
 
-    # ice fraction = 0
-    @test kersten_number(0.0, 0.75, parameters) == FT(
-        0.75^((FT(1) + 0.1 - 0.24 * 0.1 - 0.1) / FT(2)) *
-        (
-            (FT(1) + exp(-18.3 * 0.75))^(-FT(3)) -
-            ((FT(1) - 0.75) / FT(2))^FT(3)
-        )^(FT(1) - 0.1),
-    )
+        # ice fraction = 0
+        @test kersten_number(FT(0), FT(0.75), parameters) ≈ FT(
+            0.75^((FT(1) + 0.1 - 0.24 * 0.1 - 0.1) / FT(2)) *
+            (
+                (FT(1) + exp(-18.3 * 0.75))^(-FT(3)) -
+                ((FT(1) - 0.75) / FT(2))^FT(3)
+            )^(FT(1) - 0.1),
+        )
 
-    # ice fraction ~= 0
-    @test kersten_number(0.05, 0.75, parameters) == FT(0.75^(FT(1) + 0.1))
+        # ice fraction ~= 0
+        @test kersten_number(FT(0.05), FT(0.75), parameters) ==
+              FT(0.75^(FT(1) + 0.1))
 
-    @test thermal_conductivity(1.5, 0.7287, 0.7187) ==
-          FT(0.7287 * 0.7187 + (FT(1) - 0.7287) * 1.5)
+        @test thermal_conductivity(FT(1.5), FT(0.7287), FT(0.7187)) ==
+              FT(0.7287 * 0.7187 + (FT(1) - 0.7287) * 1.5)
 
-    @test volumetric_internal_energy_liq(300.0, parameters) ==
-          FT(_ρcp_l * (300.0 - _T_ref))
+        @test volumetric_internal_energy_liq(FT(300), parameters) ==
+              FT(_ρcp_l * (300.0 - _T_ref))
 
-    @test Soil.κ_solid(FT(0.5), FT(0.25), FT(2.0), FT(3.0), FT(2.0)) ≈
-          FT(2)^FT(0.5) * FT(2)^FT(0.25) * FT(3.0)^FT(0.25)
+        @test Soil.κ_solid(FT(0.5), FT(0.25), FT(2.0), FT(3.0), FT(2.0)) ≈
+              FT(2)^FT(0.5) * FT(2)^FT(0.25) * FT(3.0)^FT(0.25)
 
-    @test Soil.κ_sat_frozen(FT(0.5), FT(0.1), FT(0.4)) ==
-          FT(0.5)^FT(0.9) * FT(0.4)^FT(0.1)
+        @test Soil.κ_sat_frozen(FT(0.5), FT(0.1), FT(0.4)) ==
+              FT(0.5)^FT(0.9) * FT(0.4)^FT(0.1)
 
-    @test Soil.κ_sat_unfrozen(FT(0.5), FT(0.1), FT(0.4)) ==
-          FT(0.5)^FT(0.9) * FT(0.4)^FT(0.1)
+        @test Soil.κ_sat_unfrozen(FT(0.5), FT(0.1), FT(0.4)) ==
+              FT(0.5)^FT(0.9) * FT(0.4)^FT(0.1)
 
-    @test Soil.κ_dry(ρp, ν, κ_solid, κ_air) ==
-          ((FT(0.053) * FT(0.1) - κ_air) * FT(0.8) + κ_air * FT(1.0)) /
-          (FT(1.0) - (FT(1.0) - FT(0.053)) * FT(0.8))
-
-
-    # Impedance factor
-    @test impedance_factor(FT(1.0), parameters.Ω) ≈ 1e-7
-
-    # Viscosity Factor
-    T = FT.([278.0, 288.0, 298.0])
-    @test viscosity_factor.(T, parameters.γ, parameters.γT_ref) ≈
-          exp.(parameters.γ .* (T .- parameters.γT_ref))
-
-    x = [0.0, 0.2, 0.4]
-    @test soil_tortuosity.(x, 0.0, 0.3) ≈
-          [0.3^1.5, 0.1^2.5 / 0.3, eps(Float64)^2.5 / 0.3]
-    x = [0.35, 0.25, 0.0, 0.1]
-    y = [0.0, 0.0, 0.1, 0.1 * 0.15 / 0.25]
-    @test dry_soil_layer_thickness.(x, 0.25, 0.1) ≈ y
-    @test soil_resistance(θ_r, θ_r - eps(FT), FT(0.0), parameters) ≈
-          dry_soil_layer_thickness(
-        effective_saturation(ν, θ_r - eps(FT), θ_r),
-        hcm.S_c,
-        parameters.d_ds,
-    ) / FT(LSMP.D_vapor(param_set)) / soil_tortuosity(θ_r + eps(FT), 0.0, ν)
-    @test soil_resistance(ν, ν + eps(FT), FT(0.0), parameters) ≈
-          dry_soil_layer_thickness(
-        effective_saturation(ν, ν + eps(FT), θ_r),
-        hcm.S_c,
-        parameters.d_ds,
-    ) / FT(LSMP.D_vapor(param_set)) / soil_tortuosity(ν, 0.0, ν)
-end
-
-@testset "Brooks and Corey closure" begin
-    FT = Float32
-    hcm = BrooksCorey(; ψb = FT(-0.09), c = FT(0.228))
-    # Test derived parameter
-    @test hcm.S_c == (1 + 1 / FT(0.228))^(-FT(0.228))
-
-    S = FT.([0.5, 1.0, 1.5])
-    θ = FT.([0.3, 0.4, 0.5])
-    θ_r = FT(0.2)
-    ν = FT(0.4)
-    K_sat = FT(2.9e-7)
-    S_s = FT(1e-2)
-
-    # Matric Potential and inverse
-    va = S[1]^(-1 / hcm.c) * hcm.ψb
-    ψ = matric_potential.(hcm, S[1:2])
-    @test inverse_matric_potential.(hcm, ψ) ≈ S[1:2]
-    @test ψ ≈ [va, hcm.ψb]
-    @test eltype(ψ) == FT
-
-    #Pressure head
-    p = pressure_head.(hcm, θ_r, θ, ν, S_s)
-    @test p ≈ push!(ψ, FT(0.1 / 1e-2 + hcm.ψb))
-    @test eltype(p) == FT
-    # Derivative
-    dψ = dψdϑ.(hcm, θ, ν, θ_r, S_s)
-    va = @. -hcm.ψb / (hcm.c * (ν - θ_r)) * S^(-(1 + 1 / hcm.c))
-    @test dψ ≈ [va[1], 1 / S_s, 1 / S_s]
-
-    # Hydraulic K
-    k = @. hydraulic_conductivity.(hcm, K_sat, S)
-    va = S[1]^(2 / hcm.c + 3) * K_sat
-    @test k ≈ [va, K_sat, K_sat]
-    @test eltype(k) == FT
+        @test Soil.κ_dry(ρp, ν, κ_solid, κ_air) ==
+              ((FT(0.053) * FT(0.1) - κ_air) * FT(0.8) + κ_air * FT(1.0)) /
+              (FT(1.0) - (FT(1.0) - FT(0.053)) * FT(0.8))
 
 
-end
+        # Impedance factor
+        @test impedance_factor(FT(1.0), parameters.Ω) ≈ 1e-7
 
-@testset "Richards equation and van Genuchten closures" begin
-    FT = Float32
-    θ_r = FT(0.2)
-    ν = FT(0.4)
-    S_s = FT(1e-2)
-    vg_α = FT(3.6)
-    vg_n = FT(1.56)
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    K_sat = FT(2.9e-7)
-    vg_m = FT(1.0 - 1.0 / vg_n)
-    richards_parameters = RichardsParameters(;
-        ν = ν,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-    )
-    # Effective _saturation
-    θ = FT.([0.3, 0.4, 0.5])
-    S = Soil.effective_saturation.(ν, θ, θ_r)
-    @test S ≈ [0.5, 1.0, 1.5]
-    @test eltype(S) == FT
+        # Viscosity Factor
+        T = FT.([278.0, 288.0, 298.0])
+        @test viscosity_factor.(T, parameters.γ, parameters.γT_ref) ≈
+              exp.(parameters.γ .* (T .- parameters.γT_ref))
 
-    # Matric Potential and inverse
-    va = -((S[1]^(-FT(1) / vg_m) - FT(1)) * vg_α^(-vg_n))^(FT(1) / vg_n)
-    ψ = matric_potential.(hcm, S[1:2])
-    @test inverse_matric_potential.(hcm, ψ) ≈ S[1:2]
-    @test ψ ≈ [va, 0.0]
-    @test eltype(ψ) == FT
-    # Derivative
-    dψ = dψdϑ.(hcm, θ, ν, θ_r, S_s)
-    va = FT(
-        1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r) *
-        (S[1]^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
-        S[1]^(-1 / vg_m - 1),
-    )
-    @test dψ ≈ [va, 1 / S_s, 1 / S_s]
-    #Pressure head
-    p = pressure_head.(hcm, θ_r, θ, ν, S_s)
-    @test p ≈ push!(ψ, FT(10.0))
-    @test eltype(p) == FT
+        x = [0.0, 0.2, 0.4]
+        @test soil_tortuosity.(x, 0.0, 0.3) ≈
+              [0.3^1.5, 0.1^2.5 / 0.3, eps(FT)^2.5 / 0.3]
+        x = [0.35, 0.25, 0.0, 0.1]
+        y = [0.0, 0.0, 0.1, 0.1 * 0.15 / 0.25]
+        @test dry_soil_layer_thickness.(x, 0.25, 0.1) ≈ y
+        @test soil_resistance(θ_r, θ_r - eps(FT), FT(0.0), parameters) ≈
+              dry_soil_layer_thickness(
+            Soil.effective_saturation(ν, θ_r - eps(FT), θ_r),
+            hcm.S_c,
+            parameters.d_ds,
+        ) / FT(LSMP.D_vapor(param_set)) /
+              soil_tortuosity(θ_r + eps(FT), FT(0), ν)
+        @test soil_resistance(ν, ν + eps(FT), FT(0.0), parameters) ≈
+              dry_soil_layer_thickness(
+            Soil.effective_saturation(ν, ν + eps(FT), θ_r),
+            hcm.S_c,
+            parameters.d_ds,
+        ) / FT(LSMP.D_vapor(param_set)) / soil_tortuosity(ν, FT(0), ν)
+    end
 
-    # Hydraulic K
-    k = hydraulic_conductivity.(hcm, K_sat, S)
-    va =
-        (sqrt(S[1]) * (FT(1) - (FT(1) - S[1]^(FT(1) / vg_m))^vg_m)^FT(2)) *
-        K_sat
-    @test k ≈ [va, K_sat, K_sat]
-    @test eltype(k) == FT
+    @testset "Brooks and Corey closure, FT = $FT" begin
+        hcm = BrooksCorey(; ψb = FT(-0.09), c = FT(0.228))
+        # Test derived parameter
+        @test hcm.S_c == (1 + 1 / FT(0.228))^(-FT(0.228))
 
-    # Volumetric Liquid Fraction
-    vlf = volumetric_liquid_fraction.(FT.([0.25, 0.5, 0.75]), FT(0.5), FT(0.0))
-    @test vlf ≈ FT.([0.25, 0.5, 0.5])
-end
+        S = FT.([0.5, 1.0, 1.5])
+        θ = FT.([0.3, 0.4, 0.5])
+        θ_r = FT(0.2)
+        ν = FT(0.4)
+        K_sat = FT(2.9e-7)
+        S_s = FT(1e-2)
 
-@testset "Freezing and Thawing" begin
-    FT = Float64
-    param_set = create_lsm_parameters(FT)
+        # Matric Potential and inverse
+        va = S[1]^(-1 / hcm.c) * hcm.ψb
+        ψ = matric_potential.(hcm, S[1:2])
+        @test inverse_matric_potential.(hcm, ψ) ≈ S[1:2]
+        @test ψ ≈ [va, hcm.ψb]
+        @test eltype(ψ) == FT
 
-    # Density of liquid water (kg/m``^3``)
-    _ρ_l = FT(LSMP.ρ_cloud_liq(param_set))
-    # Density of ice water (kg/m``^3``)
-    _ρ_i = FT(LSMP.ρ_cloud_ice(param_set))
-    # Volum. isobaric heat capacity liquid water (J/m3/K)
-    _ρcp_l = FT(LSMP.cp_l(param_set) * _ρ_l)
-    # Volumetric isobaric heat capacity ice (J/m3/K)
-    _ρcp_i = FT(LSMP.cp_i(param_set) * _ρ_i)
-    # Reference temperature (K)
-    _T_ref = FT(LSMP.T_0(param_set))
-    # Latent heat of fusion at ``T_0`` (J/kg)
-    _LH_f0 = FT(LSMP.LH_f0(param_set))
-    # Gravitational acceleration
-    _grav = FT(LSMP.grav(param_set))
-    # T freeze
-    _T_freeze = FT(LSMP.T_freeze(param_set))
+        #Pressure head
+        p = pressure_head.(hcm, θ_r, θ, ν, S_s)
+        @test p ≈ push!(ψ, FT(0.1 / 1e-2 + hcm.ψb))
+        @test eltype(p) == FT
+        # Derivative
+        dψ = dψdϑ.(hcm, θ, ν, θ_r, S_s)
+        va = @. -hcm.ψb / (hcm.c * (ν - θ_r)) * S^(-(1 + 1 / hcm.c))
+        @test dψ ≈ [va[1], 1 / S_s, 1 / S_s]
 
-    # Thermal conductivity of dry air
-    κ_air = FT(LSMP.K_therm(param_set))
+        # Hydraulic K
+        k = @. Soil.hydraulic_conductivity.(hcm, K_sat, S)
+        va = S[1]^(2 / hcm.c + 3) * K_sat
+        @test k ≈ [va, K_sat, K_sat]
+        @test eltype(k) == FT
+    end
 
-    ν = 0.2
-    S_s = 1e-3
-    θ_r = 0.1
-    vg_α = 2.0
-    vg_n = 1.4
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
+    @testset "Richards equation and van Genuchten closures, FT = $FT" begin
+        θ_r = FT(0.2)
+        ν = FT(0.4)
+        S_s = FT(1e-2)
+        vg_α = FT(3.6)
+        vg_n = FT(1.56)
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        K_sat = FT(2.9e-7)
+        vg_m = FT(1.0 - 1.0 / vg_n)
+        richards_parameters = RichardsParameters{FT, typeof(hcm)}(;
+            ν = ν,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+        )
+        # Effective _saturation
+        θ = FT.([0.3, 0.4, 0.5])
+        S = Soil.effective_saturation.(ν, θ, θ_r)
+        @test S ≈ [0.5, 1.0, 1.5]
+        @test eltype(S) == FT
 
-    K_sat = 1e-5
-    ν_ss_om = 0.1
-    ν_ss_gravel = 0.1
-    ν_ss_quartz = 0.1
-    ρc_ds = 1e6
-    κ_solid = 0.1
-    ρp = 1.0
-    κ_sat_unfrozen = 0.0
-    κ_sat_frozen = 0.0
-    κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    parameters = EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = param_set,
-    )
+        # Matric Potential and inverse
+        va = -((S[1]^(-FT(1) / vg_m) - FT(1)) * vg_α^(-vg_n))^(FT(1) / vg_n)
+        ψ = matric_potential.(hcm, S[1:2])
+        @test inverse_matric_potential.(hcm, ψ) ≈ S[1:2]
+        @test ψ ≈ [va, 0.0]
+        @test eltype(ψ) == FT
+        # Derivative
+        dψ = dψdϑ.(hcm, θ, ν, θ_r, S_s)
+        va = FT(
+            1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r) *
+            (S[1]^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
+            S[1]^(-1 / vg_m - 1),
+        )
+        @test dψ ≈ [va, 1 / S_s, 1 / S_s]
+        #Pressure head
+        p = pressure_head.(hcm, θ_r, θ, ν, S_s)
+        @test p ≈ push!(ψ, FT(10.0))
+        @test eltype(p) == FT
 
-    Δz = FT(1.0)
-    @test thermal_time(ρc_ds, Δz, κ_dry) == ρc_ds * Δz^2 / κ_dry
-    θ_l = FT.([0.11, 0.15, ν])
-    θ_i = FT(0.0)
-    T = FT(273)
-    θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
-    ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
-    ψT = @.(_LH_f0 / _T_freeze / _grav * (T - _T_freeze))
-    θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
-    @test (
-        phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
-        θ_l .- θ_star
-    )
-    @test sum(
-        phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) .> 0.0,
-    ) == 3
-    # try θ_l = 0.1
+        # Hydraulic K
+        k = Soil.hydraulic_conductivity.(hcm, K_sat, S)
+        va =
+            (sqrt(S[1]) * (FT(1) - (FT(1) - S[1]^(FT(1) / vg_m))^vg_m)^FT(2)) *
+            K_sat
+        @test k ≈ [va, K_sat, K_sat]
+        @test eltype(k) == FT
 
-    θ_l = FT.([0.11, 0.15, ν])
-    θ_i = FT(0.0)
-    T = FT(274)
-    θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
-    ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
-    ψT = FT(0.0)
-    θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
-    @test (
-        phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
-        zeros(FT, 3)
-    )
-    @test (θ_star ≈ θ_l)
+        # Volumetric Liquid Fraction
+        vlf =
+            volumetric_liquid_fraction.(
+                FT.([0.25, 0.5, 0.75]),
+                FT(0.5),
+                FT(0.0),
+            )
+        @test vlf ≈ FT.([0.25, 0.5, 0.5])
+    end
+
+    @testset "Freezing and Thawing, FT = $FT" begin
+        param_set = create_lsm_parameters(FT)
+
+        # Density of liquid water (kg/m``^3``)
+        _ρ_l = FT(LSMP.ρ_cloud_liq(param_set))
+        # Density of ice water (kg/m``^3``)
+        _ρ_i = FT(LSMP.ρ_cloud_ice(param_set))
+        # Volum. isobaric heat capacity liquid water (J/m3/K)
+        _ρcp_l = FT(LSMP.cp_l(param_set) * _ρ_l)
+        # Volumetric isobaric heat capacity ice (J/m3/K)
+        _ρcp_i = FT(LSMP.cp_i(param_set) * _ρ_i)
+        # Reference temperature (K)
+        _T_ref = FT(LSMP.T_0(param_set))
+        # Latent heat of fusion at ``T_0`` (J/kg)
+        _LH_f0 = FT(LSMP.LH_f0(param_set))
+        # Gravitational acceleration
+        _grav = FT(LSMP.grav(param_set))
+        # T freeze
+        _T_freeze = FT(LSMP.T_freeze(param_set))
+
+        # Thermal conductivity of dry air
+        κ_air = FT(LSMP.K_therm(param_set))
+
+        ν = FT(0.2)
+        S_s = FT(1e-3)
+        θ_r = FT(0.1)
+        vg_α = FT(2.0)
+        vg_n = FT(1.4)
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+
+        K_sat = FT(1e-5)
+        ν_ss_om = FT(0.1)
+        ν_ss_gravel = FT(0.1)
+        ν_ss_quartz = FT(0.1)
+        ρc_ds = FT(1e6)
+        κ_solid = FT(0.1)
+        ρp = FT(1.0)
+        κ_sat_unfrozen = FT(0)
+        κ_sat_frozen = FT(0)
+        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        parameters = EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = param_set,
+        )
+
+        Δz = FT(1.0)
+        @test thermal_time(ρc_ds, Δz, κ_dry) == ρc_ds * Δz^2 / κ_dry
+        θ_l = FT.([0.11, 0.15, ν])
+        θ_i = FT(0.0)
+        T = FT(273)
+        θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
+        ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
+        ψT = @.(_LH_f0 / _T_freeze / _grav * (T - _T_freeze))
+        θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
+        @test (
+            phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
+            θ_l .- θ_star
+        )
+        @test sum(
+            phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) .> 0.0,
+        ) == 3
+        # try θ_l = 0.1
+
+        θ_l = FT.([0.11, 0.15, ν])
+        θ_i = FT(0.0)
+        T = FT(274)
+        θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
+        ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
+        ψT = FT(0.0)
+        θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
+        @test (
+            phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
+            zeros(FT, 3)
+        )
+        @test (θ_star ≈ θ_l)
 
 
+        θ_l = FT(0.01)
+        θ_i = FT.([0.05, 0.08])
+        T = FT(274)
+        θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
+        ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
+        ψT = FT(0.0)
+        θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
+        @test (
+            phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
+            θ_l .- θ_star
+        )
+        @test sum(
+            phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) .< 0.0,
+        ) == 2
 
-    θ_l = FT(0.01)
-    θ_i = FT.([0.05, 0.08])
-    T = FT(274)
-    θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
-    ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
-    ψT = FT(0.0)
-    θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
-    @test (
-        phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
-        θ_l .- θ_star
-    )
-    @test sum(
-        phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) .< 0.0,
-    ) == 2
 
-
-    θ_l = FT(0.11)
-    θ_i = FT.([0.05, 0.08])
-    T = FT(260)
-    θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
-    ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
-    ψT = @.(_LH_f0 / _T_freeze / _grav * (T - _T_freeze))
-    θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
-    @test (
-        phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
-        θ_l .- θ_star
-    )
-    @test sum(
-        phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) .> 0.0,
-    ) == 2
-
+        θ_l = FT(0.11)
+        θ_i = FT.([0.05, 0.08])
+        T = FT(260)
+        θtot = @.(_ρ_i / _ρ_l * θ_i + θ_l)
+        ψ0 = @. matric_potential(hcm, Soil.effective_saturation(ν, θtot, θ_r))
+        ψT = @.(_LH_f0 / _T_freeze / _grav * (T - _T_freeze))
+        θ_star = @. inverse_matric_potential(hcm, ψ0 + ψT) * (ν - θ_r) + θ_r
+        @test (
+            phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) ≈
+            θ_l .- θ_star
+        )
+        @test sum(
+            phase_change_source.(θ_l, θ_i, T, FT(1.0), Ref(parameters)) .> 0.0,
+        ) == 2
+    end
 end

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -8,432 +8,435 @@ using ClimaLSM.Soil
 import ClimaLSM
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
-FT = Float64
 
-@testset "Soil horizontal operators unit tests" begin
-    ν = FT(0.495)
-    K_sat = FT(1)#0.0443 / 3600 / 100); # m/s
-    S_s = FT(1)#e-3); #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    vg_m = 1 - 1 / vg_n
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0)
-    zmax = FT(0)
-    zmin = FT(-1)
-    xmax = FT(1.0)
-    soil_domain = HybridBox(;
-        xlim = (0.0, xmax),
-        ylim = (0.0, 1.0),
-        zlim = (zmin, zmax),
-        nelements = (100, 2, 100),
-        npolynomial = 3,
-    )
-    top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    sources = ()
-    boundary_fluxes =
-        (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
-    params = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+for FT in (Float32, Float64)
+    @testset "Soil horizontal operators unit tests, FT = $FT" begin
+        ν = FT(0.495)
+        K_sat = FT(1)#0.0443 / 3600 / 100); # m/s
+        S_s = FT(1)#e-3); #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        vg_m = 1 - 1 / vg_n
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0)
+        zmax = FT(0)
+        zmin = FT(-1)
+        xmax = FT(1.0)
+        soil_domain = HybridBox(;
+            xlim = FT.((0, xmax)),
+            ylim = FT.((0, 1)),
+            zlim = (zmin, zmax),
+            nelements = (100, 2, 100),
+            npolynomial = 3,
+        )
+        top_flux_bc = FluxBC((p, t) -> 0.0)
+        bot_flux_bc = FluxBC((p, t) -> 0.0)
+        sources = ()
+        boundary_fluxes =
+            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        params =
+            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
 
-    soil = Soil.RichardsModel{FT}(;
-        parameters = params,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
+        soil = Soil.RichardsModel{FT}(;
+            parameters = params,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
 
-    # sinusoidal water table
-    function init_soil!(Ysoil, x, z, params)
-        function hydrostatic_profile(
-            x::FT,
-            z::FT,
-            params::RichardsParameters{FT},
-        ) where {FT}
-            (; ν, hydrology_cm, θ_r, S_s) = params
-            (; α, m, n) = hydrology_cm
-            z_∇ = FT(zmin / 2.0 + (zmax - zmin) / 10.0 * sin(π * 2 * x / xmax))
-            if z > z_∇
-                S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-                ϑ_l = S * (ν - θ_r) + θ_r
-            else
-                ϑ_l = -S_s * (z - z_∇) + ν
-            end
-            return FT(ϑ_l)
-        end
-        Ysoil.soil.ϑ_l .= hydrostatic_profile.(x, z, Ref(params))
-    end
-
-    Y, p, coords = initialize(soil)
-    # test that the dss buffer was added
-    @test propertynames(p) == (:soil, :dss_buffer_3d, :dss_buffer_2d)
-    @test typeof(p.dss_buffer_3d) == typeof(
-        ClimaCore.Spaces.create_dss_buffer(
-            ClimaCore.Fields.zeros(soil_domain.space.subsurface),
-        ),
-    )
-    @test typeof(p.dss_buffer_2d) == typeof(
-        ClimaCore.Spaces.create_dss_buffer(
-            ClimaCore.Fields.zeros(soil_domain.space.surface),
-        ),
-    )
-    init_soil!(Y, coords.subsurface.x, coords.subsurface.z, soil.parameters)
-    dY = similar(Y)
-
-    t0 = FT(0.0)
-    set_initial_aux_state! = make_set_initial_aux_state(soil)
-    set_initial_aux_state!(p, Y, t0)
-    imp_tendency! = make_imp_tendency(soil)
-    exp_tendency! = make_exp_tendency(soil)
-    imp_tendency!(dY, Y, p, t0)
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
-
-    function dθdx(x, z)
-        z_∇ = zmin / 2.0 + (zmax - zmin) / 10.0 * sin(π * 2 * x / xmax)
-        dz∇dx = (zmax - zmin) / 10.0 * cos(π * 2 * x / xmax) * (2 * π / xmax)
-        if z > z_∇
-            dSdz_∇ =
-                -(vg_m) *
-                (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 1) *
-                vg_n *
-                (vg_α * (z - z_∇))^(vg_n - 1) *
-                (-vg_α)
-            dSdx = dSdz_∇ * dz∇dx
-            return (ν - θ_r) * dSdx
-        else
-            return S_s * dz∇dx
-        end
-    end
-
-    function d2θdx2(x, z)
-        z_∇ = zmin / 2.0 + (zmax - zmin) / 10.0 * sin(π * 2 * x / xmax)
-        dz∇dx = (zmax - zmin) / 10.0 * cos(π * 2 * x / xmax) * (2π / xmax)
-        d2z∇dx2 =
-            -(zmax - zmin) / 10.0 * sin(π * 2 * x / xmax) * (2π / xmax)^2.0
-        if z > z_∇
-            dSdz_∇ =
-                -(vg_m) *
-                (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 1) *
-                vg_n *
-                (vg_α * (z - z_∇))^(vg_n - 1) *
-                (-vg_α)
-
-            d2Sdz∇2 =
-                -vg_m *
-                vg_n *
-                vg_α^2.0 *
-                (
-                    (vg_n - 1) *
-                    (vg_α * (z - z_∇))^(vg_n - 2) *
-                    (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 1) -
-                    (vg_m + 1) *
-                    vg_n *
-                    (vg_α * (z - z_∇))^(2.0 * (vg_n - 1)) *
-                    (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 2)
+        # sinusoidal water table
+        function init_soil!(Ysoil, x, z, params)
+            function hydrostatic_profile(
+                x::FT,
+                z::FT,
+                params::RichardsParameters{FT},
+            ) where {FT}
+                (; ν, hydrology_cm, θ_r, S_s) = params
+                (; α, m, n) = hydrology_cm
+                z_∇ = FT(
+                    zmin / 2.0 + (zmax - zmin) / 10.0 * sin(π * 2 * x / xmax),
                 )
-            d2Sdx2 = dz∇dx^2.0 * d2Sdz∇2 + dSdz_∇ * d2z∇dx2
-            return (ν - θ_r) * d2Sdx2
-        else
-            return S_s * d2z∇dx2
-        end
-    end
-
-    function dKdθ(θ)
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1
-            f = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
-            f1 = f^2.0 / 2.0 / S^0.5
-            f2 = 2 * S^(1 / vg_m - 1 / 2) * f / (1 - S^(1 / vg_m))^(1.0 - vg_m)
-            return (f1 + f2) * K_sat / (ν - θ_r)
-        else
-            return 0.0
+                if z > z_∇
+                    S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
+                    ϑ_l = S * (ν - θ_r) + θ_r
+                else
+                    ϑ_l = -S_s * (z - z_∇) + ν
+                end
+                return FT(ϑ_l)
+            end
+            Ysoil.soil.ϑ_l .= hydrostatic_profile.(x, z, Ref(params))
         end
 
-    end
+        Y, p, coords = initialize(soil)
+        # test that the dss buffer was added
+        @test propertynames(p) == (:soil, :dss_buffer_3d, :dss_buffer_2d)
+        @test typeof(p.dss_buffer_3d) == typeof(
+            ClimaCore.Spaces.create_dss_buffer(
+                ClimaCore.Fields.zeros(soil_domain.space.subsurface),
+            ),
+        )
+        @test typeof(p.dss_buffer_2d) == typeof(
+            ClimaCore.Spaces.create_dss_buffer(
+                ClimaCore.Fields.zeros(soil_domain.space.surface),
+            ),
+        )
+        init_soil!(Y, coords.subsurface.x, coords.subsurface.z, soil.parameters)
+        dY = similar(Y)
 
-    function dψdθ(θ)
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1.0
-            return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r) *
-                   (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
-                   S^(-1 / vg_m - 1)
-        else
-            return 1.0 / S_s
+        t0 = FT(0.0)
+        set_initial_aux_state! = make_set_initial_aux_state(soil)
+        set_initial_aux_state!(p, Y, t0)
+        imp_tendency! = make_imp_tendency(soil)
+        exp_tendency! = make_exp_tendency(soil)
+        imp_tendency!(dY, Y, p, t0)
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        function dθdx(x, z)
+            z_∇ = zmin / 2.0 + (zmax - zmin) / 10.0 * sin(π * 2 * x / xmax)
+            dz∇dx =
+                (zmax - zmin) / 10.0 * cos(π * 2 * x / xmax) * (2 * π / xmax)
+            if z > z_∇
+                dSdz_∇ =
+                    -(vg_m) *
+                    (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 1) *
+                    vg_n *
+                    (vg_α * (z - z_∇))^(vg_n - 1) *
+                    (-vg_α)
+                dSdx = dSdz_∇ * dz∇dx
+                return (ν - θ_r) * dSdx
+            else
+                return S_s * dz∇dx
+            end
         end
-    end
+
+        function d2θdx2(x, z)
+            z_∇ = zmin / 2.0 + (zmax - zmin) / 10.0 * sin(π * 2 * x / xmax)
+            dz∇dx = (zmax - zmin) / 10.0 * cos(π * 2 * x / xmax) * (2π / xmax)
+            d2z∇dx2 =
+                -(zmax - zmin) / 10.0 * sin(π * 2 * x / xmax) * (2π / xmax)^2.0
+            if z > z_∇
+                dSdz_∇ =
+                    -(vg_m) *
+                    (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 1) *
+                    vg_n *
+                    (vg_α * (z - z_∇))^(vg_n - 1) *
+                    (-vg_α)
+
+                d2Sdz∇2 =
+                    -vg_m *
+                    vg_n *
+                    vg_α^2.0 *
+                    (
+                        (vg_n - 1) *
+                        (vg_α * (z - z_∇))^(vg_n - 2) *
+                        (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 1) -
+                        (vg_m + 1) *
+                        vg_n *
+                        (vg_α * (z - z_∇))^(2.0 * (vg_n - 1)) *
+                        (1 + (vg_α * (z - z_∇))^vg_n)^(-vg_m - 2)
+                    )
+                d2Sdx2 = dz∇dx^2.0 * d2Sdz∇2 + dSdz_∇ * d2z∇dx2
+                return (ν - θ_r) * d2Sdx2
+            else
+                return S_s * d2z∇dx2
+            end
+        end
+
+        function dKdθ(θ)
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1
+                f = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
+                f1 = f^2.0 / 2.0 / S^0.5
+                f2 =
+                    2 * S^(1 / vg_m - 1 / 2) * f /
+                    (1 - S^(1 / vg_m))^(1.0 - vg_m)
+                return (f1 + f2) * K_sat / (ν - θ_r)
+            else
+                return 0.0
+            end
+
+        end
+
+        function dψdθ(θ)
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1.0
+                return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r) *
+                       (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
+                       S^(-1 / vg_m - 1)
+            else
+                return 1.0 / S_s
+            end
+        end
 
 
-    function d2ψdθ2(θ)
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1.0
-            return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r)^2.0 * (
-                S^(-2.0 / vg_m - 2.0) *
-                (-1 / vg_m) *
-                (1 / vg_n - 1) *
-                (S^(-1 / vg_m) - 1)^(1 / vg_n - 2) +
-                (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
-                (-1 / vg_m - 1) *
-                S^(-1 / vg_m - 2)
+        function d2ψdθ2(θ)
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1.0
+                return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r)^2.0 * (
+                    S^(-2.0 / vg_m - 2.0) *
+                    (-1 / vg_m) *
+                    (1 / vg_n - 1) *
+                    (S^(-1 / vg_m) - 1)^(1 / vg_n - 2) +
+                    (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
+                    (-1 / vg_m - 1) *
+                    S^(-1 / vg_m - 2)
+                )
+            else
+                return 0.0
+            end
+        end
+
+        function K(θ)
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1
+                f = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
+                return K_sat * f^2.0 * sqrt(S)
+            else
+                return K_sat
+            end
+
+        end
+
+
+        X = coords.subsurface.x
+        Z = coords.subsurface.z
+        θ = Y.soil.ϑ_l
+
+        #5.517176201418359e-9 max error with horizontal terms off
+
+        # Test in unsaturated zone
+        for N in [25, 75]
+            myXslice = parent(X)[N, 1, 1, 1, :]
+            myθslice = parent(Y.soil.ϑ_l)[N, 1, 1, 1, :]
+            mydYslice = parent(dY.soil.ϑ_l)[N, 1, 1, 1, :]
+            local_p = sortperm(myXslice)
+
+            Xsort = myXslice[local_p]
+            θsort = myθslice[local_p]
+            dYsort = mydYslice[local_p]
+            unique_indices = unique(i -> Xsort[i], 1:length(Xsort))
+            XX = Xsort[unique_indices]
+            θX = θsort[unique_indices]
+            myZ = unique(parent(Z)[N, 1, 1, 1, :])[1]
+            dYX = dYsort[unique_indices]
+            expected = @. (
+                dKdθ(θX) * dψdθ(θX) * dθdx(XX, myZ)^2.0 +
+                K(θX) * dψdθ(θX) * d2θdx2(XX, myZ) +
+                K(θX) * dθdx(XX, myZ)^2.0 * d2ψdθ2(θX)
             )
-        else
-            return 0.0
+            @test maximum(abs.(dYX .- expected)) < 10^10 * eps(FT)
         end
     end
 
-    function K(θ)
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1
-            f = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
-            return K_sat * f^2.0 * sqrt(S)
-        else
-            return K_sat
-        end
-
-    end
-
-
-    X = coords.subsurface.x
-    Z = coords.subsurface.z
-    θ = Y.soil.ϑ_l
-
-    #5.517176201418359e-9 max error with horizontal terms off
-
-    # Test in unsaturated zone
-    for N in [25, 75]
-        myXslice = parent(X)[N, 1, 1, 1, :]
-        myθslice = parent(Y.soil.ϑ_l)[N, 1, 1, 1, :]
-        mydYslice = parent(dY.soil.ϑ_l)[N, 1, 1, 1, :]
-        local_p = sortperm(myXslice)
-
-        Xsort = myXslice[local_p]
-        θsort = myθslice[local_p]
-        dYsort = mydYslice[local_p]
-        unique_indices = unique(i -> Xsort[i], 1:length(Xsort))
-        XX = Xsort[unique_indices]
-        θX = θsort[unique_indices]
-        myZ = unique(parent(Z)[N, 1, 1, 1, :])[1]
-        dYX = dYsort[unique_indices]
-        expected = @. (
-            dKdθ(θX) * dψdθ(θX) * dθdx(XX, myZ)^2.0 +
-            K(θX) * dψdθ(θX) * d2θdx2(XX, myZ) +
-            K(θX) * dθdx(XX, myZ)^2.0 * d2ψdθ2(θX)
+    @testset "Soil energy+hydrology horizontal operators, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        ν = FT(0.44)
+        K_sat = FT(29.7 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.68)
+        vg_α = FT(14.5) # inverse meters
+        vg_m = 1 - 1 / vg_n
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.045)
+        ν_ss_om = FT(0.0)
+        ν_ss_quartz = FT(1.0)
+        ν_ss_gravel = FT(0.0)
+        κ_minerals = FT(2.5)
+        κ_om = FT(0.25)
+        κ_quartz = FT(8.0)
+        κ_air = FT(0.025)
+        κ_ice = FT(2.21)
+        κ_liq = FT(0.57)
+        ρp = FT(2.66 / 1e3 * 1e6)
+        ρc_ds = FT(2e6)
+        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
+        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
+        parameters = Soil.EnergyHydrologyParameters{FT}(
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
         )
-        @test maximum(abs.(dYX .- expected)) < 1e-5
-    end
-end
-
-
-@testset "Soil energy+hydrology horizontal operators" begin
-    earth_param_set = create_lsm_parameters(FT)
-    ν = FT(0.44)
-    K_sat = FT(29.7 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.68)
-    vg_α = FT(14.5) # inverse meters
-    vg_m = 1 - 1 / vg_n
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.045)
-    ν_ss_om = FT(0.0)
-    ν_ss_quartz = FT(1.0)
-    ν_ss_gravel = FT(0.0)
-    κ_minerals = FT(2.5)
-    κ_om = FT(0.25)
-    κ_quartz = FT(8.0)
-    κ_air = FT(0.025)
-    κ_ice = FT(2.21)
-    κ_liq = FT(0.57)
-    ρp = FT(2.66 / 1e3 * 1e6)
-    ρc_ds = FT(2e6)
-    κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-    κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-    κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
-    parameters = Soil.EnergyHydrologyParameters{FT}(
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-    zmax = FT(0)
-    zmin = FT(-1)
-    xmax = FT(1.0)
-    soil_domain = HybridBox(;
-        xlim = (0.0, xmax),
-        ylim = (0.0, 1.0),
-        zlim = (zmin, zmax),
-        nelements = (100, 2, 100),
-        npolynomial = 3,
-    )
-
-    top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    boundary_fluxes = (;
-        top = (water = top_flux_bc, heat = top_flux_bc),
-        bottom = (water = bot_flux_bc, heat = bot_flux_bc),
-    )
-    sources = ()
-
-    soil = Soil.EnergyHydrology{FT}(;
-        parameters = parameters,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
-
-    Y, p, coords = initialize(soil)
-
-    # specify ICs
-    function init_soil!(Ysoil, z, params)
-        function hydrostatic_profile(
-            z::FT,
-            params::EnergyHydrologyParameters,
-        ) where {FT}
-            (; ν, hydrology_cm, θ_r, S_s) = params
-            (; α, m, n) = hydrology_cm
-            z_∇ = FT(zmin / 2.0)
-            if z > z_∇
-                S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-                ϑ_l = S * (ν - θ_r) + θ_r
-            else
-                ϑ_l = -S_s * (z - z_∇) + ν
-            end
-            return FT(ϑ_l)
-        end
-        Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
-        Ysoil.soil.θ_i .= ClimaCore.Fields.zeros(FT, axes(Ysoil.soil.θ_i))
-    end
-    init_soil!(Y, coords.subsurface.z, soil.parameters)
-
-
-    θ_l = Soil.volumetric_liquid_fraction.(Y.soil.ϑ_l, ν, θ_r)
-    volumetric_heat_capacity =
-        Soil.volumetric_heat_capacity.(θ_l, Y.soil.θ_i, Ref(parameters))
-    Y.soil.ρe_int .=
-        ClimaCore.Fields.zeros(FT, axes(Y.soil.ρe_int)) .+
-        volumetric_internal_energy.(
-            0.0,
-            volumetric_heat_capacity,
-            280.0,
-            Ref(parameters),
+        zmax = FT(0)
+        zmin = FT(-1)
+        xmax = FT(1.0)
+        soil_domain = HybridBox(;
+            xlim = FT.((0, xmax)),
+            ylim = FT.((0, 1)),
+            zlim = (zmin, zmax),
+            nelements = (100, 2, 100),
+            npolynomial = 3,
         )
 
+        top_flux_bc = FluxBC((p, t) -> 0.0)
+        bot_flux_bc = FluxBC((p, t) -> 0.0)
+        boundary_fluxes = (;
+            top = (water = top_flux_bc, heat = top_flux_bc),
+            bottom = (water = bot_flux_bc, heat = bot_flux_bc),
+        )
+        sources = ()
 
-    t0 = FT(0.0)
-    set_initial_aux_state! = make_set_initial_aux_state(soil)
-    set_initial_aux_state!(p, Y, t0)
-    imp_tendency! = make_imp_tendency(soil)
-    exp_tendency! = make_exp_tendency(soil)
-    dY = similar(Y)
-    imp_tendency!(dY, Y, p, t0)
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
+        soil = Soil.EnergyHydrology{FT}(;
+            parameters = parameters,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
 
-    ## dY should be zero. Look at dY/Y.
-    @test maximum(abs.(parent(dY.soil.ϑ_l))) / ν < 5e-12
-    @test maximum(abs.(parent(dY.soil.θ_i))) / ν < 5e-12
-    @test maximum(abs.(parent(dY.soil.ρe_int))) ./ 2.052e7 < 5e-12
-end
+        Y, p, coords = initialize(soil)
 
-
-@testset "Soil hydrology tendency on sphere" begin
-    ν = FT(0.44)
-    K_sat = FT(1.0)
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.68)
-    vg_α = FT(14.5) # inverse meters
-    vg_m = 1 - 1 / vg_n
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.045)
-
-    parameters = Soil.RichardsParameters(
-        ν = ν,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-    )
-
-    soil_domain = SphericalShell(;
-        radius = FT(100.0),
-        depth = FT(1.0),
-        nelements = (1, 30),
-        npolynomial = 3,
-    )
-    top_flux_bc = FluxBC((p, t) -> eltype(t)(K_sat))
-    bot_flux_bc = FluxBC((p, t) -> eltype(t)(K_sat))
-    sources = ()
-    boundary_fluxes =
-        (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
-
-    soil = Soil.RichardsModel{FT}(;
-        parameters = parameters,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
-
-    Y, p, coords = initialize(soil)
-
-    # specify ICs
-    function init_soil!(Ysoil, z, params)
-        function hydrostatic_profile(
-            z::FT,
-            params::RichardsParameters,
-        ) where {FT}
-            (; ν, hydrology_cm, θ_r, S_s) = params
-            (; α, m, n) = hydrology_cm
-            z_∇ = FT(0.5)
-            if z > z_∇
-                S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-                ϑ_l = S * (ν - θ_r) + θ_r
-            else
-                ϑ_l = -S_s * (z - z_∇) + ν
+        # specify ICs
+        function init_soil!(Ysoil, z, params)
+            function hydrostatic_profile(
+                z::FT,
+                params::EnergyHydrologyParameters,
+            ) where {FT}
+                (; ν, hydrology_cm, θ_r, S_s) = params
+                (; α, m, n) = hydrology_cm
+                z_∇ = FT(zmin / 2.0)
+                if z > z_∇
+                    S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
+                    ϑ_l = S * (ν - θ_r) + θ_r
+                else
+                    ϑ_l = -S_s * (z - z_∇) + ν
+                end
+                return FT(ϑ_l)
             end
-            return FT(ϑ_l)
+            Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
+            Ysoil.soil.θ_i .= ClimaCore.Fields.zeros(FT, axes(Ysoil.soil.θ_i))
         end
-        Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
+        init_soil!(Y, coords.subsurface.z, soil.parameters)
+
+
+        θ_l = Soil.volumetric_liquid_fraction.(Y.soil.ϑ_l, ν, θ_r)
+        volumetric_heat_capacity =
+            Soil.volumetric_heat_capacity.(θ_l, Y.soil.θ_i, Ref(parameters))
+        Y.soil.ρe_int .=
+            ClimaCore.Fields.zeros(FT, axes(Y.soil.ρe_int)) .+
+            volumetric_internal_energy.(
+                FT(0),
+                volumetric_heat_capacity,
+                FT(280),
+                Ref(parameters),
+            )
+
+
+        t0 = FT(0.0)
+        set_initial_aux_state! = make_set_initial_aux_state(soil)
+        set_initial_aux_state!(p, Y, t0)
+        imp_tendency! = make_imp_tendency(soil)
+        exp_tendency! = make_exp_tendency(soil)
+        dY = similar(Y)
+        imp_tendency!(dY, Y, p, t0)
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        ## dY should be zero. Look at dY/Y.
+        @test maximum(abs.(parent(dY.soil.ϑ_l))) / ν < 10^3 * eps(FT)
+        @test maximum(abs.(parent(dY.soil.θ_i))) / ν < eps(FT)
+        @test maximum(abs.(parent(dY.soil.ρe_int))) ./ 2.052e7 < 10^3 * eps(FT)
     end
-    init_soil!(Y, coords.subsurface.z, soil.parameters)
 
-    t0 = FT(0)
-    set_initial_aux_state! = make_set_initial_aux_state(soil)
-    set_initial_aux_state!(p, Y, t0)
-    imp_tendency! = make_imp_tendency(soil)
-    exp_tendency! = make_exp_tendency(soil)
-    dY = similar(Y)
-    imp_tendency!(dY, Y, p, t0)
+    @testset "Soil hydrology tendency on sphere, FT = $FT" begin
+        ν = FT(0.44)
+        K_sat = FT(1.0)
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.68)
+        vg_α = FT(14.5) # inverse meters
+        vg_m = 1 - 1 / vg_n
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.045)
 
-    ## vertical change should be zero except at the boundary, where it should be ±30.
-    @test (mean(unique(parent(ClimaCore.level(dY.soil.ϑ_l, 1)))) - 30.0) / ν <
-          1e-10
-    @test (mean(unique(parent(ClimaCore.level(dY.soil.ϑ_l, 30)))) + 30.0) / ν <
-          1e-10
-    @test mean([
-        maximum(abs.(unique(parent(ClimaCore.level(dY.soil.ϑ_l, k))))) for
-        k in 2:29
-    ]) / ν < 1e-10
+        parameters = Soil.RichardsParameters{FT, typeof(hcm)}(
+            ν = ν,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+        )
 
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
+        soil_domain = SphericalShell(;
+            radius = FT(100.0),
+            depth = FT(1.0),
+            nelements = (1, 30),
+            npolynomial = 3,
+        )
+        top_flux_bc = FluxBC((p, t) -> K_sat)
+        bot_flux_bc = FluxBC((p, t) -> K_sat)
+        sources = ()
+        boundary_fluxes =
+            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
 
-    # horizontal change should be 0 everywhere
-    @test mean([
-        maximum(abs.(unique(parent(ClimaCore.level(dY.soil.ϑ_l, k))))) for
-        k in 1:30
-    ]) / ν < 1e-10
+        soil = Soil.RichardsModel{FT}(;
+            parameters = parameters,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
 
+        Y, p, coords = initialize(soil)
+
+        # specify ICs
+        function init_soil!(Ysoil, z, params)
+            function hydrostatic_profile(
+                z::FT,
+                params::RichardsParameters,
+            ) where {FT}
+                (; ν, hydrology_cm, θ_r, S_s) = params
+                (; α, m, n) = hydrology_cm
+                z_∇ = FT(0.5)
+                if z > z_∇
+                    S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
+                    ϑ_l = S * (ν - θ_r) + θ_r
+                else
+                    ϑ_l = -S_s * (z - z_∇) + ν
+                end
+                return FT(ϑ_l)
+            end
+            Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
+        end
+        init_soil!(Y, coords.subsurface.z, soil.parameters)
+
+        t0 = FT(0)
+        set_initial_aux_state! = make_set_initial_aux_state(soil)
+        set_initial_aux_state!(p, Y, t0)
+        imp_tendency! = make_imp_tendency(soil)
+        exp_tendency! = make_exp_tendency(soil)
+        dY = similar(Y)
+        imp_tendency!(dY, Y, p, t0)
+
+        ## vertical change should be zero except at the boundary, where it should be ±30.
+        @test (mean(unique(parent(ClimaCore.level(dY.soil.ϑ_l, 1)))) - 30.0) /
+              ν < 1e-1
+        @test (mean(unique(parent(ClimaCore.level(dY.soil.ϑ_l, 30)))) + 30.0) /
+              ν < 1e-1
+        @test mean([
+            maximum(abs.(unique(parent(ClimaCore.level(dY.soil.ϑ_l, k))))) for
+            k in 2:29
+        ]) / ν < 1e-1
+
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        # horizontal change should be 0 everywhere
+        @test mean([
+            maximum(abs.(unique(parent(ClimaCore.level(dY.soil.ϑ_l, k))))) for
+            k in 1:30
+        ]) / ν < eps(FT)
+    end
 end
-
 
 @testset "Lateral flow flag" begin
     FT = Float32

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -11,555 +11,600 @@ import ClimaLSM.Parameters as LSMP
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
 
-FT = Float64
 
-@testset "Richards equation with flux BCs" begin
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0)
-    zmax = FT(0)
-    zmin = FT(-10)
-    nelems = 50
+for FT in (Float32, Float64)
+    @testset "Richards equation with flux BCs, FT = $FT" begin
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0)
+        zmax = FT(0)
+        zmin = FT(-10)
+        nelems = 50
 
-    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    sources = ()
-    boundary_fluxes =
-        (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
-    params = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+        top_flux_bc = FluxBC((p, t) -> 0.0)
+        bot_flux_bc = FluxBC((p, t) -> 0.0)
+        sources = ()
+        boundary_fluxes =
+            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        params =
+            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
 
-    soil = Soil.RichardsModel{FT}(;
-        parameters = params,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
+        soil = Soil.RichardsModel{FT}(;
+            parameters = params,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
 
-    Y, p, coords = initialize(soil)
-    # Here we do not add a dss buffer: check that `initialize`
-    # has not added a buffer to `p` and that it only contains the
-    # `soil` variables.
-    @test propertynames(p) == (:soil,)
-    # specify ICs
-    function init_soil!(Ysoil, z, params)
-        function hydrostatic_profile(
-            z::FT,
-            params::RichardsParameters{FT},
-        ) where {FT}
-            (; ν, hydrology_cm, θ_r) = params
-            (; α, m, n) = hydrology_cm
-            #unsaturated zone only, assumes water table starts at z_∇
-            z_∇ = FT(-10)# matches zmin
-            S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-            ϑ_l = S * (ν - θ_r) + θ_r
-            return FT(ϑ_l)
-        end
-        Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
-    end
-
-    init_soil!(Y, coords.subsurface.z, soil.parameters)
-
-    t0 = FT(0)
-    set_initial_aux_state! = make_set_initial_aux_state(soil)
-    set_initial_aux_state!(p, Y, t0)
-    dY = similar(Y)
-
-    imp_tendency! = make_imp_tendency(soil)
-    exp_tendency! = make_exp_tendency(soil)
-    imp_tendency!(dY, Y, p, t0)
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
-
-    @test mean(parent(dY)) < 1e-8
-    # should be hydrostatic equilibrium at every layer, at each step:
-    @test mean(parent(p.soil.ψ .+ coords.subsurface.z)[:] .+ 10.0) < 1e-10
-end
-
-
-@testset "Soil Energy and Water tendency unit tests" begin
-    earth_param_set = create_lsm_parameters(FT)
-    ν = FT(0.495)
-    K_sat = FT(0.0443 / 3600 / 100) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    vg_m = FT(1) - FT(1) / vg_n
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.1)
-    ν_ss_om = FT(0.0)
-    ν_ss_quartz = FT(1.0)
-    ν_ss_gravel = FT(0.0)
-    κ_minerals = FT(2.5)
-    κ_om = FT(0.25)
-    κ_quartz = FT(8.0)
-    κ_air = FT(0.025)
-    κ_ice = FT(2.21)
-    κ_liq = FT(0.57)
-    ρp = FT(2.66 / 1e3 * 1e6)
-    ρc_ds = FT(2e6 * (1.0 - ν))
-    κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-    κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-    κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
-    zmax = FT(0)
-    zmin = FT(-1)
-    nelems = 200
-    Δz = abs(zmax - zmin) / nelems
-    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    sources = ()
-    # Use the same BCs for RRE and heat
-    boundary_fluxes = (;
-        top = (water = top_flux_bc, heat = top_flux_bc),
-        bottom = (water = bot_flux_bc, heat = bot_flux_bc),
-    )
-
-
-    ###
-    hyd_off_en_on = Soil.EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = 0.0,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-    soil_heat_on = Soil.EnergyHydrology{FT}(;
-        parameters = hyd_off_en_on,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
-
-    Y, p, coords = initialize(soil_heat_on)
-
-    # specify ICs
-    function init_soil_heat!(Ysoil, z, params)
-        ν = params.ν
-        Ysoil.soil.ϑ_l .= ν / 2.0
-        Ysoil.soil.θ_i .= 0.0
-        T = 280.0 .+ 0.5 .* (z .+ 0.5) .^ 2.0
-        ρc_s = Soil.volumetric_heat_capacity(ν / 2.0, 0.0, params)
-        Ysoil.soil.ρe_int =
-            Soil.volumetric_internal_energy.(0.0, ρc_s, T, Ref(params))
-    end
-
-    t0 = FT(0)
-    init_soil_heat!(Y, coords.subsurface.z, soil_heat_on.parameters)
-    set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
-    set_initial_aux_state!(p, Y, t0)
-    exp_tendency! = make_exp_tendency(soil_heat_on)
-    dY = similar(Y)
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
-
-    F_face = 0.0
-    κ = parent(p.soil.κ)
-    F_below = -0.5 * (κ[end] + κ[end - 1]) * (-Δz + 0.5)
-    dY_top = -(F_face - F_below) / Δz
-    F_top = -0.5 * (κ[2] + κ[1]) * ((-1.0 + Δz) + 0.5)
-    dY_bot = -(F_top - F_face) / Δz
-    expected = parent(p.soil.κ)
-    expected[1] = dY_bot
-    expected[end] = dY_top
-    @test mean(abs.(expected .- parent(dY.soil.ρe_int))) /
-          median(parent(Y.soil.ρe_int)) < 1e-13
-    @test maximum(abs.(parent(dY.soil.ϑ_l))) == 0.0
-    @test maximum(abs.(parent(dY.soil.θ_i))) == 0.0
-
-    ###
-    hyd_on_en_off = Soil.EnergyHydrologyParameters{FT}(
-        κ_dry = 0.0,
-        κ_sat_frozen = 0.0,
-        κ_sat_unfrozen = 0.0,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-    soil_water_on = Soil.EnergyHydrology{FT}(;
-        parameters = hyd_on_en_off,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
-
-    Y, p, coords = initialize(soil_water_on)
-
-    # specify ICs
-    function init_soil_water!(Ysoil, z, params)
-        ν = params.ν
-        Ysoil.soil.ϑ_l .= ν / 2.0 .+ ν / 4.0 .* (z .+ 0.5) .^ 2.0
-        Ysoil.soil.θ_i .= 0.0
-        ρc_s = Soil.volumetric_heat_capacity.(Y.soil.ϑ_l, 0.0, Ref(params))
-
-        Ysoil.soil.ρe_int =
-            volumetric_internal_energy.(0.0, ρc_s, 288.0, Ref(params))
-    end
-
-    t0 = FT(0)
-    init_soil_water!(Y, coords.subsurface.z, soil_water_on.parameters)
-    set_initial_aux_state! = make_set_initial_aux_state(soil_water_on)
-    set_initial_aux_state!(p, Y, t0)
-    exp_tendency! = make_exp_tendency(soil_water_on)
-    dY = similar(Y)
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
-
-    function dKdθ(θ::FT)::FT where {FT}
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1
-            f::FT = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
-            f1::FT = f^2.0 / 2.0 / S^0.5
-            f2::FT =
-                2 * S^(1 / vg_m - 1 / 2) * f / (1 - S^(1 / vg_m))^(1.0 - vg_m)
-            return (f1 + f2) * K_sat / (ν - θ_r)
-        else
-            return 0.0
+        Y, p, coords = initialize(soil)
+        # Here we do not add a dss buffer: check that `initialize`
+        # has not added a buffer to `p` and that it only contains the
+        # `soil` variables.
+        @test propertynames(p) == (:soil,)
+        # specify ICs
+        function init_soil!(Ysoil, z, params)
+            function hydrostatic_profile(
+                z::FT,
+                params::RichardsParameters{FT},
+            ) where {FT}
+                (; ν, hydrology_cm, θ_r) = params
+                (; α, m, n) = hydrology_cm
+                #unsaturated zone only, assumes water table starts at z_∇
+                z_∇ = FT(-10)# matches zmin
+                S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
+                ϑ_l = S * (ν - θ_r) + θ_r
+                return FT(ϑ_l)
+            end
+            Ysoil.soil.ϑ_l .= hydrostatic_profile.(z, Ref(params))
         end
 
+        init_soil!(Y, coords.subsurface.z, soil.parameters)
+
+        t0 = FT(0)
+        set_initial_aux_state! = make_set_initial_aux_state(soil)
+        set_initial_aux_state!(p, Y, t0)
+        dY = similar(Y)
+
+        imp_tendency! = make_imp_tendency(soil)
+        exp_tendency! = make_exp_tendency(soil)
+        imp_tendency!(dY, Y, p, t0)
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        @test mean(parent(dY)) < eps(FT)
+        # should be hydrostatic equilibrium at every layer, at each step:
+        @test mean(parent(p.soil.ψ .+ coords.subsurface.z)[:] .+ FT(10)) <
+              eps(FT)
     end
 
-    function dψdθ(θ::FT)::FT where {FT}
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1.0
-            return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r) *
-                   (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
-                   S^(-1 / vg_m - 1)
-        else
-            return 1.0 / S_s
-        end
-    end
+    @testset "Soil Energy and Water tendency unit tests, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        vg_m = FT(1) - FT(1) / vg_n
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.1)
+        ν_ss_om = FT(0.0)
+        ν_ss_quartz = FT(1.0)
+        ν_ss_gravel = FT(0.0)
+        κ_minerals = FT(2.5)
+        κ_om = FT(0.25)
+        κ_quartz = FT(8.0)
+        κ_air = FT(0.025)
+        κ_ice = FT(2.21)
+        κ_liq = FT(0.57)
+        ρp = FT(2.66 / 1e3 * 1e6)
+        ρc_ds = FT(2e6 * (1.0 - ν))
+        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
+        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
+        zmax = FT(0)
+        zmin = FT(-1)
+        nelems = 200
+        Δz = abs(zmax - zmin) / nelems
+        soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+        top_flux_bc = FluxBC((p, t) -> 0.0)
+        bot_flux_bc = FluxBC((p, t) -> 0.0)
+        sources = ()
+        # Use the same BCs for RRE and heat
+        boundary_fluxes = (;
+            top = (water = top_flux_bc, heat = top_flux_bc),
+            bottom = (water = bot_flux_bc, heat = bot_flux_bc),
+        )
 
 
-    function d2ψdθ2(θ::FT)::FT where {FT}
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1.0
-            return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r)^2.0 * (
-                S^(-2.0 / vg_m - 2.0) *
-                (-1 / vg_m) *
-                (1 / vg_n - 1) *
-                (S^(-1 / vg_m) - 1)^(1 / vg_n - 2) +
-                (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
-                (-1 / vg_m - 1) *
-                S^(-1 / vg_m - 2)
+        ###
+        hyd_off_en_on = Soil.EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = FT(0),
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
+        )
+        soil_heat_on = Soil.EnergyHydrology{FT}(;
+            parameters = hyd_off_en_on,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
+
+        Y, p, coords = initialize(soil_heat_on)
+
+        # specify ICs
+        function init_soil_heat!(Ysoil, z, params)
+            FT = eltype(Ysoil.soil.ϑ_l)
+            ν = params.ν
+            Ysoil.soil.ϑ_l .= ν / 2.0
+            Ysoil.soil.θ_i .= 0.0
+            T = FT.(280.0 .+ 0.5 .* (z .+ 0.5) .^ 2.0)
+            ρc_s = @. Soil.volumetric_heat_capacity(
+                Ysoil.soil.ϑ_l,
+                Ysoil.soil.θ_i,
+                params,
             )
-        else
-            return 0.0
-        end
-    end
-
-    function K(θ::FT)::FT where {FT}
-        S = (θ - θ_r) / (ν - θ_r)
-        if S < 1
-            f = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
-            return K_sat * f^2.0 * sqrt(S)
-        else
-            return K_sat
+            Ysoil.soil.ρe_int = @. Soil.volumetric_internal_energy.(
+                Ysoil.soil.θ_i,
+                ρc_s,
+                T,
+                params,
+            )
         end
 
+        t0 = FT(0)
+        init_soil_heat!(Y, coords.subsurface.z, soil_heat_on.parameters)
+        set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
+        set_initial_aux_state!(p, Y, t0)
+        exp_tendency! = make_exp_tendency(soil_heat_on)
+        dY = similar(Y)
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        F_face = FT(0)
+        κ = parent(p.soil.κ)
+        F_below = -0.5 * (κ[end] + κ[end - 1]) * (-Δz + 0.5)
+        dY_top = -(F_face - F_below) / Δz
+        F_top = -0.5 * (κ[2] + κ[1]) * ((-1.0 + Δz) + 0.5)
+        dY_bot = -(F_top - F_face) / Δz
+        expected = parent(p.soil.κ)
+        expected[1] = dY_bot
+        expected[end] = dY_top
+        @test mean(abs.(expected .- parent(dY.soil.ρe_int))) /
+              median(parent(Y.soil.ρe_int)) < eps(FT)
+        @test maximum(abs.(parent(dY.soil.ϑ_l))) == FT(0)
+        @test maximum(abs.(parent(dY.soil.θ_i))) == FT(0)
+
+        ###
+        hyd_on_en_off = Soil.EnergyHydrologyParameters{FT}(
+            κ_dry = FT(0),
+            κ_sat_frozen = FT(0),
+            κ_sat_unfrozen = FT(0),
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
+        )
+        soil_water_on = Soil.EnergyHydrology{FT}(;
+            parameters = hyd_on_en_off,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
+
+        Y, p, coords = initialize(soil_water_on)
+
+        # specify ICs
+        function init_soil_water!(Ysoil, z, params)
+            FT = eltype(Ysoil.soil.ϑ_l)
+            ν = params.ν
+            Ysoil.soil.ϑ_l .= ν / 2.0 .+ ν / 4.0 .* (z .+ 0.5) .^ 2.0
+            Ysoil.soil.θ_i .= 0.0
+            ρc_s = @. Soil.volumetric_heat_capacity.(
+                Y.soil.ϑ_l,
+                Ysoil.soil.θ_i,
+                params,
+            )
+            Ysoil.soil.ρe_int = @. volumetric_internal_energy.(
+                Ysoil.soil.θ_i,
+                ρc_s,
+                FT(288),
+                params,
+            )
+        end
+
+        t0 = FT(0)
+        init_soil_water!(Y, coords.subsurface.z, soil_water_on.parameters)
+        set_initial_aux_state! = make_set_initial_aux_state(soil_water_on)
+        set_initial_aux_state!(p, Y, t0)
+        exp_tendency! = make_exp_tendency(soil_water_on)
+        dY = similar(Y)
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        function dKdθ(θ::FT)::FT where {FT}
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1
+                f::FT = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
+                f1::FT = f^2.0 / 2.0 / S^0.5
+                f2::FT =
+                    2 * S^(1 / vg_m - 1 / 2) * f /
+                    (1 - S^(1 / vg_m))^(1.0 - vg_m)
+                return (f1 + f2) * K_sat / (ν - θ_r)
+            else
+                return FT(0)
+            end
+        end
+
+        function dψdθ(θ::FT)::FT where {FT}
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1.0
+                return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r) *
+                       (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
+                       S^(-1 / vg_m - 1)
+            else
+                return 1.0 / S_s
+            end
+        end
+
+
+        function d2ψdθ2(θ::FT)::FT where {FT}
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1.0
+                return 1.0 / (vg_α * vg_m * vg_n) / (ν - θ_r)^2.0 * (
+                    S^(-2.0 / vg_m - 2.0) *
+                    (-1 / vg_m) *
+                    (1 / vg_n - 1) *
+                    (S^(-1 / vg_m) - 1)^(1 / vg_n - 2) +
+                    (S^(-1 / vg_m) - 1)^(1 / vg_n - 1) *
+                    (-1 / vg_m - 1) *
+                    S^(-1 / vg_m - 2)
+                )
+            else
+                return FT(0)
+            end
+        end
+
+        function K(θ::FT)::FT where {FT}
+            S = (θ - θ_r) / (ν - θ_r)
+            if S < 1
+                f = 1.0 - (1.0 - S^(1.0 / vg_m))^vg_m
+                return K_sat * f^2.0 * sqrt(S)
+            else
+                return K_sat
+            end
+
+        end
+
+        function dθdz(z::FT)::FT where {FT}
+            return ν / 2.0 * (z + 0.5)
+        end
+
+
+        function d2θdz2(z::FT)::FT where {FT}
+            return ν / 2.0
+        end
+
+        θ = parent(Y.soil.ϑ_l)# on the center
+        θ_face = 0.5 * (θ[2:end] + θ[1:(end - 1)])
+        Z = parent(coords.subsurface.z)
+        Z_face = 0.5 * (Z[2:end] + Z[1:(end - 1)])
+        K_face = 0.5 .* (K.(θ[2:end]) .+ K.(θ[1:(end - 1)]))
+        flux_interior = (@. -K_face * (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
+        flux = vcat(
+            [top_flux_bc.bc(p, FT(0.0))],
+            flux_interior,
+            [bot_flux_bc.bc(p, FT(0.0))],
+        )
+
+        expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
+        @test mean(abs.(expected .- parent(dY.soil.ϑ_l))) / ν < 10^2 * eps(FT)
+        @test maximum(abs.(parent(dY.soil.θ_i))) == FT(0)
+
+        ρe_int_l = parent(
+            Soil.volumetric_internal_energy_liq.(
+                p.soil.T,
+                Ref(soil_water_on.parameters),
+            ),
+        )
+        ρe_int_l_face = 0.5 * (ρe_int_l[2:end] + ρe_int_l[1:(end - 1)])
+        flux_interior =
+            (@. -K_face * ρe_int_l_face * (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
+        flux = vcat(
+            [top_flux_bc.bc(p, FT(0.0))],
+            flux_interior,
+            [bot_flux_bc.bc(p, FT(0.0))],
+        )
+        expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
+
+        @test mean(abs.(expected .- parent(dY.soil.ρe_int))) /
+              median(parent(Y.soil.ρe_int)) < 10^2 * eps(FT)
+
+        ###
+
+        hyd_off_en_off = Soil.EnergyHydrologyParameters{FT}(;
+            κ_dry = FT(0),
+            κ_sat_frozen = FT(0),
+            κ_sat_unfrozen = FT(0),
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = FT(0),
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
+        )
+
+        soil_both_off = Soil.EnergyHydrology{FT}(;
+            parameters = hyd_off_en_off,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
+
+        Y, p, coords = initialize(soil_both_off)
+
+        # specify ICs
+        function init_soil_off!(Ysoil, z, params)
+            FT = eltype(Ysoil.soil.ϑ_l)
+            ν = params.ν
+            Ysoil.soil.ϑ_l .= ν / 2.0
+            Ysoil.soil.θ_i .= 0.0
+            T = FT.(280.0 .+ 0.5 .* (z .+ 0.5) .^ 2.0)
+            ρc_s = @. Soil.volumetric_heat_capacity(
+                Ysoil.soil.ϑ_l,
+                Ysoil.soil.θ_i,
+                params,
+            )
+            Ysoil.soil.ρe_int = @. Soil.volumetric_internal_energy.(
+                Ysoil.soil.θ_i,
+                ρc_s,
+                T,
+                params,
+            )
+        end
+
+        t0 = FT(0)
+        init_soil_off!(Y, coords.subsurface.z, soil_both_off.parameters)
+        set_initial_aux_state! = make_set_initial_aux_state(soil_both_off)
+        set_initial_aux_state!(p, Y, t0)
+        exp_tendency! = make_exp_tendency(soil_both_off)
+        dY = similar(Y)
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        @test maximum(abs.(parent(dY.soil.ρe_int))) == FT(0)
+        @test maximum(abs.(parent(dY.soil.ϑ_l))) == FT(0)
+        @test maximum(abs.(parent(dY.soil.θ_i))) == FT(0)
+
+
+        ### Test with both energy and hydrology on
+        hyd_on_en_on = Soil.EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
+        )
+
+        soil_both_on = Soil.EnergyHydrology{FT}(;
+            parameters = hyd_on_en_on,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
+
+        Y, p, coords = initialize(soil_both_on)
+
+        # specify ICs
+        function init_soil_on!(Ysoil, z, params)
+            FT = eltype(Ysoil.soil.ϑ_l)
+            ν = params.ν
+            Ysoil.soil.ϑ_l .= ν / 2.0 .+ ν / 4.0 .* (z .+ 0.5) .^ 2.0
+            Ysoil.soil.θ_i .= 0.0
+            T = FT.(280.0 .+ 0.5 .* (z .+ 0.5) .^ 2.0)
+            ρc_s = @. Soil.volumetric_heat_capacity.(
+                Y.soil.ϑ_l,
+                Ysoil.soil.θ_i,
+                params,
+            )
+            Ysoil.soil.ρe_int =
+                @. volumetric_internal_energy.(Ysoil.soil.θ_i, ρc_s, T, params)
+        end
+
+        t0 = FT(0)
+        init_soil_on!(Y, coords.subsurface.z, soil_both_on.parameters)
+        set_initial_aux_state! = make_set_initial_aux_state(soil_both_on)
+        set_initial_aux_state!(p, Y, t0)
+
+        exp_tendency! = make_exp_tendency(soil_both_on)
+        dY = similar(Y)
+        exp_tendency!(dY, Y, p, t0)
+        ClimaLSM.dss!(dY, p, t0)
+
+        @test maximum(abs.(parent(dY.soil.θ_i))) == FT(0)
+
+        θ = parent(Y.soil.ϑ_l)# on the center
+        θ_face = 0.5 * (θ[2:end] + θ[1:(end - 1)])
+        Z = parent(coords.subsurface.z)
+        Z_face = 0.5 * (Z[2:end] + Z[1:(end - 1)])
+        K_face = 0.5 .* (K.(θ[2:end]) .+ K.(θ[1:(end - 1)]))
+        vf = parent(
+            Soil.viscosity_factor.(
+                p.soil.T,
+                hyd_on_en_on.γ,
+                hyd_on_en_on.γT_ref,
+            ),
+        )
+        vf_face = 0.5 .* (vf[2:end] .+ vf[1:(end - 1)])
+
+        flux_interior =
+            (@. -K_face * vf_face * (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
+        flux = vcat(
+            [top_flux_bc.bc(p, FT(0.0))],
+            flux_interior,
+            [bot_flux_bc.bc(p, FT(0.0))],
+        )
+
+        expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
+        @test mean(abs.(expected .- parent(dY.soil.ϑ_l))) / ν < 10^2 * eps(FT)
+
+        ρe_int_l = parent(
+            Soil.volumetric_internal_energy_liq.(
+                p.soil.T,
+                Ref(soil_both_on.parameters),
+            ),
+        )
+        ρe_int_l_face = 0.5 * (ρe_int_l[2:end] + ρe_int_l[1:(end - 1)])
+        κ = parent(p.soil.κ)
+        κ_face = 0.5 * (κ[2:end] + κ[1:(end - 1)])
+
+
+        flux_interior = (@. -K_face *
+            vf_face *
+            ρe_int_l_face *
+            (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
+        flux_one = vcat(
+            [top_flux_bc.bc(p, FT(0.0))],
+            flux_interior,
+            [bot_flux_bc.bc(p, FT(0.0))],
+        )
+        flux_interior = (@. -κ_face * (Z_face + 0.5))
+        flux_two = vcat(
+            [top_flux_bc.bc(p, FT(0.0))],
+            flux_interior,
+            [bot_flux_bc.bc(p, FT(0.0))],
+        )
+        flux = flux_one .+ flux_two
+        expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
+
+        @test mean(abs.(expected .- parent(dY.soil.ρe_int))) /
+              median(parent(Y.soil.ρe_int)) < 10^2 * eps(FT)
     end
 
-    function dθdz(z::FT)::FT where {FT}
-        return ν / 2.0 * (z + 0.5)
+    @testset "Phase change source term, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        ν = FT(0.495)
+        K_sat = FT(0.0) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        θ_r = FT(0.1)
+        ν_ss_om = FT(0.0)
+        ν_ss_quartz = FT(1.0)
+        ν_ss_gravel = FT(0.0)
+        κ_minerals = FT(2.5)
+        κ_om = FT(0.25)
+        κ_quartz = FT(8.0)
+        κ_air = FT(0.025)
+        κ_ice = FT(2.21)
+        κ_liq = FT(0.57)
+        ρp = FT(2.66 / 1e3 * 1e6)
+        ρc_ds = FT(2e6 * (1.0 - ν))
+        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
+        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
+        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
+        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
+        zmax = FT(0)
+        zmin = FT(-1)
+        nelems = 200
+        Δz = FT(0.005)
+        soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+        top_flux_bc = FluxBC((p, t) -> 0.0)
+        bot_flux_bc = FluxBC((p, t) -> 0.0)
+        boundary_fluxes = (;
+            top = (water = top_flux_bc, heat = top_flux_bc),
+            bottom = (water = bot_flux_bc, heat = bot_flux_bc),
+        )
+
+        sources = (PhaseChange{FT}(Δz),)
+
+        ###
+        hyd_off_en_on = Soil.EnergyHydrologyParameters{FT}(;
+            κ_dry = κ_dry,
+            κ_sat_frozen = κ_sat_frozen,
+            κ_sat_unfrozen = κ_sat_unfrozen,
+            ρc_ds = ρc_ds,
+            ν = ν,
+            ν_ss_om = ν_ss_om,
+            ν_ss_quartz = ν_ss_quartz,
+            ν_ss_gravel = ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+            earth_param_set = earth_param_set,
+        )
+        soil_heat_on = Soil.EnergyHydrology{FT}(;
+            parameters = hyd_off_en_on,
+            domain = soil_domain,
+            boundary_conditions = boundary_fluxes,
+            sources = sources,
+        )
+
+        Y, p, coords = initialize(soil_heat_on)
+
+        # specify ICs
+        function init_soil_heat!(Ysoil, z, params)
+            FT = eltype(Ysoil.soil.ϑ_l)
+            ν = params.ν
+            Ysoil.soil.ϑ_l .= ν / 2.0
+            Ysoil.soil.θ_i .= 0.0
+            T = FT(270)
+            ρc_s = @. Soil.volumetric_heat_capacity(
+                Ysoil.soil.ϑ_l,
+                Ysoil.soil.θ_i,
+                params,
+            )
+            Ysoil.soil.ρe_int = @. Soil.volumetric_internal_energy.(
+                Ysoil.soil.θ_i,
+                ρc_s,
+                T,
+                params,
+            )
+        end
+
+        init_soil_heat!(Y, coords.subsurface.z, soil_heat_on.parameters)
+        set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
+        set_initial_aux_state!(p, Y, FT(0.0))
+        dY = similar(Y)
+        dY .= FT(0.0)
+        source!(dY, sources[1], Y, p, soil_heat_on)
+        _ρ_l = FT(LSMP.ρ_cloud_liq(soil_heat_on.parameters.earth_param_set))
+        _ρ_i = FT(LSMP.ρ_cloud_ice(soil_heat_on.parameters.earth_param_set))
+        @test parent(dY.soil.ϑ_l) ≈ -(_ρ_i / _ρ_l) .* parent(dY.soil.θ_i)
     end
-
-
-    function d2θdz2(z::FT)::FT where {FT}
-        return ν / 2.0
-    end
-
-    θ = parent(Y.soil.ϑ_l)# on the center
-    θ_face = 0.5 * (θ[2:end] + θ[1:(end - 1)])
-    Z = parent(coords.subsurface.z)
-    Z_face = 0.5 * (Z[2:end] + Z[1:(end - 1)])
-    K_face = 0.5 .* (K.(θ[2:end]) .+ K.(θ[1:(end - 1)]))
-    flux_interior = (@. -K_face * (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
-    flux = vcat(
-        [top_flux_bc.bc(p, FT(0.0))],
-        flux_interior,
-        [bot_flux_bc.bc(p, FT(0.0))],
-    )
-
-    expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
-    @test mean(abs.(expected .- parent(dY.soil.ϑ_l))) / ν < 1e-13
-    @test maximum(abs.(parent(dY.soil.θ_i))) == 0.0
-
-    ρe_int_l = parent(
-        Soil.volumetric_internal_energy_liq.(
-            p.soil.T,
-            Ref(soil_water_on.parameters),
-        ),
-    )
-    ρe_int_l_face = 0.5 * (ρe_int_l[2:end] + ρe_int_l[1:(end - 1)])
-    flux_interior =
-        (@. -K_face * ρe_int_l_face * (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
-    flux = vcat(
-        [top_flux_bc.bc(p, FT(0.0))],
-        flux_interior,
-        [bot_flux_bc.bc(p, FT(0.0))],
-    )
-    expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
-
-    @test mean(abs.(expected .- parent(dY.soil.ρe_int))) /
-          median(parent(Y.soil.ρe_int)) < 1e-13
-
-    ###
-
-    hyd_off_en_off = Soil.EnergyHydrologyParameters{FT}(;
-        κ_dry = 0.0,
-        κ_sat_frozen = 0.0,
-        κ_sat_unfrozen = 0.0,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = 0.0,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-
-    soil_both_off = Soil.EnergyHydrology{FT}(;
-        parameters = hyd_off_en_off,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
-
-    Y, p, coords = initialize(soil_both_off)
-
-    # specify ICs
-    function init_soil_off!(Ysoil, z, params)
-        ν = params.ν
-        Ysoil.soil.ϑ_l .= ν / 2.0
-        Ysoil.soil.θ_i .= 0.0
-        T = 280.0 .+ 0.5 .* (z .+ 0.5) .^ 2.0
-        ρc_s = Soil.volumetric_heat_capacity(ν / 2.0, 0.0, params)
-        Ysoil.soil.ρe_int =
-            Soil.volumetric_internal_energy.(0.0, ρc_s, T, Ref(params))
-    end
-
-    t0 = FT(0)
-    init_soil_off!(Y, coords.subsurface.z, soil_both_off.parameters)
-    set_initial_aux_state! = make_set_initial_aux_state(soil_both_off)
-    set_initial_aux_state!(p, Y, t0)
-    exp_tendency! = make_exp_tendency(soil_both_off)
-    dY = similar(Y)
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
-
-    @test maximum(abs.(parent(dY.soil.ρe_int))) == 0.0
-    @test maximum(abs.(parent(dY.soil.ϑ_l))) == 0.0
-    @test maximum(abs.(parent(dY.soil.θ_i))) == 0.0
-
-
-    ### Test with both energy and hydrology on
-    hyd_on_en_on = Soil.EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-
-    soil_both_on = Soil.EnergyHydrology{FT}(;
-        parameters = hyd_on_en_on,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
-
-    Y, p, coords = initialize(soil_both_on)
-
-    # specify ICs
-    function init_soil_on!(Ysoil, z, params)
-        ν = params.ν
-        Ysoil.soil.ϑ_l .= ν / 2.0 .+ ν / 4.0 .* (z .+ 0.5) .^ 2.0
-        Ysoil.soil.θ_i .= 0.0
-        T = 280.0 .+ 0.5 .* (z .+ 0.5) .^ 2.0
-        ρc_s = Soil.volumetric_heat_capacity.(Y.soil.ϑ_l, 0.0, Ref(params))
-        Ysoil.soil.ρe_int =
-            volumetric_internal_energy.(0.0, ρc_s, T, Ref(params))
-    end
-
-    t0 = FT(0)
-    init_soil_on!(Y, coords.subsurface.z, soil_both_on.parameters)
-    set_initial_aux_state! = make_set_initial_aux_state(soil_both_on)
-    set_initial_aux_state!(p, Y, t0)
-
-    exp_tendency! = make_exp_tendency(soil_both_on)
-    dY = similar(Y)
-    exp_tendency!(dY, Y, p, t0)
-    ClimaLSM.dss!(dY, p, t0)
-
-    @test maximum(abs.(parent(dY.soil.θ_i))) == 0.0
-
-    θ = parent(Y.soil.ϑ_l)# on the center
-    θ_face = 0.5 * (θ[2:end] + θ[1:(end - 1)])
-    Z = parent(coords.subsurface.z)
-    Z_face = 0.5 * (Z[2:end] + Z[1:(end - 1)])
-    K_face = 0.5 .* (K.(θ[2:end]) .+ K.(θ[1:(end - 1)]))
-    vf = parent(
-        Soil.viscosity_factor.(p.soil.T, hyd_on_en_on.γ, hyd_on_en_on.γT_ref),
-    )
-    vf_face = 0.5 .* (vf[2:end] .+ vf[1:(end - 1)])
-
-    flux_interior = (@. -K_face * vf_face * (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
-    flux = vcat(
-        [top_flux_bc.bc(p, FT(0.0))],
-        flux_interior,
-        [bot_flux_bc.bc(p, FT(0.0))],
-    )
-
-    expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
-    @test mean(abs.(expected .- parent(dY.soil.ϑ_l))) / ν < 1e-13
-
-    ρe_int_l = parent(
-        Soil.volumetric_internal_energy_liq.(
-            p.soil.T,
-            Ref(soil_both_on.parameters),
-        ),
-    )
-    ρe_int_l_face = 0.5 * (ρe_int_l[2:end] + ρe_int_l[1:(end - 1)])
-    κ = parent(p.soil.κ)
-    κ_face = 0.5 * (κ[2:end] + κ[1:(end - 1)])
-
-
-    flux_interior = (@. -K_face *
-        vf_face *
-        ρe_int_l_face *
-        (1.0 + dψdθ(θ_face) * dθdz(Z_face)))
-    flux_one = vcat(
-        [top_flux_bc.bc(p, FT(0.0))],
-        flux_interior,
-        [bot_flux_bc.bc(p, FT(0.0))],
-    )
-    flux_interior = (@. -κ_face * (Z_face + 0.5))
-    flux_two = vcat(
-        [top_flux_bc.bc(p, FT(0.0))],
-        flux_interior,
-        [bot_flux_bc.bc(p, FT(0.0))],
-    )
-    flux = flux_one .+ flux_two
-    expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
-
-    @test mean(abs.(expected .- parent(dY.soil.ρe_int))) /
-          median(parent(Y.soil.ρe_int)) < 1e-13
-end
-
-
-
-@testset "Phase change source term" begin
-    earth_param_set = create_lsm_parameters(FT)
-    ν = FT(0.495)
-    K_sat = FT(0.0) # m/s
-    S_s = FT(1e-3) #inverse meters
-    vg_n = FT(2.0)
-    vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
-    θ_r = FT(0.1)
-    ν_ss_om = FT(0.0)
-    ν_ss_quartz = FT(1.0)
-    ν_ss_gravel = FT(0.0)
-    κ_minerals = FT(2.5)
-    κ_om = FT(0.25)
-    κ_quartz = FT(8.0)
-    κ_air = FT(0.025)
-    κ_ice = FT(2.21)
-    κ_liq = FT(0.57)
-    ρp = FT(2.66 / 1e3 * 1e6)
-    ρc_ds = FT(2e6 * (1.0 - ν))
-    κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-    κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-    κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-    κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
-    zmax = FT(0)
-    zmin = FT(-1)
-    nelems = 200
-    Δz = 0.005
-    soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-    top_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    bot_flux_bc = FluxBC((p, t) -> eltype(t)(0.0))
-    boundary_fluxes = (;
-        top = (water = top_flux_bc, heat = top_flux_bc),
-        bottom = (water = bot_flux_bc, heat = bot_flux_bc),
-    )
-
-    sources = (PhaseChange{FT}(Δz),)
-
-    ###
-    hyd_off_en_on = Soil.EnergyHydrologyParameters{FT}(;
-        κ_dry = κ_dry,
-        κ_sat_frozen = κ_sat_frozen,
-        κ_sat_unfrozen = κ_sat_unfrozen,
-        ρc_ds = ρc_ds,
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
-    )
-    soil_heat_on = Soil.EnergyHydrology{FT}(;
-        parameters = hyd_off_en_on,
-        domain = soil_domain,
-        boundary_conditions = boundary_fluxes,
-        sources = sources,
-    )
-
-    Y, p, coords = initialize(soil_heat_on)
-
-    # specify ICs
-    function init_soil_heat!(Ysoil, z, params)
-        ν = params.ν
-        Ysoil.soil.ϑ_l .= ν / 2.0
-        Ysoil.soil.θ_i .= 0.0
-        T = 270.0
-        ρc_s = Soil.volumetric_heat_capacity(ν / 2.0, 0.0, params)
-        Ysoil.soil.ρe_int =
-            Soil.volumetric_internal_energy.(0.0, ρc_s, T, Ref(params))
-    end
-
-    init_soil_heat!(Y, coords.subsurface.z, soil_heat_on.parameters)
-    set_initial_aux_state! = make_set_initial_aux_state(soil_heat_on)
-    set_initial_aux_state!(p, Y, FT(0.0))
-    dY = similar(Y)
-    dY .= FT(0.0)
-    source!(dY, sources[1], Y, p, soil_heat_on)
-    _ρ_l = FT(LSMP.ρ_cloud_liq(soil_heat_on.parameters.earth_param_set))
-    _ρ_i = FT(LSMP.ρ_cloud_ice(soil_heat_on.parameters.earth_param_set))
-    @test parent(dY.soil.ϑ_l) ≈ -(_ρ_i / _ρ_l) .* parent(dY.soil.θ_i)
 end

--- a/test/standalone/SurfaceWater/pond_test.jl
+++ b/test/standalone/SurfaceWater/pond_test.jl
@@ -7,55 +7,54 @@ end
 using ClimaLSM
 using ClimaLSM.Pond
 
-FT = Float64
-@testset "Pond integration tests" begin
-    function precipitation(t::T) where {T}
-        if t < T(20)
-            precip = -T(1e-8)
-        else
-            precip = t < T(100) ? T(-5e-5) : T(0.0)
-        end
-        return precip
-    end
-
-    pond_model = Pond.PondModel{FT}(;
-        runoff = PrescribedRunoff{FT}(precipitation, (t) -> 0.0),
-    )
-
-    Y, p, coords = initialize(pond_model)
-    Y.surface_water.η .= FT(0.0)
-
-    exp_tendency! = make_exp_tendency(pond_model)
-    t0 = FT(0)
-    tf = FT(200)
-    dt = FT(1)
-    set_initial_aux_state! = make_set_initial_aux_state(pond_model)
-    set_initial_aux_state!(p, Y, t0)
-
-
-    function expected_pond_height(t)
-        if t < 20
-            return 1e-8 * t
-        elseif t < 100
-            return (1e-8 * 20 + (t - 20.0) * (5e-5))
-        else
-            return (20 * (1e-8) + 80 * (5e-5))
-        end
-    end
-
-    nsteps = Int((tf - t0) / dt)
-    dY = similar(Y)
-    t = t0
-    for step in 1:nsteps
-        exp_tendency!(dY, Y, p, t)
-        @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
-        t = t + dt
-        if t % 40 == 0
-            @test abs.(
-                expected_pond_height(t) .- parent(Y.surface_water.η)[1]
-            ) < 1e-14
+for FT in (Float32, Float64)
+    @testset "Pond integration tests, FT = $FT" begin
+        function precipitation(t)
+            if t < 20
+                precip = -1e-8
+            else
+                precip = t < 100 ? -5e-5 : 0.0
+            end
+            return precip
         end
 
-    end
+        pond_model = Pond.PondModel{FT}(;
+            runoff = PrescribedRunoff{FT}(precipitation, (t) -> 0.0),
+        )
 
+        Y, p, coords = initialize(pond_model)
+        Y.surface_water.η .= FT(0.0)
+
+        exp_tendency! = make_exp_tendency(pond_model)
+        t0 = FT(0)
+        tf = FT(200)
+        dt = FT(1)
+        set_initial_aux_state! = make_set_initial_aux_state(pond_model)
+        set_initial_aux_state!(p, Y, t0)
+
+
+        function expected_pond_height(t)
+            if t < 20
+                return 1e-8 * t
+            elseif t < 100
+                return (1e-8 * 20 + (t - 20.0) * (5e-5))
+            else
+                return (20 * (1e-8) + 80 * (5e-5))
+            end
+        end
+
+        nsteps = Int((tf - t0) / dt)
+        dY = similar(Y)
+        t = t0
+        for step in 1:nsteps
+            exp_tendency!(dY, Y, p, t)
+            @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
+            t = t + dt
+            if t % 40 == 0
+                @test abs.(
+                    FT(expected_pond_height(t)) .- parent(Y.surface_water.η)[1]
+                ) < eps(FT)
+            end
+        end
+    end
 end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -14,634 +14,653 @@ import ClimaLSM
 import ClimaLSM.Parameters as LSMP
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-@testset "Canopy software pipes" begin
-    FT = Float32
-    domain = Point(; z_sfc = FT(0.0))
+for FT in (Float32, Float64)
+    @testset "Canopy software pipes, FT = $FT" begin
+        domain = Point(; z_sfc = FT(0.0))
 
-    AR_params = AutotrophicRespirationParameters{FT}()
-    RTparams = BeerLambertParameters{FT}()
-    photosynthesis_params = FarquharParameters{FT}(C3();)
-    stomatal_g_params = MedlynConductanceParameters{FT}()
+        AR_params = AutotrophicRespirationParameters{FT}()
+        RTparams = BeerLambertParameters{FT}()
+        photosynthesis_params = FarquharParameters{FT}(C3();)
+        stomatal_g_params = MedlynConductanceParameters{FT}()
 
-    AR_model = AutotrophicRespirationModel{FT}(AR_params)
-    stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
-    photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
-    rt_model = BeerLambertModel{FT}(RTparams)
+        AR_model = AutotrophicRespirationModel{FT}(AR_params)
+        stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
+        photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
+        rt_model = BeerLambertModel{FT}(RTparams)
 
-    earth_param_set = create_lsm_parameters(FT)
-    LAI = FT(8.0) # m2 [leaf] m-2 [ground]
-    z_0m = FT(2.0) # m, Roughness length for momentum - value from tall forest ChatGPT
-    z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
-    h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
-    shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
-        z_0m,
-        z_0b,
-        earth_param_set,
-    )
-    lat = FT(0.0) # degree
-    long = FT(-180) # degree
+        earth_param_set = create_lsm_parameters(FT)
+        LAI = FT(8.0) # m2 [leaf] m-2 [ground]
+        z_0m = FT(2.0) # m, Roughness length for momentum - value from tall forest ChatGPT
+        z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
+        h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
+        shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+            z_0m,
+            z_0b,
+            earth_param_set,
+        )
+        lat = FT(0.0) # degree
+        long = FT(-180) # degree
 
-    function zenith_angle(
-        t::FT,
-        orbital_data,
-        ref_time;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(
-            instantaneous_zenith_angle(
+        function zenith_angle(
+            t,
+            orbital_data,
+            ref_time;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            return instantaneous_zenith_angle(
                 ref_time + Dates.Second(round(t)),
                 orbital_data,
                 longitude,
                 latitude,
                 insol_params,
-            )[1],
+            )[1]
+        end
+
+        function shortwave_radiation(
+            t;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
         )
-    end
+            return 1000 # W/m^2
+        end
 
-    function shortwave_radiation(
-        t::FT;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(1000) # W/m^2
-    end
+        function longwave_radiation(t)
+            return 200 # W/m^2
+        end
 
-    function longwave_radiation(t::FT) where {FT}
-        return FT(200) # W/m^2
-    end
+        u_atmos = t -> 10 #m.s-1
 
-    u_atmos = t -> eltype(t)(10) #m.s-1
+        liquid_precip = (t) -> 0 # m
+        snow_precip = (t) -> 0 # m
+        T_atmos = t -> 290 # Kelvin
+        q_atmos = t -> 0.001 # kg/kg
+        P_atmos = t -> 1e5 # Pa
+        h_atmos = h_int # m
+        c_atmos = (t) -> 4.11e-4 # mol/mol
+        ref_time = DateTime(2005)
+        atmos = PrescribedAtmosphere(
+            liquid_precip,
+            snow_precip,
+            T_atmos,
+            u_atmos,
+            q_atmos,
+            P_atmos,
+            ref_time,
+            h_atmos;
+            c_co2 = c_atmos,
+        )
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            shortwave_radiation,
+            longwave_radiation,
+            ref_time;
+            θs = zenith_angle,
+            orbital_data = Insolation.OrbitalData(),
+        )
 
-    liquid_precip = (t) -> eltype(t)(0) # m
-    snow_precip = (t) -> eltype(t)(0) # m
-    T_atmos = t -> eltype(t)(290) # Kelvin
-    q_atmos = t -> eltype(t)(0.001) # kg/kg
-    P_atmos = t -> eltype(t)(1e5) # Pa
-    h_atmos = h_int # m
-    c_atmos = (t) -> eltype(t)(4.11e-4) # mol/mol
-    ref_time = DateTime(2005)
-    atmos = PrescribedAtmosphere(
-        liquid_precip,
-        snow_precip,
-        T_atmos,
-        u_atmos,
-        q_atmos,
-        P_atmos,
-        ref_time,
-        h_atmos;
-        c_co2 = c_atmos,
-    )
-    radiation = PrescribedRadiativeFluxes(
-        FT,
-        shortwave_radiation,
-        longwave_radiation,
-        ref_time;
-        θs = zenith_angle,
-        orbital_data = Insolation.OrbitalData(),
-    )
-
-    # Plant Hydraulics
-    RAI = FT(1)
-    SAI = FT(0)
-    ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
-        t -> eltype(t)(LAI),
-        SAI,
-        RAI,
-    )
-    K_sat_plant = FT(1.8e-8) # m/s
-    ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
-    Weibull_param = FT(4) # unitless, Holtzman's original c param value
-    a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
-    plant_ν = FT(0.7) # m3/m3
-    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    conductivity_model =
-        PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
-    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-    root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-    function root_distribution(z::T) where {T}
-        return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-    end
-    param_set = PlantHydraulics.PlantHydraulicsParameters(;
-        ai_parameterization = ai_parameterization,
-        ν = plant_ν,
-        S_s = plant_S_s,
-        root_distribution = root_distribution,
-        conductivity_model = conductivity_model,
-        retention_model = retention_model,
-    )
-    Δz = FT(1.0) # height of compartments
-    n_stem = Int64(0) # number of stem elements
-    n_leaf = Int64(1) # number of leaf elements
-    compartment_centers =
-        FT.(
-            Vector(
-                range(
-                    start = Δz / 2,
-                    step = Δz,
-                    stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+        # Plant Hydraulics
+        RAI = FT(1)
+        SAI = FT(0)
+        ai_parameterization =
+            PlantHydraulics.PrescribedSiteAreaIndex{FT}(t -> LAI, SAI, RAI)
+        K_sat_plant = FT(1.8e-8) # m/s
+        ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
+        Weibull_param = FT(4) # unitless, Holtzman's original c param value
+        a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+        plant_ν = FT(0.7) # m3/m3
+        plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
+        function root_distribution(z::T) where {T}
+            return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+        end
+        param_set = PlantHydraulics.PlantHydraulicsParameters(;
+            ai_parameterization = ai_parameterization,
+            ν = plant_ν,
+            S_s = plant_S_s,
+            root_distribution = root_distribution,
+            conductivity_model = conductivity_model,
+            retention_model = retention_model,
+        )
+        Δz = FT(1.0) # height of compartments
+        n_stem = Int64(0) # number of stem elements
+        n_leaf = Int64(1) # number of leaf elements
+        compartment_centers =
+            FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+                    ),
                 ),
-            ),
-        )
-    compartment_faces =
-        FT.(
-            Vector(
-                range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
             )
+        compartment_faces =
+            FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
+                )
+            )
+
+        ψ_soil0 = FT(0.0)
+        soil_driver = PrescribedSoil{FT}()
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            parameters = param_set,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_faces,
+            compartment_midpoints = compartment_centers,
+        )
+        canopy = ClimaLSM.Canopy.CanopyModel{FT}(;
+            parameters = shared_params,
+            domain = domain,
+            autotrophic_respiration = AR_model,
+            radiative_transfer = rt_model,
+            photosynthesis = photosynthesis_model,
+            conductance = stomatal_model,
+            hydraulics = plant_hydraulics,
+            soil_driver = soil_driver,
+            atmos = atmos,
+            radiation = radiation,
+        )
+        Y, p, coords = ClimaLSM.initialize(canopy)
+        @test typeof(canopy.energy) == PrescribedCanopyTempModel{FT}
+        @test propertynames(p) == (:canopy,)
+        for component in ClimaLSM.Canopy.canopy_components(canopy)
+            @test propertynames(getproperty(p.canopy, component)) ==
+                  ClimaLSM.auxiliary_vars(getproperty(canopy, component))
+            @test propertynames(getproperty(Y.canopy, component)) ==
+                  ClimaLSM.prognostic_vars(getproperty(canopy, component))
+
+            @test getproperty(auxiliary_types(canopy), component) ==
+                  auxiliary_types(getproperty(canopy, component))
+            @test getproperty(auxiliary_vars(canopy), component) ==
+                  auxiliary_vars(getproperty(canopy, component))
+            @test getproperty(prognostic_types(canopy), component) ==
+                  prognostic_types(getproperty(canopy, component))
+            @test getproperty(prognostic_types(canopy), component) ==
+                  prognostic_types(getproperty(canopy, component))
+        end
+        Y.canopy.hydraulics[1] = plant_ν
+        set_initial_aux_state! = make_set_initial_aux_state(canopy)
+        exp_tendency! = make_exp_tendency(canopy)
+        t0 = FT(0.0)
+        dY = similar(Y)
+        set_initial_aux_state!(p, Y, t0)
+        # check that this is updated correctly:
+        # @test p.canopy.autotrophic_respiration.Ra ==
+        exp_tendency!(dY, Y, p, t0)
+        (evapotranspiration, shf, lhf) =
+            ClimaLSM.Canopy.canopy_turbulent_surface_fluxes(
+                canopy.atmos,
+                canopy,
+                Y,
+                p,
+                t0,
+            )
+
+        @test p.canopy.hydraulics.fa.:1 == evapotranspiration
+        @test p.canopy.energy.shf == shf
+        @test p.canopy.energy.lhf == lhf
+        @test p.canopy.conductance.transpiration == evapotranspiration
+        c = FT(LSMP.light_speed(earth_param_set))
+        h = FT(LSMP.planck_constant(earth_param_set))
+        N_a = FT(LSMP.avogadro_constant(earth_param_set))
+        _σ = FT(LSMP.Stefan(earth_param_set))
+        (; α_PAR_leaf, λ_γ_PAR, λ_γ_NIR, ϵ_canopy) =
+            canopy.radiative_transfer.parameters
+        APAR = p.canopy.radiative_transfer.apar
+        ANIR = p.canopy.radiative_transfer.anir
+        energy_per_photon_PAR = h * c / λ_γ_PAR
+        energy_per_photon_NIR = h * c / λ_γ_NIR
+
+        @test p.canopy.radiative_transfer.SW_n ==
+              @. (energy_per_photon_PAR * N_a * APAR) +
+                 (energy_per_photon_NIR * N_a * ANIR)
+
+        T_canopy = FT.(atmos.T(t0))
+        T_soil = FT.(soil_driver.T(t0))
+        ϵ_soil = FT.(soil_driver.ϵ)
+        LW_d = FT.(radiation.LW_d(t0))
+        LW_d_canopy = (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4
+        LW_u_soil = ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy
+        @test parent(p.canopy.radiative_transfer.LW_n)[1] ≈
+              ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 +
+              ϵ_canopy * LW_u_soil
+
+
+        # Penman-monteith
+        Δ = FT(100 * (0.444017302 + (290 - 273.15) * 0.0286064092))
+        Rn = FT(shortwave_radiation(t0))
+        G = FT(0.0)
+        thermo_params = canopy.parameters.earth_param_set.thermo_params
+        ts_in = construct_atmos_ts(atmos, t0, thermo_params)
+        ρa = Thermodynamics.air_density(thermo_params, ts_in)
+        cp =
+            FT(cp_m(thermo_params, Thermodynamics.PhasePartition.(q_atmos(t0))))
+
+        es =
+            Thermodynamics.saturation_vapor_pressure.(
+                Ref(thermo_params),
+                FT.(T_atmos(t0)),
+                Ref(Thermodynamics.Liquid()),
+            )
+        ea =
+            Thermodynamics.partial_pressure_vapor.(
+                Ref(thermo_params),
+                FT.(P_atmos(t0)),
+                Thermodynamics.PhasePartition.(FT.(q_atmos(t0))),
+            )
+
+        VPD = es .- ea
+
+        conditions = surface_fluxes(atmos, canopy, Y, p, t0) #Per unit m^2 of leaf
+        r_ae = parent(conditions.r_ae)[1] # s/m
+        ga = 1 / r_ae
+        γ = FT(66)
+        R = FT(LSMP.gas_constant(earth_param_set))
+        gs = parent(
+            ClimaLSM.Canopy.upscale_leaf_conductance.(
+                p.canopy.conductance.gs,
+                LAI,
+                FT.(T_atmos(t0)),
+                R,
+                FT.(P_atmos(t0)),
+            ),
+        )[1]
+        Lv = FT(2453e6) #J/m^3
+
+        ET = penman_monteith(
+            Δ, # Rate of change of saturation specific humidity with air temperature. (Pa K−1)
+            Rn, # Net irradiance (W m−2), the external source of energy flux
+            G, # Ground heat flux (W m−2)
+            ρa, # Dry air density (kg m−3)
+            cp, # Specific heat capacity of air (J kg−1 K−1)
+            VPD, # vapor pressure deficit (Pa)
+            ga, # Conductivity of air, atmospheric conductance (m s−1)
+            γ, # Psychrometric constant (γ ≈ 66 Pa K−1)
+            gs, # Conductivity of stoma, surface or stomatal conductance (m s−1)
+            Lv, # Volumetric latent heat of vaporization. Energy required per water volume vaporized. (Lv = 2453 MJ m−3)
         )
 
-    ψ_soil0 = FT(0.0)
-    soil_driver = PrescribedSoil{FT}()
-    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-        parameters = param_set,
-        n_stem = n_stem,
-        n_leaf = n_leaf,
-        compartment_surfaces = compartment_faces,
-        compartment_midpoints = compartment_centers,
-    )
-    canopy = ClimaLSM.Canopy.CanopyModel{FT}(;
-        parameters = shared_params,
-        domain = domain,
-        autotrophic_respiration = AR_model,
-        radiative_transfer = rt_model,
-        photosynthesis = photosynthesis_model,
-        conductance = stomatal_model,
-        hydraulics = plant_hydraulics,
-        soil_driver = soil_driver,
-        atmos = atmos,
-        radiation = radiation,
-    )
-    Y, p, coords = ClimaLSM.initialize(canopy)
-    @test typeof(canopy.energy) == PrescribedCanopyTempModel{FT}
-    @test propertynames(p) == (:canopy,)
-    for component in ClimaLSM.Canopy.canopy_components(canopy)
-        @test propertynames(getproperty(p.canopy, component)) ==
-              ClimaLSM.auxiliary_vars(getproperty(canopy, component))
-        @test propertynames(getproperty(Y.canopy, component)) ==
-              ClimaLSM.prognostic_vars(getproperty(canopy, component))
+        @test abs(
+            (parent(evapotranspiration)[1] - ET) /
+            parent(evapotranspiration)[1],
+        ) < 0.5
 
-        @test getproperty(auxiliary_types(canopy), component) ==
-              auxiliary_types(getproperty(canopy, component))
-        @test getproperty(auxiliary_vars(canopy), component) ==
-              auxiliary_vars(getproperty(canopy, component))
-        @test getproperty(prognostic_types(canopy), component) ==
-              prognostic_types(getproperty(canopy, component))
-        @test getproperty(prognostic_types(canopy), component) ==
-              prognostic_types(getproperty(canopy, component))
-    end
-    Y.canopy.hydraulics[1] = plant_ν
-    set_initial_aux_state! = make_set_initial_aux_state(canopy)
-    exp_tendency! = make_exp_tendency(canopy)
-    t0 = FT(0.0)
-    dY = similar(Y)
-    set_initial_aux_state!(p, Y, t0)
-    # check that this is updated correctly:
-    # @test p.canopy.autotrophic_respiration.Ra == 
-    exp_tendency!(dY, Y, p, t0)
-    (evapotranspiration, shf, lhf) =
-        ClimaLSM.Canopy.canopy_turbulent_surface_fluxes(
-            canopy.atmos,
+        @test ClimaLSM.surface_evaporative_scaling(canopy, Y, p) == FT(1.0)
+        @test ClimaLSM.surface_height(canopy, Y, p) == compartment_faces[1]
+        T_sfc = FT.(canopy.atmos.T(t0))
+        @test ClimaLSM.surface_temperature(canopy, Y, p, t0) == T_sfc
+        @test ClimaLSM.Canopy.canopy_temperature(
+            canopy.energy,
             canopy,
             Y,
             p,
             t0,
-        )
-
-    @test p.canopy.hydraulics.fa.:1 == evapotranspiration
-    @test p.canopy.energy.shf == shf
-    @test p.canopy.energy.lhf == lhf
-    @test p.canopy.conductance.transpiration == evapotranspiration
-    c = FT(LSMP.light_speed(earth_param_set))
-    h = FT(LSMP.planck_constant(earth_param_set))
-    N_a = FT(LSMP.avogadro_constant(earth_param_set))
-    _σ = FT(LSMP.Stefan(earth_param_set))
-    (; α_PAR_leaf, λ_γ_PAR, λ_γ_NIR, ϵ_canopy) =
-        canopy.radiative_transfer.parameters
-    APAR = p.canopy.radiative_transfer.apar
-    ANIR = p.canopy.radiative_transfer.anir
-    energy_per_photon_PAR = h * c / λ_γ_PAR
-    energy_per_photon_NIR = h * c / λ_γ_NIR
-
-    @test p.canopy.radiative_transfer.SW_n ==
-          @. (energy_per_photon_PAR * N_a * APAR) +
-             (energy_per_photon_NIR * N_a * ANIR)
-
-    T_canopy = atmos.T(t0)
-    T_soil = soil_driver.T(t0)
-    ϵ_soil = soil_driver.ϵ
-    LW_d = radiation.LW_d(t0)
-    LW_d_canopy = (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4
-    LW_u_soil = ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy
-    @test parent(p.canopy.radiative_transfer.LW_n)[1] ≈
-          ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 +
-          ϵ_canopy * LW_u_soil
-
-
-    # Penman-monteith
-    Δ = FT(100 * (0.444017302 + (290 - 273.15) * 0.0286064092))
-    Rn = shortwave_radiation(t0)
-    G = FT(0.0)
-    thermo_params = canopy.parameters.earth_param_set.thermo_params
-    ts_in = construct_atmos_ts(atmos, t0, thermo_params)
-    ρa = Thermodynamics.air_density(thermo_params, ts_in)
-    cp = cp_m(thermo_params, Thermodynamics.PhasePartition.(q_atmos(t0)))
-
-    es =
-        Thermodynamics.saturation_vapor_pressure.(
+        ) == T_sfc
+        ρ_sfc =
+            ClimaLSM.surface_air_density(canopy.atmos, canopy, Y, p, t0, T_sfc)
+        @test ClimaLSM.surface_specific_humidity(canopy, Y, p, T_sfc, ρ_sfc) ==
+              Thermodynamics.q_vap_saturation_generic.(
             Ref(thermo_params),
-            T_atmos(t0),
+            T_sfc,
+            ρ_sfc,
             Ref(Thermodynamics.Liquid()),
         )
-    ea =
-        Thermodynamics.partial_pressure_vapor.(
-            Ref(thermo_params),
-            P_atmos(t0),
-            Thermodynamics.PhasePartition.(q_atmos(t0)),
-        )
-
-    VPD = es .- ea
-
-    conditions = surface_fluxes(atmos, canopy, Y, p, t0) #Per unit m^2 of leaf
-    r_ae = parent(conditions.r_ae)[1] # s/m
-    ga = 1 / r_ae
-    γ = FT(66)
-    R = FT(LSMP.gas_constant(earth_param_set))
-    gs = parent(
-        ClimaLSM.Canopy.upscale_leaf_conductance.(
-            p.canopy.conductance.gs,
-            LAI,
-            T_atmos(t0),
-            R,
-            P_atmos(t0),
-        ),
-    )[1]
-    Lv = FT(2453e6) #J/m^3
-
-    ET = penman_monteith(
-        Δ, # Rate of change of saturation specific humidity with air temperature. (Pa K−1)
-        Rn, # Net irradiance (W m−2), the external source of energy flux
-        G, # Ground heat flux (W m−2)
-        ρa, # Dry air density (kg m−3)
-        cp, # Specific heat capacity of air (J kg−1 K−1)
-        VPD, # vapor pressure deficit (Pa)
-        ga, # Conductivity of air, atmospheric conductance (m s−1)
-        γ, # Psychrometric constant (γ ≈ 66 Pa K−1)
-        gs, # Conductivity of stoma, surface or stomatal conductance (m s−1)
-        Lv, # Volumetric latent heat of vaporization. Energy required per water volume vaporized. (Lv = 2453 MJ m−3)
-    )
-
-    @test abs(
-        (parent(evapotranspiration)[1] - ET) / parent(evapotranspiration)[1],
-    ) < 0.5
-
-    @test ClimaLSM.surface_evaporative_scaling(canopy, Y, p) == FT(1.0)
-    @test ClimaLSM.surface_height(canopy, Y, p) == compartment_faces[1]
-    T_sfc = canopy.atmos.T(t0)
-    @test ClimaLSM.surface_temperature(canopy, Y, p, t0) == T_sfc
-    @test ClimaLSM.Canopy.canopy_temperature(canopy.energy, canopy, Y, p, t0) ==
-          T_sfc
-    ρ_sfc = ClimaLSM.surface_air_density(canopy.atmos, canopy, Y, p, t0, T_sfc)
-    @test ClimaLSM.surface_specific_humidity(canopy, Y, p, T_sfc, ρ_sfc) ==
-          Thermodynamics.q_vap_saturation_generic.(
-        Ref(thermo_params),
-        T_sfc,
-        ρ_sfc,
-        Ref(Thermodynamics.Liquid()),
-    )
-    @test ρ_sfc == compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
-end
-
-
-@testset "Component prescribed fields" begin
-    FT = Float32
-    # Plant Hydraulics
-    LAI = FT(2)
-    RAI = FT(1)
-    SAI = FT(1)
-    ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
-        t -> eltype(t)(LAI * sin(t * 2π / 365)),
-        SAI,
-        RAI,
-    )
-    K_sat_plant = FT(1.8e-8) # m/s
-    ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
-    Weibull_param = FT(4) # unitless, Holtzman's original c param value
-    a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
-    plant_ν = FT(0.7) # m3/m3
-    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    conductivity_model =
-        PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
-    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-    root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-    function root_distribution(z::T) where {T}
-        return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+        @test ρ_sfc == compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
     end
-    param_set = PlantHydraulics.PlantHydraulicsParameters(;
-        ai_parameterization = ai_parameterization,
-        ν = plant_ν,
-        S_s = plant_S_s,
-        root_distribution = root_distribution,
-        conductivity_model = conductivity_model,
-        retention_model = retention_model,
-    )
-    Δz = FT(1.0) # height of compartments
-    n_stem = Int64(0) # number of stem elements
-    n_leaf = Int64(1) # number of leaf elements
-    compartment_centers =
-        FT.(
-            Vector(
-                range(
-                    start = Δz / 2,
-                    step = Δz,
-                    stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+
+
+    @testset "Component prescribed fields, FT = $FT" begin
+        FT = Float32
+        # Plant Hydraulics
+        LAI = FT(2)
+        RAI = FT(1)
+        SAI = FT(1)
+        ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
+            t -> LAI * sin(t * 2π / 365),
+            SAI,
+            RAI,
+        )
+        K_sat_plant = FT(1.8e-8) # m/s
+        ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
+        Weibull_param = FT(4) # unitless, Holtzman's original c param value
+        a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+        plant_ν = FT(0.7) # m3/m3
+        plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
+        function root_distribution(z::T) where {T}
+            return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+        end
+        param_set = PlantHydraulics.PlantHydraulicsParameters(;
+            ai_parameterization = ai_parameterization,
+            ν = plant_ν,
+            S_s = plant_S_s,
+            root_distribution = root_distribution,
+            conductivity_model = conductivity_model,
+            retention_model = retention_model,
+        )
+        Δz = FT(1.0) # height of compartments
+        n_stem = Int64(0) # number of stem elements
+        n_leaf = Int64(1) # number of leaf elements
+        compartment_centers =
+            FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+                    ),
                 ),
-            ),
-        )
-    compartment_faces =
-        FT.(
-            Vector(
-                range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
             )
-        )
-
-    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-        parameters = param_set,
-        n_stem = n_stem,
-        n_leaf = n_leaf,
-        compartment_surfaces = compartment_faces,
-        compartment_midpoints = compartment_centers,
-    )
-
-    t0 = FT(100)
-    domain = Point(; z_sfc = FT(0.0))
-    p = ClimaCore.fill(
-        (;
-            canopy = (;
-                hydraulics = (;
-                    area_index = (
-                        leaf = FT(0.0),
-                        root = FT(0.0),
-                        stem = FT(0.0),
-                    )
+        compartment_faces =
+            FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
                 )
             )
-        ),
-        domain.space.surface,
-    )
-    # Test that they are set properly
-    set_canopy_prescribed_field!(plant_hydraulics, p, t0)
-    @test all(
-        parent(p.canopy.hydraulics.area_index.leaf) .==
-        FT(LAI * sin(t0 * 2π / 365)),
-    )
-    @test all(parent(p.canopy.hydraulics.area_index.stem) .== FT(1.0))
-    @test all(parent(p.canopy.hydraulics.area_index.root) .== FT(1.0))
 
-    # Test that LAI is updated
-    update_canopy_prescribed_field!(plant_hydraulics, p, FT(200))
-    @test all(
-        parent(p.canopy.hydraulics.area_index.leaf) .==
-        FT(LAI * sin(200 * 2π / 365)),
-    )
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            parameters = param_set,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_faces,
+            compartment_midpoints = compartment_centers,
+        )
 
-    struct Default{FT} <: ClimaLSM.Canopy.AbstractCanopyComponent{FT} end
-    set_canopy_prescribed_field!(Default{FT}(), p, t0)
-    update_canopy_prescribed_field!(Default{FT}(), p, t0)
-    # Test that they are unchanged
-    @test all(
-        parent(p.canopy.hydraulics.area_index.leaf) .==
-        FT(LAI * sin(200 * 2π / 365)),
-    )
-    @test all(parent(p.canopy.hydraulics.area_index.stem) .== FT(1.0))
-    @test all(parent(p.canopy.hydraulics.area_index.root) .== FT(1.0))
-end
+        t0 = FT(100)
+        domain = Point(; z_sfc = FT(0.0))
+        p = ClimaCore.fill(
+            (;
+                canopy = (;
+                    hydraulics = (;
+                        area_index = (
+                            leaf = FT(0.0),
+                            root = FT(0.0),
+                            stem = FT(0.0),
+                        )
+                    )
+                )
+            ),
+            domain.space.surface,
+        )
+        # Test that they are set properly
+        set_canopy_prescribed_field!(plant_hydraulics, p, t0)
+        @test all(
+            parent(p.canopy.hydraulics.area_index.leaf) .==
+            FT(LAI * sin(t0 * 2π / 365)),
+        )
+        @test all(parent(p.canopy.hydraulics.area_index.stem) .== FT(1.0))
+        @test all(parent(p.canopy.hydraulics.area_index.root) .== FT(1.0))
 
-@testset "PrescribedSoil" begin
-    FT = Float32
-    soil_driver = PrescribedSoil{FT}()
-    @test ground_albedo_PAR(soil_driver, nothing, nothing, nothing) == FT(0.2)
-    @test ground_albedo_NIR(soil_driver, nothing, nothing, nothing) == FT(0.4)
-    @test soil_driver.root_depths ==
-          FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0)
-    @test soil_driver.ψ(2.0) == 0.0
-    @test soil_driver.T(2.0) == 298.0
-end
+        # Test that LAI is updated
+        update_canopy_prescribed_field!(plant_hydraulics, p, FT(200))
+        @test all(
+            parent(p.canopy.hydraulics.area_index.leaf) .==
+            FT(LAI * sin(200 * 2π / 365)),
+        )
 
-@testset "Canopy software pipes with energy model" begin
-    FT = Float32
-    domain = Point(; z_sfc = FT(0.0))
+        struct Default{FT} <: ClimaLSM.Canopy.AbstractCanopyComponent{FT} end
+        set_canopy_prescribed_field!(Default{FT}(), p, t0)
+        update_canopy_prescribed_field!(Default{FT}(), p, t0)
+        # Test that they are unchanged
+        @test all(
+            parent(p.canopy.hydraulics.area_index.leaf) .==
+            FT(LAI * sin(200 * 2π / 365)),
+        )
+        @test all(parent(p.canopy.hydraulics.area_index.stem) .== FT(1.0))
+        @test all(parent(p.canopy.hydraulics.area_index.root) .== FT(1.0))
+    end
 
-    RTparams = BeerLambertParameters{FT}()
-    photosynthesis_params = FarquharParameters{FT}(C3();)
-    stomatal_g_params = MedlynConductanceParameters{FT}()
+    @testset "PrescribedSoil, FT = $FT" begin
+        soil_driver = PrescribedSoil{FT}()
+        @test ground_albedo_PAR(soil_driver, nothing, nothing, nothing) ==
+              FT(0.2)
+        @test ground_albedo_NIR(soil_driver, nothing, nothing, nothing) ==
+              FT(0.4)
+        @test soil_driver.root_depths ==
+              FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0)
+        @test FT.(soil_driver.ψ(2.0)) == FT.(0.0)
+        @test FT.(soil_driver.T(2.0)) == FT.(298.0)
+    end
 
-    stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
-    photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
-    rt_model = BeerLambertModel{FT}(RTparams)
-    energy_model = BigLeafEnergyModel{FT}(BigLeafEnergyParameters{FT}())
-    earth_param_set = create_lsm_parameters(FT)
-    LAI = FT(8.0) # m2 [leaf] m-2 [ground]
-    z_0m = FT(2.0) # m, Roughness length for momentum - value from tall forest ChatGPT
-    z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
-    h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
-    shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
-        z_0m,
-        z_0b,
-        earth_param_set,
-    )
-    lat = FT(0.0) # degree
-    long = FT(-180) # degree
+    @testset "Canopy software pipes with energy model, FT = $FT" begin
+        domain = Point(; z_sfc = FT(0.0))
 
-    function zenith_angle(
-        t::FT,
-        orbital_data,
-        ref_time;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(
-            instantaneous_zenith_angle(
+        RTparams = BeerLambertParameters{FT}()
+        photosynthesis_params = FarquharParameters{FT}(C3();)
+        stomatal_g_params = MedlynConductanceParameters{FT}()
+
+        stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
+        photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
+        rt_model = BeerLambertModel{FT}(RTparams)
+        energy_model = BigLeafEnergyModel{FT}(BigLeafEnergyParameters{FT}())
+        earth_param_set = create_lsm_parameters(FT)
+        LAI = FT(8.0) # m2 [leaf] m-2 [ground]
+        z_0m = FT(2.0) # m, Roughness length for momentum - value from tall forest ChatGPT
+        z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
+        h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
+        shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+            z_0m,
+            z_0b,
+            earth_param_set,
+        )
+        lat = FT(0.0) # degree
+        long = FT(-180) # degree
+
+        function zenith_angle(
+            t,
+            orbital_data,
+            ref_time;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            return instantaneous_zenith_angle(
                 ref_time + Dates.Second(round(t)),
                 orbital_data,
                 longitude,
                 latitude,
                 insol_params,
-            )[1],
+            )[1]
+        end
+
+        function shortwave_radiation(
+            t;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
         )
-    end
+            return 1000 # W/m^2
+        end
 
-    function shortwave_radiation(
-        t::FT;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(1000) # W/m^2
-    end
+        function longwave_radiation(t)
+            return 200 # W/m^2
+        end
 
-    function longwave_radiation(t::FT) where {FT}
-        return FT(200) # W/m^2
-    end
+        u_atmos = t -> 10 #m.s-1
 
-    u_atmos = t -> eltype(t)(10) #m.s-1
+        liquid_precip = (t) -> 0 # m
+        snow_precip = (t) -> 0 # m
+        T_atmos = t -> 290 # Kelvin
+        q_atmos = t -> 0.001 # kg/kg
+        P_atmos = t -> 1e5 # Pa
+        h_atmos = h_int # m
+        c_atmos = (t) -> 4.11e-4 # mol/mol
+        ref_time = DateTime(2005)
+        atmos = PrescribedAtmosphere(
+            liquid_precip,
+            snow_precip,
+            T_atmos,
+            u_atmos,
+            q_atmos,
+            P_atmos,
+            ref_time,
+            h_atmos;
+            c_co2 = c_atmos,
+        )
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            shortwave_radiation,
+            longwave_radiation,
+            ref_time;
+            θs = zenith_angle,
+            orbital_data = Insolation.OrbitalData(),
+        )
 
-    liquid_precip = (t) -> eltype(t)(0) # m
-    snow_precip = (t) -> eltype(t)(0) # m
-    T_atmos = t -> eltype(t)(290) # Kelvin
-    q_atmos = t -> eltype(t)(0.001) # kg/kg
-    P_atmos = t -> eltype(t)(1e5) # Pa
-    h_atmos = h_int # m
-    c_atmos = (t) -> eltype(t)(4.11e-4) # mol/mol
-    ref_time = DateTime(2005)
-    atmos = PrescribedAtmosphere(
-        liquid_precip,
-        snow_precip,
-        T_atmos,
-        u_atmos,
-        q_atmos,
-        P_atmos,
-        ref_time,
-        h_atmos;
-        c_co2 = c_atmos,
-    )
-    radiation = PrescribedRadiativeFluxes(
-        FT,
-        shortwave_radiation,
-        longwave_radiation,
-        ref_time;
-        θs = zenith_angle,
-        orbital_data = Insolation.OrbitalData(),
-    )
-
-    # Plant Hydraulics
-    RAI = FT(1)
-    SAI = FT(0)
-    ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
-        t -> eltype(t)(LAI),
-        SAI,
-        RAI,
-    )
-    K_sat_plant = FT(1.8e-8) # m/s
-    ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
-    Weibull_param = FT(4) # unitless, Holtzman's original c param value
-    a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
-    plant_ν = FT(0.7) # m3/m3
-    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    conductivity_model =
-        PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
-    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-    root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-    function root_distribution(z::T) where {T}
-        return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-    end
-    param_set = PlantHydraulics.PlantHydraulicsParameters(;
-        ai_parameterization = ai_parameterization,
-        ν = plant_ν,
-        S_s = plant_S_s,
-        root_distribution = root_distribution,
-        conductivity_model = conductivity_model,
-        retention_model = retention_model,
-    )
-    Δz = FT(1.0) # height of compartments
-    n_stem = Int64(0) # number of stem elements
-    n_leaf = Int64(1) # number of leaf elements
-    compartment_centers =
-        FT.(
-            Vector(
-                range(
-                    start = Δz / 2,
-                    step = Δz,
-                    stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+        # Plant Hydraulics
+        RAI = FT(1)
+        SAI = FT(0)
+        ai_parameterization =
+            PlantHydraulics.PrescribedSiteAreaIndex{FT}(t -> LAI, SAI, RAI)
+        K_sat_plant = FT(1.8e-8) # m/s
+        ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
+        Weibull_param = FT(4) # unitless, Holtzman's original c param value
+        a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+        plant_ν = FT(0.7) # m3/m3
+        plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        root_depths = FT.(-Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
+        function root_distribution(z::T) where {T}
+            return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+        end
+        param_set = PlantHydraulics.PlantHydraulicsParameters(;
+            ai_parameterization = ai_parameterization,
+            ν = plant_ν,
+            S_s = plant_S_s,
+            root_distribution = root_distribution,
+            conductivity_model = conductivity_model,
+            retention_model = retention_model,
+        )
+        Δz = FT(1.0) # height of compartments
+        n_stem = Int64(0) # number of stem elements
+        n_leaf = Int64(1) # number of leaf elements
+        compartment_centers =
+            FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+                    ),
                 ),
-            ),
-        )
-    compartment_faces =
-        FT.(
-            Vector(
-                range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
             )
+        compartment_faces =
+            FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
+                )
+            )
+
+        ψ_soil0 = FT(0.0)
+        T_soil0 = FT(290)
+        soil_driver = PrescribedSoil{FT}(
+            root_depths,
+            (t) -> ψ_soil0,
+            (t) -> T_soil0,
+            FT(0.2),
+            FT(0.4),
+            FT(0.98),
         )
 
-    ψ_soil0 = FT(0.0)
-    T_soil0 = FT(290)
-    soil_driver = PrescribedSoil(
-        root_depths,
-        (t::FT) -> ψ_soil0,
-        (t::FT) -> T_soil0,
-        FT(0.2),
-        FT(0.4),
-        FT(0.98),
-    )
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            parameters = param_set,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_faces,
+            compartment_midpoints = compartment_centers,
+        )
+        autotrophic_parameters =
+            ClimaLSM.Canopy.AutotrophicRespirationParameters{FT}()
+        autotrophic_respiration_model =
+            ClimaLSM.Canopy.AutotrophicRespirationModel{FT}(
+                autotrophic_parameters,
+            )
 
-    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-        parameters = param_set,
-        n_stem = n_stem,
-        n_leaf = n_leaf,
-        compartment_surfaces = compartment_faces,
-        compartment_midpoints = compartment_centers,
-    )
-    autotrophic_parameters =
-        ClimaLSM.Canopy.AutotrophicRespirationParameters{FT}()
-    autotrophic_respiration_model =
-        ClimaLSM.Canopy.AutotrophicRespirationModel(autotrophic_parameters)
+        canopy = ClimaLSM.Canopy.CanopyModel{FT}(;
+            parameters = shared_params,
+            domain = domain,
+            radiative_transfer = rt_model,
+            photosynthesis = photosynthesis_model,
+            conductance = stomatal_model,
+            autotrophic_respiration = autotrophic_respiration_model,
+            energy = energy_model,
+            hydraulics = plant_hydraulics,
+            soil_driver = soil_driver,
+            atmos = atmos,
+            radiation = radiation,
+        )
+        @test canopy.radiative_transfer.parameters.ϵ_canopy == FT(0.98)
+        @test canopy.energy.parameters.ac_canopy == FT(2.0e3)
+        Y, p, coords = ClimaLSM.initialize(canopy)
+        @test propertynames(p) == (:canopy,)
+        for component in ClimaLSM.Canopy.canopy_components(canopy)
+            @test propertynames(getproperty(p.canopy, component)) ==
+                  ClimaLSM.auxiliary_vars(getproperty(canopy, component))
+            @test propertynames(getproperty(Y.canopy, component)) ==
+                  ClimaLSM.prognostic_vars(getproperty(canopy, component))
 
-    canopy = ClimaLSM.Canopy.CanopyModel{FT}(;
-        parameters = shared_params,
-        domain = domain,
-        radiative_transfer = rt_model,
-        photosynthesis = photosynthesis_model,
-        conductance = stomatal_model,
-        autotrophic_respiration = autotrophic_respiration_model,
-        energy = energy_model,
-        hydraulics = plant_hydraulics,
-        soil_driver = soil_driver,
-        atmos = atmos,
-        radiation = radiation,
-    )
-    @test canopy.radiative_transfer.parameters.ϵ_canopy == FT(0.98)
-    @test canopy.energy.parameters.ac_canopy == FT(2.0e3)
-    Y, p, coords = ClimaLSM.initialize(canopy)
-    @test propertynames(p) == (:canopy,)
-    for component in ClimaLSM.Canopy.canopy_components(canopy)
-        @test propertynames(getproperty(p.canopy, component)) ==
-              ClimaLSM.auxiliary_vars(getproperty(canopy, component))
-        @test propertynames(getproperty(Y.canopy, component)) ==
-              ClimaLSM.prognostic_vars(getproperty(canopy, component))
+            @test getproperty(auxiliary_types(canopy), component) ==
+                  auxiliary_types(getproperty(canopy, component))
+            @test getproperty(auxiliary_vars(canopy), component) ==
+                  auxiliary_vars(getproperty(canopy, component))
+            @test getproperty(prognostic_types(canopy), component) ==
+                  prognostic_types(getproperty(canopy, component))
+            @test getproperty(prognostic_types(canopy), component) ==
+                  prognostic_types(getproperty(canopy, component))
+        end
+        Y.canopy.hydraulics[1] = plant_ν
+        Y.canopy.energy.T = FT(289)
 
-        @test getproperty(auxiliary_types(canopy), component) ==
-              auxiliary_types(getproperty(canopy, component))
-        @test getproperty(auxiliary_vars(canopy), component) ==
-              auxiliary_vars(getproperty(canopy, component))
-        @test getproperty(prognostic_types(canopy), component) ==
-              prognostic_types(getproperty(canopy, component))
-        @test getproperty(prognostic_types(canopy), component) ==
-              prognostic_types(getproperty(canopy, component))
+        set_initial_aux_state! = make_set_initial_aux_state(canopy)
+        t0 = FT(0.0)
+        set_initial_aux_state!(p, Y, t0)
+        exp_tendency! = make_exp_tendency(canopy)
+        dY = similar(Y)
+        exp_tendency!(dY, Y, p, t0)
+        (evapotranspiration, shf, lhf) =
+            canopy_turbulent_surface_fluxes(canopy.atmos, canopy, Y, p, t0)
+        @test p.canopy.hydraulics.fa.:1 == evapotranspiration
+        @test p.canopy.energy.lhf == lhf
+        @test p.canopy.energy.shf == shf
+        @test all(parent(p.canopy.energy.fa_energy_roots) .== FT(0))
+
+        @test all(
+            parent(ClimaLSM.surface_temperature(canopy, Y, p, t0)) .== FT(289),
+        )
+        @test all(
+            parent(
+                ClimaLSM.Canopy.canopy_temperature(
+                    canopy.energy,
+                    canopy,
+                    Y,
+                    p,
+                    t0,
+                ),
+            ) .== FT(289),
+        )
     end
-    Y.canopy.hydraulics[1] = plant_ν
-    Y.canopy.energy.T = FT(289)
-
-    set_initial_aux_state! = make_set_initial_aux_state(canopy)
-    t0 = FT(0.0)
-    set_initial_aux_state!(p, Y, t0)
-    exp_tendency! = make_exp_tendency(canopy)
-    dY = similar(Y)
-    exp_tendency!(dY, Y, p, t0)
-    (evapotranspiration, shf, lhf) =
-        canopy_turbulent_surface_fluxes(canopy.atmos, canopy, Y, p, t0)
-    @test p.canopy.hydraulics.fa.:1 == evapotranspiration
-    @test p.canopy.energy.lhf == lhf
-    @test p.canopy.energy.shf == shf
-    @test all(parent(p.canopy.energy.fa_energy_roots) .== FT(0))
-
-    @test all(
-        parent(ClimaLSM.surface_temperature(canopy, Y, p, t0)) .== FT(289),
-    )
-    @test all(
-        parent(
-            ClimaLSM.Canopy.canopy_temperature(canopy.energy, canopy, Y, p, t0),
-        ) .== FT(289),
-    )
 end

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -13,49 +13,51 @@ using Insolation
 using Dates
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-@testset "LAI assertions" begin
-    FT = Float64
-    LAI = FT.([0, 1])
-    SAI = FT.([0, 1])
-    RAI = FT.([0, 1])
-    n_stem = [0, 1]
-    n_leaf = [1]
-    for L in LAI
-        for S in SAI
-            for R in RAI
-                for n_s in n_stem
-                    for n_l in n_leaf
-                        area_index = (root = R, stem = S, leaf = L)
-                        if n_l == 0
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
-                                n_s,
-                                n_l,
-                                area_index,
-                            )
-                        end
 
-                        if (L > eps(FT) || S > eps(FT)) && R < eps(FT)
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
-                                n_s,
-                                n_l,
-                                area_index,
-                            )
-                        end
+for FT in (Float32, Float64)
+    @testset "LAI assertions, FT = $FT" begin
+        LAI = FT.([0, 1])
+        SAI = FT.([0, 1])
+        RAI = FT.([0, 1])
+        n_stem = [0, 1]
+        n_leaf = [1]
+        for L in LAI
+            for S in SAI
+                for R in RAI
+                    for n_s in n_stem
+                        for n_l in n_leaf
+                            area_index = (root = R, stem = S, leaf = L)
+                            if n_l == 0
+                                @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                                    n_s,
+                                    n_l,
+                                    area_index,
+                                )
+                            end
 
-                        if S > FT(0) && n_s == 0
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
-                                n_s,
-                                n_l,
-                                area_index,
-                            )
-                        end
+                            if (L > eps(FT) || S > eps(FT)) && R < eps(FT)
+                                @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                                    n_s,
+                                    n_l,
+                                    area_index,
+                                )
+                            end
 
-                        if S < eps(FT) && n_s > 0
-                            @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
-                                n_s,
-                                n_l,
-                                area_index,
-                            )
+                            if S > FT(0) && n_s == 0
+                                @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                                    n_s,
+                                    n_l,
+                                    area_index,
+                                )
+                            end
+
+                            if S < eps(FT) && n_s > 0
+                                @test_throws AssertionError ClimaLSM.Canopy.PlantHydraulics.lai_consistency_check(
+                                    n_s,
+                                    n_l,
+                                    area_index,
+                                )
+                            end
                         end
                     end
                 end
@@ -63,197 +65,472 @@ include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
         end
     end
 
-end
+    @testset "Plant hydraulics parameterizations, FT = $FT" begin
+        ν = FT(0.5)
+        S_s = FT(1e-2)
+        K_sat = FT(1.8e-8)
+        ψ63 = FT(-4 / 0.0098)
+        Weibull_param = FT(4)
+        a = FT(0.05 * 0.0098)
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        S_l = FT.([0.7, 0.9, 1.0, 1.1])
+        @test all(
+            @. PlantHydraulics.inverse_water_retention_curve(
+                retention_model,
+                PlantHydraulics.water_retention_curve(
+                    retention_model,
+                    S_l,
+                    ν,
+                    S_s,
+                ),
+                ν,
+                S_s,
+            ) == S_l
+        )
+        ψ = PlantHydraulics.water_retention_curve.(retention_model, S_l, ν, S_s)
+        # @show @. abs(PlantHydraulics.hydraulic_conductivity(conductivity_model, ψ) -
+        # min(K_sat * exp(-(ψ / ψ63)^Weibull_param), K_sat))
+        @test all(
+            @. abs(
+                PlantHydraulics.hydraulic_conductivity(conductivity_model, ψ) -
+                min(K_sat * exp(-(ψ / ψ63)^Weibull_param), K_sat),
+            ) < 2 * eps(FT)
+        )
+    end
 
-@testset "Plant hydraulics parameterizations" begin
-    FT = Float32
-    ν = FT(0.5)
-    S_s = FT(1e-2)
-    K_sat = FT(1.8e-8)
-    ψ63 = FT(-4 / 0.0098)
-    Weibull_param = FT(4)
-    a = FT(0.05 * 0.0098)
-    conductivity_model = PlantHydraulics.Weibull{FT}(K_sat, ψ63, Weibull_param)
-    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-    S_l = FT.([0.7, 0.9, 1.0, 1.1])
-    @test all(
-        @. PlantHydraulics.inverse_water_retention_curve(
-            retention_model,
-            PlantHydraulics.water_retention_curve(retention_model, S_l, ν, S_s),
-            ν,
-            S_s,
-        ) == S_l
-    )
-    ψ = PlantHydraulics.water_retention_curve.(retention_model, S_l, ν, S_s)
-    @test all(
-        @. PlantHydraulics.hydraulic_conductivity(conductivity_model, ψ) ≈
-           min(K_sat * exp(-(ψ / ψ63)^Weibull_param), K_sat)
-    )
-end
+    @testset "Plant hydraulics model integration tests, FT = $FT" begin
+        domains = [
+            Point(; z_sfc = FT(0.0)),
+            Plane(;
+                xlim = FT.((0, 1)),
+                ylim = FT.((0, 1)),
+                nelements = (2, 2),
+                periodic = (true, true),
+                npolynomial = 1,
+            ),
+        ]
 
-@testset "Plant hydraulics model integration tests" begin
-    FT = Float64
-    domains = [
-        Point(; z_sfc = FT(0.0)),
-        Plane(;
-            xlim = (0.0, 1.0),
-            ylim = (0.0, 1.0),
-            nelements = (2, 2),
-            periodic = (true, true),
-            npolynomial = 1,
-        ),
-    ]
+        AR_params = AutotrophicRespirationParameters{FT}()
+        RTparams = BeerLambertParameters{FT}()
+        photosynthesis_params = FarquharParameters{FT}(C3();)
+        stomatal_g_params = MedlynConductanceParameters{FT}()
 
-    AR_params = AutotrophicRespirationParameters{FT}()
-    RTparams = BeerLambertParameters{FT}()
-    photosynthesis_params = FarquharParameters{FT}(C3();)
-    stomatal_g_params = MedlynConductanceParameters{FT}()
+        AR_model = AutotrophicRespirationModel{FT}(AR_params)
+        stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
+        photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
+        rt_model = BeerLambertModel{FT}(RTparams)
 
-    AR_model = AutotrophicRespirationModel{FT}(AR_params)
-    stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
-    photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
-    rt_model = BeerLambertModel{FT}(RTparams)
+        earth_param_set = create_lsm_parameters(FT)
+        LAI = (t) -> 1.0 # m2 [leaf] m-2 [ground]
+        z_0m = FT(2.0) # m, Roughness length for momentum
+        z_0b = FT(0.1) # m, Roughness length for scalars
+        h_c = FT(20.0) # m, canopy height
+        h_sfc = FT(20.0) # m, canopy height
+        h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
+        shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+            z_0m,
+            z_0b,
+            earth_param_set,
+        )
+        lat = FT(0.0) # degree
+        long = FT(-180) # degree
 
-    earth_param_set = create_lsm_parameters(FT)
-    LAI = (t) -> eltype(t)(1.0) # m2 [leaf] m-2 [ground]
-    z_0m = FT(2.0) # m, Roughness length for momentum
-    z_0b = FT(0.1) # m, Roughness length for scalars
-    h_c = FT(20.0) # m, canopy height
-    h_sfc = FT(20.0) # m, canopy height
-    h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
-    shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
-        z_0m,
-        z_0b,
-        earth_param_set,
-    )
-    lat = FT(0.0) # degree
-    long = FT(-180) # degree
-
-    function zenith_angle(
-        t::FT,
-        orbital_data,
-        ref_time;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(
-            instantaneous_zenith_angle(
+        function zenith_angle(
+            t,
+            orbital_data,
+            ref_time;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            return instantaneous_zenith_angle(
                 ref_time + Dates.Second(round(t)),
                 orbital_data,
                 longitude,
                 latitude,
                 insol_params,
-            )[1],
+            )[1]
+        end
+
+        function shortwave_radiation(
+            t;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
         )
+            return 1000 # W/m^2
+        end
+
+        function longwave_radiation(t)
+            return 200 # W/m^2
+        end
+
+        u_atmos = t -> 10 #m.s-1
+
+        liquid_precip = (t) -> 0 # m
+        snow_precip = (t) -> 0 # m
+        T_atmos = t -> 290 # Kelvin
+        q_atmos = t -> 0.001 # kg/kg
+        P_atmos = t -> 1e5 # Pa
+        h_atmos = h_int # m
+        c_atmos = (t) -> 4.11e-4 # mol/mol
+        ref_time = DateTime(2005)
+        atmos = PrescribedAtmosphere(
+            liquid_precip,
+            snow_precip,
+            T_atmos,
+            u_atmos,
+            q_atmos,
+            P_atmos,
+            ref_time,
+            h_atmos;
+            c_co2 = c_atmos,
+        )
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            shortwave_radiation,
+            longwave_radiation,
+            ref_time;
+            θs = zenith_angle,
+            orbital_data = Insolation.OrbitalData(),
+        )
+        Δz = FT(1.0) # height of compartments
+        n_stem = Int64(5) # number of stem elements
+        n_leaf = Int64(6) # number of leaf elements
+        SAI = FT(1) # m2/m2
+        RAI = FT(1) # m2/m2
+        ai_parameterization =
+            PlantHydraulics.PrescribedSiteAreaIndex{FT}(LAI, SAI, RAI)
+        K_sat_plant = 1.8e-8 # m/s.
+        ψ63 = FT(-4 / 0.0098) # / MPa to m
+        Weibull_param = FT(4) # unitless
+        a = FT(0.05 * 0.0098) # 1/m
+        plant_ν = FT(0.7) # m3/m3
+        plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        root_depths = FT.(-Array{FT}(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
+        function root_distribution(z::T) where {T}
+            return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+        end
+        compartment_midpoints = Vector{FT}(
+            range(
+                start = Δz / 2,
+                step = Δz,
+                stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+            ),
+        )
+
+        compartment_surfaces = Vector{FT}(
+            range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
+        )
+
+        param_set = PlantHydraulics.PlantHydraulicsParameters(;
+            ai_parameterization = ai_parameterization,
+            ν = plant_ν,
+            S_s = plant_S_s,
+            root_distribution = root_distribution,
+            conductivity_model = conductivity_model,
+            retention_model = retention_model,
+        )
+
+        function leaf_transpiration(t)
+            T = FT(1e-8) # m/s
+        end
+
+        ψ_soil0 = FT(0.0)
+        transpiration =
+            PrescribedTranspiration{FT}((t) -> leaf_transpiration(t))
+
+        soil_driver = PrescribedSoil{FT}()
+
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            parameters = param_set,
+            transpiration = transpiration,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_surfaces,
+            compartment_midpoints = compartment_midpoints,
+        )
+        autotrophic_parameters =
+            ClimaLSM.Canopy.AutotrophicRespirationParameters{FT}()
+        autotrophic_respiration_model =
+            ClimaLSM.Canopy.AutotrophicRespirationModel{FT}(
+                autotrophic_parameters,
+            )
+        for domain in domains
+            model = ClimaLSM.Canopy.CanopyModel{FT}(;
+                parameters = shared_params,
+                domain = domain,
+                autotrophic_respiration = autotrophic_respiration_model,
+                radiative_transfer = rt_model,
+                photosynthesis = photosynthesis_model,
+                conductance = stomatal_model,
+                hydraulics = plant_hydraulics,
+                soil_driver = soil_driver,
+                atmos = atmos,
+                radiation = radiation,
+            )
+            # Set system to hydrostatic equilibrium state by setting fluxes to zero, and setting LHS of both ODEs to 0
+            function initial_compute_exp_tendency!(F, Y)
+                AI = (; leaf = LAI(0.0), root = RAI, stem = SAI)
+                T0A = FT(1e-8) * AI[:leaf]
+                for i in 1:(n_leaf + n_stem)
+                    if i == 1
+                        fa =
+                            sum(
+                                flux.(
+                                    root_depths,
+                                    plant_hydraulics.compartment_midpoints[i],
+                                    ψ_soil0,
+                                    Y[i],
+                                    PlantHydraulics.hydraulic_conductivity(
+                                        conductivity_model,
+                                        ψ_soil0,
+                                    ),
+                                    PlantHydraulics.hydraulic_conductivity(
+                                        conductivity_model,
+                                        Y[i],
+                                    ),
+                                ) .* root_distribution.(root_depths) .* (
+                                    vcat(root_depths, [0.0])[2:end] -
+                                    vcat(root_depths, [0.0])[1:(end - 1)]
+                                ),
+                            ) * AI[:root]
+                    else
+                        fa =
+                            flux(
+                                plant_hydraulics.compartment_midpoints[i - 1],
+                                plant_hydraulics.compartment_midpoints[i],
+                                Y[i - 1],
+                                Y[i],
+                                PlantHydraulics.hydraulic_conductivity(
+                                    conductivity_model,
+                                    ψ_soil0,
+                                ),
+                                PlantHydraulics.hydraulic_conductivity(
+                                    conductivity_model,
+                                    Y[i],
+                                ),
+                            ) * (
+                                AI[plant_hydraulics.compartment_labels[1]] +
+                                AI[plant_hydraulics.compartment_labels[2]]
+                            ) / 2
+                    end
+                    F[i] = fa - T0A
+                end
+            end
+
+            soln = nlsolve(
+                initial_compute_exp_tendency!,
+                Vector{FT}(-0.03:0.01:0.07);
+                ftol = 1e-11,
+            )
+
+            S_l =
+                inverse_water_retention_curve.(
+                    retention_model,
+                    soln.zero,
+                    plant_ν,
+                    plant_S_s,
+                )
+
+            ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
+
+            Y, p, coords = initialize(model)
+            if typeof(domain) <: ClimaLSM.Domains.Point
+                @test propertynames(p) == (:canopy,)
+            elseif typeof(domain) <: ClimaLSM.Domains.Plane
+                @test propertynames(p) == (:canopy, :dss_buffer_2d)
+                @test typeof(p.dss_buffer_2d) == typeof(
+                    ClimaCore.Spaces.create_dss_buffer(
+                        ClimaCore.Fields.zeros(domain.space.surface),
+                    ),
+                )
+            end
+
+            dY = similar(Y)
+            for i in 1:(n_stem + n_leaf)
+                Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
+                p.canopy.hydraulics.ψ.:($i) .= NaN
+                p.canopy.hydraulics.fa.:($i) .= NaN
+                dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
+            end
+            set_initial_aux_state! = make_set_initial_aux_state(model)
+            set_initial_aux_state!(p, Y, 0.0)
+            canopy_exp_tendency! = make_exp_tendency(model)
+            canopy_exp_tendency!(dY, Y, p, 0.0)
+
+            m = similar(dY.canopy.hydraulics.ϑ_l.:1)
+            m .= FT(0)
+            for i in 1:(n_stem + n_leaf)
+                @. m += sqrt(dY.canopy.hydraulics.ϑ_l.:($$i)^2.0)
+            end
+            @test maximum(parent(m)) < 200 * eps(FT) # starts in equilibrium
+
+
+            # repeat using the plant hydraulics model directly
+            # make sure it agrees with what we get when use the canopy model ODE
+            Y, p, coords = initialize(model)
+            standalone_dY = similar(Y)
+            for i in 1:(n_stem + n_leaf)
+                Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
+                p.canopy.hydraulics.ψ.:($i) .= NaN
+                p.canopy.hydraulics.fa.:($i) .= NaN
+                standalone_dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
+            end
+            set_initial_aux_state!(p, Y, 0.0)
+            standalone_exp_tendency! =
+                make_compute_exp_tendency(model.hydraulics, model)
+            standalone_exp_tendency!(standalone_dY, Y, p, 0.0)
+
+            m = similar(dY.canopy.hydraulics.ϑ_l.:1)
+            m .= FT(0)
+            for i in 1:(n_stem + n_leaf)
+                @. m += sqrt(dY.canopy.hydraulics.ϑ_l.:($$i)^2.0)
+            end
+            @test maximum(parent(m)) < 10^2.1 * eps(FT) # starts in equilibrium
+        end
     end
 
-    function shortwave_radiation(
-        t::FT;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(1000) # W/m^2
-    end
+    @testset "No plant, FT = $FT" begin
+        domain = Point(; z_sfc = FT(0.0))
 
-    function longwave_radiation(t::FT) where {FT}
-        return FT(200) # W/m^2
-    end
+        AR_params = AutotrophicRespirationParameters{FT}()
+        RTparams = BeerLambertParameters{FT}()
+        photosynthesis_params = FarquharParameters{FT}(C3();)
+        stomatal_g_params = MedlynConductanceParameters{FT}()
 
-    u_atmos = t -> eltype(t)(10) #m.s-1
+        AR_model = AutotrophicRespirationModel{FT}(AR_params)
+        stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
+        photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
+        rt_model = BeerLambertModel{FT}(RTparams)
 
-    liquid_precip = (t) -> eltype(t)(0) # m
-    snow_precip = (t) -> eltype(t)(0) # m
-    T_atmos = t -> eltype(t)(290) # Kelvin
-    q_atmos = t -> eltype(t)(0.001) # kg/kg
-    P_atmos = t -> eltype(t)(1e5) # Pa
-    h_atmos = h_int # m
-    c_atmos = (t) -> eltype(t)(4.11e-4) # mol/mol
-    ref_time = DateTime(2005)
-    atmos = PrescribedAtmosphere(
-        liquid_precip,
-        snow_precip,
-        T_atmos,
-        u_atmos,
-        q_atmos,
-        P_atmos,
-        ref_time,
-        h_atmos;
-        c_co2 = c_atmos,
-    )
-    radiation = PrescribedRadiativeFluxes(
-        FT,
-        shortwave_radiation,
-        longwave_radiation,
-        ref_time;
-        θs = zenith_angle,
-        orbital_data = Insolation.OrbitalData(),
-    )
-    Δz = FT(1.0) # height of compartments
-    n_stem = Int64(5) # number of stem elements
-    n_leaf = Int64(6) # number of leaf elements
-    SAI = FT(1) # m2/m2
-    RAI = FT(1) # m2/m2
-    ai_parameterization =
-        PlantHydraulics.PrescribedSiteAreaIndex{FT}(LAI, SAI, RAI)
-    K_sat_plant = 1.8e-8 # m/s.
-    ψ63 = FT(-4 / 0.0098) # / MPa to m
-    Weibull_param = FT(4) # unitless
-    a = FT(0.05 * 0.0098) # 1/m
-    plant_ν = FT(0.7) # m3/m3
-    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    conductivity_model =
-        PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
-    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-    root_depths = -Array(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0 # 1st element is the deepest root depth 
-    function root_distribution(z::T) where {T}
-        return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-    end
-    compartment_midpoints = Vector(
-        range(
-            start = Δz / 2,
-            step = Δz,
-            stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-        ),
-    )
+        earth_param_set = create_lsm_parameters(FT)
+        LAI = FT(0.0) # m2 [leaf] m-2 [ground]
+        z_0m = FT(2.0) # m, Roughness length for momentum
+        z_0b = FT(0.1) # m, Roughness length for scalars
+        h_c = FT(0.0) # m, canopy height
+        h_sfc = FT(0.0) # m, canopy height
+        h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
+        shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+            z_0m,
+            z_0b,
+            earth_param_set,
+        )
+        lat = FT(0.0) # degree
+        long = FT(-180) # degree
 
-    compartment_surfaces =
-        Vector(range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)))
+        function zenith_angle(
+            t,
+            orbital_data,
+            ref_time;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            return instantaneous_zenith_angle(
+                ref_time + Dates.Second(round(t)),
+                orbital_data,
+                longitude,
+                latitude,
+                insol_params,
+            )[1]
+        end
 
-    param_set = PlantHydraulics.PlantHydraulicsParameters(;
-        ai_parameterization = ai_parameterization,
-        ν = plant_ν,
-        S_s = plant_S_s,
-        root_distribution = root_distribution,
-        conductivity_model = conductivity_model,
-        retention_model = retention_model,
-    )
+        function shortwave_radiation(
+            t;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            return 1000 # W/m^2
+        end
 
-    function leaf_transpiration(t::FT) where {FT}
-        T = FT(1e-8) # m/s
-    end
+        function longwave_radiation(t)
+            return 200 # W/m^2
+        end
 
-    ψ_soil0 = FT(0.0)
+        u_atmos = t -> 10 #m.s-1
 
-    transpiration =
-        PrescribedTranspiration{FT}((t::FT) -> leaf_transpiration(t))
+        liquid_precip = (t) -> 0 # m
+        snow_precip = (t) -> 0 # m
+        T_atmos = t -> 290 # Kelvin
+        q_atmos = t -> 0.001 # kg/kg
+        P_atmos = t -> 1e5 # Pa
+        h_atmos = h_int # m
+        c_atmos = (t) -> 4.11e-4 # mol/mol
+        ref_time = DateTime(2005)
+        atmos = PrescribedAtmosphere(
+            liquid_precip,
+            snow_precip,
+            T_atmos,
+            u_atmos,
+            q_atmos,
+            P_atmos,
+            ref_time,
+            h_atmos;
+            c_co2 = c_atmos,
+        )
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            shortwave_radiation,
+            longwave_radiation,
+            ref_time;
+            θs = zenith_angle,
+            orbital_data = Insolation.OrbitalData(),
+        )
 
-    soil_driver = PrescribedSoil{FT}()
+        n_stem = Int64(0) # number of stem elements
+        n_leaf = Int64(1) # number of leaf elements
+        SAI = FT(0) # m2/m2
+        RAI = FT(0) # m2/m2
+        ai_parameterization =
+            PlantHydraulics.PrescribedSiteAreaIndex{FT}(t -> 0, SAI, RAI)
+        K_sat_plant = 0 # m/s.
+        ψ63 = FT(-4 / 0.0098) # / MPa to m
+        Weibull_param = FT(4) # unitless
+        a = FT(0.05 * 0.0098) # 1/m
+        plant_ν = FT(0.1) # m3/m3
+        plant_S_s = FT(1e-2)
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        root_depths = [FT(0.0)]# 1st element is the deepest root depth
+        function root_distribution(z::T) where {T}
+            return T(0) # (1/m)
+        end
+        compartment_midpoints = [FT(1.0)]
+        compartment_surfaces = [FT(0.0), FT(2.0)]
 
-    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-        parameters = param_set,
-        transpiration = transpiration,
-        n_stem = n_stem,
-        n_leaf = n_leaf,
-        compartment_surfaces = compartment_surfaces,
-        compartment_midpoints = compartment_midpoints,
-    )
-    autotrophic_parameters =
-        ClimaLSM.Canopy.AutotrophicRespirationParameters{FT}()
-    autotrophic_respiration_model =
-        ClimaLSM.Canopy.AutotrophicRespirationModel(autotrophic_parameters)
-    for domain in domains
+        param_set = PlantHydraulics.PlantHydraulicsParameters(;
+            ai_parameterization = ai_parameterization,
+            ν = plant_ν,
+            S_s = plant_S_s,
+            root_distribution = root_distribution,
+            conductivity_model = conductivity_model,
+            retention_model = retention_model,
+        )
+
+        transpiration = DiagnosticTranspiration{FT}()
+        soil_driver = PrescribedSoil{FT}()
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            parameters = param_set,
+            transpiration = transpiration,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_surfaces,
+            compartment_midpoints = compartment_midpoints,
+        )
+
+        autotrophic_parameters =
+            ClimaLSM.Canopy.AutotrophicRespirationParameters{FT}()
+        autotrophic_respiration_model =
+            ClimaLSM.Canopy.AutotrophicRespirationModel(autotrophic_parameters)
+
         model = ClimaLSM.Canopy.CanopyModel{FT}(;
             parameters = shared_params,
             domain = domain,
@@ -266,272 +543,23 @@ end
             atmos = atmos,
             radiation = radiation,
         )
-        # Set system to hydrostatic equilibrium state by setting fluxes to zero, and setting LHS of both ODEs to 0
-        function initial_compute_exp_tendency!(F, Y)
-            AI = (; leaf = LAI(0.0), root = RAI, stem = SAI)
-            T0A = FT(1e-8) * AI[:leaf]
-            for i in 1:(n_leaf + n_stem)
-                if i == 1
-                    fa =
-                        sum(
-                            flux.(
-                                root_depths,
-                                plant_hydraulics.compartment_midpoints[i],
-                                ψ_soil0,
-                                Y[i],
-                                PlantHydraulics.hydraulic_conductivity(
-                                    conductivity_model,
-                                    ψ_soil0,
-                                ),
-                                PlantHydraulics.hydraulic_conductivity(
-                                    conductivity_model,
-                                    Y[i],
-                                ),
-                            ) .* root_distribution.(root_depths) .* (
-                                vcat(root_depths, [0.0])[2:end] -
-                                vcat(root_depths, [0.0])[1:(end - 1)]
-                            ),
-                        ) * AI[:root]
-                else
-                    fa =
-                        flux(
-                            plant_hydraulics.compartment_midpoints[i - 1],
-                            plant_hydraulics.compartment_midpoints[i],
-                            Y[i - 1],
-                            Y[i],
-                            PlantHydraulics.hydraulic_conductivity(
-                                conductivity_model,
-                                ψ_soil0,
-                            ),
-                            PlantHydraulics.hydraulic_conductivity(
-                                conductivity_model,
-                                Y[i],
-                            ),
-                        ) * (
-                            AI[plant_hydraulics.compartment_labels[1]] +
-                            AI[plant_hydraulics.compartment_labels[2]]
-                        ) / 2
-                end
-                F[i] = fa - T0A
-            end
-        end
-
-        soln = nlsolve(
-            initial_compute_exp_tendency!,
-            Vector(-0.03:0.01:0.07);
-            ftol = 1e-11,
-        )
-
-        S_l =
-            inverse_water_retention_curve.(
-                retention_model,
-                soln.zero,
-                plant_ν,
-                plant_S_s,
-            )
-
-        ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
 
         Y, p, coords = initialize(model)
-        if typeof(domain) <: ClimaLSM.Domains.Point
-            @test propertynames(p) == (:canopy,)
-        elseif typeof(domain) <: ClimaLSM.Domains.Plane
-            @test propertynames(p) == (:canopy, :dss_buffer_2d)
-            @test typeof(p.dss_buffer_2d) == typeof(
-                ClimaCore.Spaces.create_dss_buffer(
-                    ClimaCore.Fields.zeros(domain.space.surface),
-                ),
-            )
-        end
-
         dY = similar(Y)
         for i in 1:(n_stem + n_leaf)
-            Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
+            Y.canopy.hydraulics.ϑ_l.:($i) .= FT(0.1)
             p.canopy.hydraulics.ψ.:($i) .= NaN
             p.canopy.hydraulics.fa.:($i) .= NaN
             dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
         end
         set_initial_aux_state! = make_set_initial_aux_state(model)
-        set_initial_aux_state!(p, Y, 0.0)
+        set_initial_aux_state!(p, Y, FT(0.0))
         canopy_exp_tendency! = make_exp_tendency(model)
         canopy_exp_tendency!(dY, Y, p, 0.0)
-
-        m = similar(dY.canopy.hydraulics.ϑ_l.:1)
-        m .= FT(0)
-        for i in 1:(n_stem + n_leaf)
-            @. m += sqrt(dY.canopy.hydraulics.ϑ_l.:($$i)^2.0)
-        end
-        @test maximum(parent(m)) < 1e-11 # starts in equilibrium
+        @test all(parent(dY.canopy.hydraulics.ϑ_l.:1) .≈ FT(0.0))
+        @test all(parent(p.canopy.hydraulics.fa) .≈ FT(0.0))
+        @test all(parent(p.canopy.hydraulics.fa_roots) .≈ FT(0.0))
+        @test all(parent(p.canopy.conductance.transpiration) .≈ FT(0.0))
+        @test all(parent(p.canopy.radiative_transfer.apar) .≈ FT(0.0))
     end
-end
-
-
-@testset "No plant" begin
-    FT = Float64
-    domain = Point(; z_sfc = FT(0.0))
-
-    AR_params = AutotrophicRespirationParameters{FT}()
-    RTparams = BeerLambertParameters{FT}()
-    photosynthesis_params = FarquharParameters{FT}(C3();)
-    stomatal_g_params = MedlynConductanceParameters{FT}()
-
-    AR_model = AutotrophicRespirationModel{FT}(AR_params)
-    stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
-    photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
-    rt_model = BeerLambertModel{FT}(RTparams)
-
-    earth_param_set = create_lsm_parameters(FT)
-    LAI = FT(0.0) # m2 [leaf] m-2 [ground]
-    z_0m = FT(2.0) # m, Roughness length for momentum
-    z_0b = FT(0.1) # m, Roughness length for scalars
-    h_c = FT(0.0) # m, canopy height
-    h_sfc = FT(0.0) # m, canopy height
-    h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
-    shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
-        z_0m,
-        z_0b,
-        earth_param_set,
-    )
-    lat = FT(0.0) # degree
-    long = FT(-180) # degree
-
-    function zenith_angle(
-        t::FT,
-        orbital_data,
-        ref_time;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(
-            instantaneous_zenith_angle(
-                ref_time + Dates.Second(round(t)),
-                orbital_data,
-                longitude,
-                latitude,
-                insol_params,
-            )[1],
-        )
-    end
-
-    function shortwave_radiation(
-        t::FT;
-        latitude = lat,
-        longitude = long,
-        insol_params = earth_param_set.insol_params,
-    ) where {FT}
-        return FT(1000) # W/m^2
-    end
-
-    function longwave_radiation(t::FT) where {FT}
-        return FT(200) # W/m^2
-    end
-
-    u_atmos = t -> eltype(t)(10) #m.s-1
-
-    liquid_precip = (t) -> eltype(t)(0) # m
-    snow_precip = (t) -> eltype(t)(0) # m
-    T_atmos = t -> eltype(t)(290) # Kelvin
-    q_atmos = t -> eltype(t)(0.001) # kg/kg
-    P_atmos = t -> eltype(t)(1e5) # Pa
-    h_atmos = h_int # m
-    c_atmos = (t) -> eltype(t)(4.11e-4) # mol/mol
-    ref_time = DateTime(2005)
-    atmos = PrescribedAtmosphere(
-        liquid_precip,
-        snow_precip,
-        T_atmos,
-        u_atmos,
-        q_atmos,
-        P_atmos,
-        ref_time,
-        h_atmos;
-        c_co2 = c_atmos,
-    )
-    radiation = PrescribedRadiativeFluxes(
-        FT,
-        shortwave_radiation,
-        longwave_radiation,
-        ref_time;
-        θs = zenith_angle,
-        orbital_data = Insolation.OrbitalData(),
-    )
-
-    n_stem = Int64(0) # number of stem elements
-    n_leaf = Int64(1) # number of leaf elements
-    SAI = FT(0) # m2/m2
-    RAI = FT(0) # m2/m2
-    ai_parameterization =
-        PlantHydraulics.PrescribedSiteAreaIndex{FT}(t -> eltype(t)(0), SAI, RAI)
-    K_sat_plant = 0 # m/s.
-    ψ63 = FT(-4 / 0.0098) # / MPa to m
-    Weibull_param = FT(4) # unitless
-    a = FT(0.05 * 0.0098) # 1/m
-    plant_ν = FT(0.1) # m3/m3
-    plant_S_s = FT(1e-2)
-    conductivity_model =
-        PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
-    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-    root_depths = [FT(0.0)]# 1st element is the deepest root depth 
-    function root_distribution(z::T) where {T}
-        return T(0) # (1/m)
-    end
-    compartment_midpoints = [FT(1.0)]
-    compartment_surfaces = [FT(0.0), FT(2.0)]
-
-    param_set = PlantHydraulics.PlantHydraulicsParameters(;
-        ai_parameterization = ai_parameterization,
-        ν = plant_ν,
-        S_s = plant_S_s,
-        root_distribution = root_distribution,
-        conductivity_model = conductivity_model,
-        retention_model = retention_model,
-    )
-
-    transpiration = DiagnosticTranspiration{FT}()
-    soil_driver = PrescribedSoil{FT}()
-    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-        parameters = param_set,
-        transpiration = transpiration,
-        n_stem = n_stem,
-        n_leaf = n_leaf,
-        compartment_surfaces = compartment_surfaces,
-        compartment_midpoints = compartment_midpoints,
-    )
-
-    autotrophic_parameters =
-        ClimaLSM.Canopy.AutotrophicRespirationParameters{FT}()
-    autotrophic_respiration_model =
-        ClimaLSM.Canopy.AutotrophicRespirationModel(autotrophic_parameters)
-
-    model = ClimaLSM.Canopy.CanopyModel{FT}(;
-        parameters = shared_params,
-        domain = domain,
-        autotrophic_respiration = autotrophic_respiration_model,
-        radiative_transfer = rt_model,
-        photosynthesis = photosynthesis_model,
-        conductance = stomatal_model,
-        hydraulics = plant_hydraulics,
-        soil_driver = soil_driver,
-        atmos = atmos,
-        radiation = radiation,
-    )
-
-    Y, p, coords = initialize(model)
-    dY = similar(Y)
-    for i in 1:(n_stem + n_leaf)
-        Y.canopy.hydraulics.ϑ_l.:($i) .= FT(0.1)
-        p.canopy.hydraulics.ψ.:($i) .= NaN
-        p.canopy.hydraulics.fa.:($i) .= NaN
-        dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
-    end
-    set_initial_aux_state! = make_set_initial_aux_state(model)
-    set_initial_aux_state!(p, Y, FT(0.0))
-    canopy_exp_tendency! = make_exp_tendency(model)
-    canopy_exp_tendency!(dY, Y, p, 0.0)
-    @test all(parent(dY.canopy.hydraulics.ϑ_l.:1) .≈ FT(0.0))
-    @test all(parent(p.canopy.hydraulics.fa) .≈ FT(0.0))
-    @test all(parent(p.canopy.hydraulics.fa_roots) .≈ FT(0.0))
-    @test all(parent(p.canopy.conductance.transpiration) .≈ FT(0.0))
-    @test all(parent(p.canopy.radiative_transfer.apar) .≈ FT(0.0))
 end

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -6,205 +6,244 @@ import ClimaLSM
 import ClimaLSM.Parameters as LSMP
 
 include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"))
-@testset "Big Leaf Parameterizations" begin
-    FT = Float32
-    earth_param_set = create_lsm_parameters(FT)
-    # Test with defaults
-    ARparams = AutotrophicRespirationParameters{FT}()
-    RTparams = BeerLambertParameters{FT}()
-    RT = BeerLambertModel{FT}(RTparams)
-    photosynthesisparams = FarquharParameters{FT}(C3();)
-    stomatal_g_params = MedlynConductanceParameters{FT}()
 
-    LAI = FT(5.0) # m2 (leaf) m-2 (ground)
-    RAI = FT(1.0)
-    thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
-    c = FT(LSMP.light_speed(earth_param_set))
-    h = FT(LSMP.planck_constant(earth_param_set))
-    N_a = FT(LSMP.avogadro_constant(earth_param_set))
-    λ = FT(5e-7) # m (500 nm)
-    energy_per_photon = h * c / λ
+for FT in (Float32, Float64)
+    @testset "Big Leaf Parameterizations, FT = $FT" begin
+        earth_param_set = create_lsm_parameters(FT)
+        # Test with defaults
+        ARparams = AutotrophicRespirationParameters{FT}()
+        RTparams = BeerLambertParameters{FT}()
+        RT = BeerLambertModel{FT}(RTparams)
+        photosynthesisparams = FarquharParameters{FT}(C3();)
+        stomatal_g_params = MedlynConductanceParameters{FT}()
 
-    # Drivers
-    T = FT(290) # K
-    P = FT(101250) #Pa
-    q = FT(0.02)
-    VPD = ClimaLSM.vapor_pressure_deficit(T, P, q, thermo_params)#Pa
-    p_l = FT(-2e6) # Pa
-    ca = FT(4.11e-4) # mol/mol
-    R = FT(LSMP.gas_constant(earth_param_set))
-    θs = FT.(Array(0:0.1:(π / 2)))
-    SW(θs) = cos.(θs) * FT.(500) # W/m^2
-    PAR = SW(θs) ./ (energy_per_photon * N_a) # convert 500 W/m^2 to mol of photons per m^2/s
-    K_c = extinction_coeff.(RTparams.ld, θs)
-    @test all(K_c .≈ RTparams.ld ./ cos.(θs))
-    α_soil_PAR = FT(0.2)
-    output =
-        plant_absorbed_pfd.(RT, PAR, RTparams.α_PAR_leaf, LAI, K_c, α_soil_PAR)
-    APAR = getproperty.(output, :abs)
-    TPAR = getproperty.(output, :trans)
-    RPAR = getproperty.(output, :refl)
-    @test all(@. TPAR ≈ PAR * exp(-K_c * LAI * RTparams.Ω))
-    @test all(@. RPAR ≈ PAR - APAR - TPAR * (1 - α_soil_PAR))
+        LAI = FT(5.0) # m2 (leaf) m-2 (ground)
+        RAI = FT(1.0)
+        thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
+        c = FT(LSMP.light_speed(earth_param_set))
+        h = FT(LSMP.planck_constant(earth_param_set))
+        N_a = FT(LSMP.avogadro_constant(earth_param_set))
+        λ = FT(5e-7) # m (500 nm)
+        energy_per_photon = h * c / λ
 
-    @test all(
-        @. APAR ≈
-           PAR * (1 - RTparams.α_PAR_leaf) .*
-           (1 - exp(-K_c * LAI * RTparams.Ω)) * (1 - α_soil_PAR)
-    )
-    To = photosynthesisparams.To
-    Vcmax =
-        photosynthesisparams.Vcmax25 *
-        arrhenius_function(T, To, R, photosynthesisparams.ΔHVcmax)
-    Kc = MM_Kc(photosynthesisparams.Kc25, photosynthesisparams.ΔHkc, T, To, R)
-    Ko = MM_Ko(photosynthesisparams.Ko25, photosynthesisparams.ΔHko, T, To, R)
-    Γstar = co2_compensation(
-        photosynthesisparams.Γstar25,
-        photosynthesisparams.ΔHΓstar,
-        T,
-        To,
-        R,
-    )
+        # Drivers
+        T = FT(290) # K
+        P = FT(101250) #Pa
+        q = FT(0.02)
+        VPD = ClimaLSM.vapor_pressure_deficit(T, P, q, thermo_params)#Pa
+        p_l = FT(-2e6) # Pa
+        ca = FT(4.11e-4) # mol/mol
+        R = FT(LSMP.gas_constant(earth_param_set))
+        θs = FT.(Array(0:0.1:(π / 2)))
+        SW(θs) = cos.(θs) * FT.(500) # W/m^2
+        PAR = SW(θs) ./ (energy_per_photon * N_a) # convert 500 W/m^2 to mol of photons per m^2/s
+        K_c = extinction_coeff.(RTparams.ld, θs)
+        @test all(K_c .≈ RTparams.ld ./ cos.(θs))
+        α_soil_PAR = FT(0.2)
+        output =
+            plant_absorbed_pfd.(
+                RT,
+                PAR,
+                RTparams.α_PAR_leaf,
+                LAI,
+                K_c,
+                α_soil_PAR,
+            )
+        APAR = getproperty.(output, :abs)
+        TPAR = getproperty.(output, :trans)
+        RPAR = getproperty.(output, :refl)
+        @test all(@. TPAR ≈ PAR * exp(-K_c * LAI * RTparams.Ω))
+        @test all(@. RPAR ≈ PAR - APAR - TPAR * (1 - α_soil_PAR))
 
-    @test photosynthesisparams.Kc25 *
-          arrhenius_function(T, To, R, photosynthesisparams.ΔHkc) ≈ Kc
-    @test photosynthesisparams.Ko25 *
-          arrhenius_function(T, To, R, photosynthesisparams.ΔHko) ≈ Ko
-    @test photosynthesisparams.Γstar25 *
-          arrhenius_function(T, To, R, photosynthesisparams.ΔHΓstar) ≈ Γstar
-    @test photosynthesisparams.Vcmax25 *
-          arrhenius_function(T, To, R, photosynthesisparams.ΔHVcmax) ≈ Vcmax
-
-    m_t = medlyn_term(stomatal_g_params.g1, T, P, q, thermo_params)
-
-    @test m_t == 1 + stomatal_g_params.g1 / sqrt(VPD)
-    ci = intercellular_co2(ca, Γstar, m_t)
-    @test ci == ca * (1 - 1 / m_t)
-    @test intercellular_co2(ca, FT(1), m_t) == FT(1)
-
-    Ac = rubisco_assimilation(
-        photosynthesisparams.mechanism,
-        Vcmax,
-        ci,
-        Γstar,
-        Kc,
-        Ko,
-        photosynthesisparams.oi,
-    )
-    @test Ac ==
-          Vcmax * (ci - Γstar) / (ci + Kc * (1 + photosynthesisparams.oi / Ko))
-    Jmax = max_electron_transport(
-        photosynthesisparams.Vcmax25,
-        photosynthesisparams.ΔHJmax,
-        T,
-        To,
-        R,
-    )
-    @test Jmax ==
-          photosynthesisparams.Vcmax25 *
-          FT(exp(1)) *
-          arrhenius_function(T, To, R, photosynthesisparams.ΔHJmax)
-    J =
-        electron_transport.(
-            APAR,
-            Jmax,
-            photosynthesisparams.θj,
-            photosynthesisparams.ϕ,
-        ) # mol m-2 s-1
-    @test all(
-        @.(
-            photosynthesisparams.θj * J^2 -
-            (photosynthesisparams.ϕ * APAR / 2 + Jmax) * J +
-            photosynthesisparams.ϕ * APAR / 2 * Jmax < eps(FT)
+        @test all(
+            @. APAR ≈
+               PAR * (1 - RTparams.α_PAR_leaf) .*
+               (1 - exp(-K_c * LAI * RTparams.Ω)) * (1 - α_soil_PAR)
         )
-    )
-
-    Aj = light_assimilation.(Ref(photosynthesisparams.mechanism), J, ci, Γstar)
-    @test all(@.(Aj == J * (ci - Γstar) / (4 * (ci + 2 * Γstar))))
-    β = moisture_stress(p_l, photosynthesisparams.sc, photosynthesisparams.pc)
-    @test β ==
-          (1 + exp(photosynthesisparams.sc * photosynthesisparams.pc)) /
-          (1 + exp(photosynthesisparams.sc * (p_l - photosynthesisparams.pc)))
-    #    C4 tests
-    @test rubisco_assimilation(
-        C4(),
-        Vcmax,
-        ci,
-        Γstar,
-        Kc,
-        Ko,
-        photosynthesisparams.oi,
-    ) == Vcmax
-    @test light_assimilation(C4(), J, ci, Γstar) == J
-
-    Rd = dark_respiration(
-        photosynthesisparams.Vcmax25,
-        β,
-        photosynthesisparams.f,
-        photosynthesisparams.ΔHRd,
-        T,
-        To,
-        R,
-    )
-    @test Rd ≈
-          photosynthesisparams.Vcmax25 *
-          β *
-          photosynthesisparams.f *
-          arrhenius_function(T, To, R, photosynthesisparams.ΔHRd)
-    An = net_photosynthesis.(Ac, Aj, Rd, β)
-    stomatal_conductance =
-        medlyn_conductance.(
-            stomatal_g_params.g0,
-            stomatal_g_params.Drel,
-            m_t,
-            An,
-            ca,
+        To = photosynthesisparams.To
+        Vcmax =
+            photosynthesisparams.Vcmax25 *
+            arrhenius_function(T, To, R, photosynthesisparams.ΔHVcmax)
+        Kc = MM_Kc(
+            photosynthesisparams.Kc25,
+            photosynthesisparams.ΔHkc,
+            T,
+            To,
+            R,
         )
-    @test all(
-        @.(
-            stomatal_conductance ≈
-            (stomatal_g_params.g0 + stomatal_g_params.Drel * m_t * (An / ca))
+        Ko = MM_Ko(
+            photosynthesisparams.Ko25,
+            photosynthesisparams.ΔHko,
+            T,
+            To,
+            R,
         )
-    )
-    GPP = compute_GPP.(An, K_c, LAI, RTparams.Ω) # mol m-2 s-1
-    @test all(
-        @.(GPP ≈ An * (1 - exp(-K_c * LAI * RTparams.Ω)) / (K_c * RTparams.Ω))
-    )
-
-    @test all(
-        @.(
-            upscale_leaf_conductance(stomatal_conductance, LAI, T, R, P) ≈
-            stomatal_conductance * LAI * R * T / P
+        Γstar = co2_compensation(
+            photosynthesisparams.Γstar25,
+            photosynthesisparams.ΔHΓstar,
+            T,
+            To,
+            R,
         )
-    )
 
-    # Tests for Autotrophic Respiration parameterisation
-    h_canopy = FT(1.0) # h planck defined above
-    Nl, Nr, Ns = nitrogen_content(
-        ARparams.ne,
-        photosynthesisparams.Vcmax25,
-        LAI,
-        RAI,
-        ARparams.ηsl,
-        h_canopy,
-        ARparams.σl,
-        ARparams.μr,
-        ARparams.μs,
-    )
-    Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns, ARparams.f1)
-    Rg = plant_respiration_growth.(ARparams.f2, GPP, Rpm)
+        @test photosynthesisparams.Kc25 *
+              arrhenius_function(T, To, R, photosynthesisparams.ΔHkc) ≈ Kc
+        @test photosynthesisparams.Ko25 *
+              arrhenius_function(T, To, R, photosynthesisparams.ΔHko) ≈ Ko
+        @test photosynthesisparams.Γstar25 *
+              arrhenius_function(T, To, R, photosynthesisparams.ΔHΓstar) ≈ Γstar
+        @test photosynthesisparams.Vcmax25 *
+              arrhenius_function(T, To, R, photosynthesisparams.ΔHVcmax) ≈ Vcmax
 
-    @test Nl == photosynthesisparams.Vcmax25 / ARparams.ne * ARparams.σl * LAI
-    @test Nr ==
-          ARparams.μr * photosynthesisparams.Vcmax25 / ARparams.ne *
-          ARparams.σl *
-          RAI
-    @test Ns ≈
-          ARparams.μs * photosynthesisparams.Vcmax25 / ARparams.ne *
-          ARparams.ηsl *
-          h_canopy *
-          LAI # == gives a very small error
-    @test Rpm == ARparams.f1 * Rd * (β + (Nr + Ns) / Nl)
-    @test all(@.(Rg ≈ ARparams.f2 * (GPP - Rpm)))
+        m_t = medlyn_term(stomatal_g_params.g1, T, P, q, thermo_params)
 
+        @test m_t == 1 + stomatal_g_params.g1 / sqrt(VPD)
+        ci = intercellular_co2(ca, Γstar, m_t)
+        @test ci == ca * (1 - 1 / m_t)
+        @test intercellular_co2(ca, FT(1), m_t) == FT(1)
+
+        Ac = rubisco_assimilation(
+            photosynthesisparams.mechanism,
+            Vcmax,
+            ci,
+            Γstar,
+            Kc,
+            Ko,
+            photosynthesisparams.oi,
+        )
+        @test Ac ==
+              Vcmax * (ci - Γstar) /
+              (ci + Kc * (1 + photosynthesisparams.oi / Ko))
+        Jmax = max_electron_transport(
+            photosynthesisparams.Vcmax25,
+            photosynthesisparams.ΔHJmax,
+            T,
+            To,
+            R,
+        )
+        @test Jmax ==
+              photosynthesisparams.Vcmax25 *
+              FT(exp(1)) *
+              arrhenius_function(T, To, R, photosynthesisparams.ΔHJmax)
+        J =
+            electron_transport.(
+                APAR,
+                Jmax,
+                photosynthesisparams.θj,
+                photosynthesisparams.ϕ,
+            ) # mol m-2 s-1
+        @test all(
+            @.(
+                photosynthesisparams.θj * J^2 -
+                (photosynthesisparams.ϕ * APAR / 2 + Jmax) * J +
+                photosynthesisparams.ϕ * APAR / 2 * Jmax < eps(FT)
+            )
+        )
+
+        Aj =
+            light_assimilation.(
+                Ref(photosynthesisparams.mechanism),
+                J,
+                ci,
+                Γstar,
+            )
+        @test all(@.(Aj == J * (ci - Γstar) / (4 * (ci + 2 * Γstar))))
+        β = moisture_stress(
+            p_l,
+            photosynthesisparams.sc,
+            photosynthesisparams.pc,
+        )
+        @test β ==
+              (1 + exp(photosynthesisparams.sc * photosynthesisparams.pc)) / (
+            1 + exp(photosynthesisparams.sc * (p_l - photosynthesisparams.pc))
+        )
+        #    C4 tests
+        @test rubisco_assimilation(
+            C4(),
+            Vcmax,
+            ci,
+            Γstar,
+            Kc,
+            Ko,
+            photosynthesisparams.oi,
+        ) == Vcmax
+        @test light_assimilation(C4(), J, ci, Γstar) == J
+
+        Rd = dark_respiration(
+            photosynthesisparams.Vcmax25,
+            β,
+            photosynthesisparams.f,
+            photosynthesisparams.ΔHRd,
+            T,
+            To,
+            R,
+        )
+        @test Rd ≈
+              photosynthesisparams.Vcmax25 *
+              β *
+              photosynthesisparams.f *
+              arrhenius_function(T, To, R, photosynthesisparams.ΔHRd)
+        An = net_photosynthesis.(Ac, Aj, Rd, β)
+        stomatal_conductance =
+            medlyn_conductance.(
+                stomatal_g_params.g0,
+                stomatal_g_params.Drel,
+                m_t,
+                An,
+                ca,
+            )
+        @test all(
+            @.(
+                stomatal_conductance ≈ (
+                    stomatal_g_params.g0 +
+                    stomatal_g_params.Drel * m_t * (An / ca)
+                )
+            )
+        )
+        GPP = compute_GPP.(An, K_c, LAI, RTparams.Ω) # mol m-2 s-1
+        @test all(
+            @.(
+                GPP ≈
+                An * (1 - exp(-K_c * LAI * RTparams.Ω)) / (K_c * RTparams.Ω)
+            )
+        )
+
+        @test all(
+            @.(
+                upscale_leaf_conductance(stomatal_conductance, LAI, T, R, P) ≈
+                stomatal_conductance * LAI * R * T / P
+            )
+        )
+
+        # Tests for Autotrophic Respiration parameterisation
+        h_canopy = FT(1.0) # h planck defined above
+        Nl, Nr, Ns = nitrogen_content(
+            ARparams.ne,
+            photosynthesisparams.Vcmax25,
+            LAI,
+            RAI,
+            ARparams.ηsl,
+            h_canopy,
+            ARparams.σl,
+            ARparams.μr,
+            ARparams.μs,
+        )
+        Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns, ARparams.f1)
+        Rg = plant_respiration_growth.(ARparams.f2, GPP, Rpm)
+
+        @test Nl ==
+              photosynthesisparams.Vcmax25 / ARparams.ne * ARparams.σl * LAI
+        @test Nr ==
+              ARparams.μr * photosynthesisparams.Vcmax25 / ARparams.ne *
+              ARparams.σl *
+              RAI
+        @test Ns ≈
+              ARparams.μs * photosynthesisparams.Vcmax25 / ARparams.ne *
+              ARparams.ηsl *
+              h_canopy *
+              LAI # == gives a very small error
+        @test Rpm == ARparams.f1 * Rd * (β + (Nr + Ns) / Nl)
+        @test all(@.(Rg ≈ ARparams.f2 * (GPP - Rpm)))
+
+    end
 end

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -1,8 +1,8 @@
-# This script tests the output of the ClimaLSM TwoStream implementation 
-# against the T. Quaife pySellersTwoStream implementation by providing 
+# This script tests the output of the ClimaLSM TwoStream implementation
+# against the T. Quaife pySellersTwoStream implementation by providing
 # the same setups to each model and checking that the outputs are equal.
-# The output of the python module for a variety of inputs is given in the 
-# linked file which then gets read and compared to the Clima version, ensuring 
+# The output of the python module for a variety of inputs is given in the
+# linked file which then gets read and compared to the Clima version, ensuring
 # the FAPAR of each model is within 1/2 of a percentage point.
 
 using Test
@@ -10,9 +10,6 @@ using ClimaLSM
 using ClimaLSM.Canopy
 using DelimitedFiles
 using ArtifactWrappers
-
-# Floating point precision to use
-FT = Float32
 
 # Get the test data
 data_file = ArtifactWrapper(
@@ -27,60 +24,61 @@ datapath = get_data_folder(data_file)
 data = joinpath(datapath, "2_str_test_data.csv")
 test_set = readdlm(data, ',')
 
-# Read the conditions for each setup parameter from the test file
-column_names = test_set[1, :]
-θs = acos.(FT.(test_set[2:end, column_names .== "mu"]))
-LAI = FT.(test_set[2:end, column_names .== "LAI"])
-ld = FT.(test_set[2:end, column_names .== "ld"])
-α_PAR_leaf = FT.(test_set[2:end, column_names .== "rho"])
-τ = FT.(test_set[2:end, column_names .== "tau"])
-a_soil = FT.(test_set[2:end, column_names .== "a_soil"])
-n_layers = UInt64.(test_set[2:end, column_names .== "n_layers"])
-PropDif = FT.(test_set[2:end, column_names .== "prop_diffuse"])
+# Floating point precision to use
+for FT in (Float32, Float64)
+    @testset "Two-Stream Model Correctness, FT = $FT" begin
+        # Read the conditions for each setup parameter from the test file
+        column_names = test_set[1, :]
+        θs = acos.(FT.(test_set[2:end, column_names .== "mu"]))
+        LAI = FT.(test_set[2:end, column_names .== "LAI"])
+        ld = FT.(test_set[2:end, column_names .== "ld"])
+        α_PAR_leaf = FT.(test_set[2:end, column_names .== "rho"])
+        τ = FT.(test_set[2:end, column_names .== "tau"])
+        a_soil = FT.(test_set[2:end, column_names .== "a_soil"])
+        n_layers = UInt64.(test_set[2:end, column_names .== "n_layers"])
+        PropDif = FT.(test_set[2:end, column_names .== "prop_diffuse"])
 
-# Read the result for each setup from the Python output
-py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
+        # Read the result for each setup from the Python output
+        py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
 
-# Python code does not use clumping index, and λ_γ does not impact FAPAR
-Ω = FT(1)
-λ_γ_PAR = FT(5e-7)
-λ_γ_NIR = FT(1.65e-6)
+        # Python code does not use clumping index, and λ_γ does not impact FAPAR
+        Ω = FT(1)
+        λ_γ_PAR = FT(5e-7)
+        λ_γ_NIR = FT(1.65e-6)
 
-@testset "Two-Stream Model Correctness" begin
+        # Test over all rows in the stored output from the Python module
+        for i in 2:(size(test_set, 1) - 1)
 
-    # Test over all rows in the stored output from the Python module
-    for i in 2:(size(test_set, 1) - 1)
+            # Set the parameters based on the setup read from the file
+            RT_params = TwoStreamParameters{FT}(;
+                ld = ld[i],
+                α_PAR_leaf = α_PAR_leaf[i],
+                τ_PAR_leaf = τ[i],
+                Ω = Ω,
+                λ_γ_PAR = λ_γ_PAR,
+                λ_γ_NIR = λ_γ_NIR,
+                n_layers = n_layers[i],
+            )
 
-        # Set the parameters based on the setup read from the file
-        RT_params = TwoStreamParameters{FT}(;
-            ld = ld[i],
-            α_PAR_leaf = α_PAR_leaf[i],
-            τ_PAR_leaf = τ[i],
-            Ω = Ω,
-            λ_γ_PAR = λ_γ_PAR,
-            λ_γ_NIR = λ_γ_NIR,
-            n_layers = n_layers[i],
-        )
+            # Initialize the TwoStream model
+            RT = TwoStreamModel(RT_params)
 
-        # Initialize the TwoStream model
-        RT = TwoStreamModel(RT_params)
-
-        # Compute the predicted FAPAR using the ClimaLSM TwoStream implementation
-        K = extinction_coeff(ld[i], θs[i])
-        output = plant_absorbed_pfd(
-            RT,
-            FT(1),
-            RT_params.α_PAR_leaf,
-            RT_params.τ_PAR_leaf,
-            LAI[i],
-            K,
-            θs[i],
-            a_soil[i],
-            PropDif[i],
-        )
-        FAPAR = output.abs
-        # Check that the predictions are app. equivalent to the Python model
-        @test isapprox(py_FAPAR[i], FAPAR, atol = 0.005)
-
+            # Compute the predicted FAPAR using the ClimaLSM TwoStream implementation
+            K = extinction_coeff(ld[i], θs[i])
+            output = plant_absorbed_pfd(
+                RT,
+                FT(1),
+                RT_params.α_PAR_leaf,
+                RT_params.τ_PAR_leaf,
+                LAI[i],
+                K,
+                θs[i],
+                a_soil[i],
+                PropDif[i],
+            )
+            FAPAR = output.abs
+            # Check that the predictions are app. equivalent to the Python model
+            @test isapprox(py_FAPAR[i], FAPAR, atol = 0.005)
+        end
     end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
fixes #327, #229

### Notes
- code extending tests to cover Float32 and Float64 is on branch js/float32-tests - will need to cherry pick these changes onto this branch
  - tests won't pass until other changes are made (`t::FT` and `eltype(t)`) - make those changes first
- idea: it may be helpful to add a flag that checks that our t_start/dt/t_end/FT setup won't exceed the FT's precision - if it does, give warning to user

## To-do
- [x] remove `t::FT` type annotations
- [x] remove `eltype(t)(...)` usage
  - ex https://github.com/CliMA/ClimaLSM.jl/blob/main/docs/tutorials/Bucket/bucket_tutorial.jl#L229-L230
  - in tests, this can be replaced by `FT(...)`
  - [x] functions of time that return `eltype(t)(result)` --> instead convert to FT where function called from
  - [x] boundary conditions, PrescribedAtmosphere, PrescribedRadiativeFluxes, canopy prescribed soil moisture, canopy transpiration
- [x] make sure tests cover Float64 and Float32
- [ ] make sure simulations try Float64 and Float32 - this will be a separate PR #384
  - idea: loop over `(FT, t_end)`, run Float32 only for a couple steps. At end of sim, if statement for FT which tests final type for both and makes plots for Float64
  - alt idea: loop over `FT`, run `solve` for Float64 and `step` for Float32. At end of sim, if statement for FT which tests final type for both and makes plots for Float64
- [x] add documentation for how to maintain Float32 and Float64 compatibility (in [wiki](https://github.com/CliMA/ClimaLSM.jl/wiki/Floating-point-precision-issues))


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
