### PR TITLE
Canopy boundary fluxes rhs/LW computation

### DIFF
--- a/docs/src/APIs/canopy/RadiativeTransfer.md
+++ b/docs/src/APIs/canopy/RadiativeTransfer.md
@@ -16,4 +16,6 @@ ClimaLSM.Canopy.BeerLambertParameters
 ClimaLSM.Canopy.compute_absorbances
 ClimaLSM.Canopy.plant_absorbed_pfd
 ClimaLSM.Canopy.extinction_coeff
+ClimaLSM.Canopy.extinction_coeff
+ClimaLSM.Canopy.canopy_radiant_energy_fluxes!
 ```

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -297,7 +297,8 @@ include("standalone/Vegetation/Canopy.jl")
 using .Canopy
 using .Canopy.PlantHydraulics
 import .Canopy.PlantHydraulics: root_water_flux_per_ground_area!
-import .Canopy: ground_albedo_PAR, ground_albedo_NIR
+import .Canopy:
+    ground_albedo_PAR, ground_albedo_NIR, canopy_radiant_energy_fluxes!
 ### Concrete types of AbstractLandModels
 ### and associated methods
 include("integrated/soil_energy_hydrology_biogeochemistry.jl")

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -19,14 +19,7 @@ import ClimaLSM:
     initialize_auxiliary,
     make_update_aux,
     make_compute_exp_tendency,
-    make_set_initial_aux_state,
-    canopy_turbulent_surface_fluxes,
-    surface_temperature,
-    surface_specific_humidity,
-    surface_air_density,
-    surface_evaporative_scaling,
-    surface_height,
-    surface_resistance
+    make_set_initial_aux_state
 
 using ClimaLSM.Domains: Point, Plane, SphericalSurface
 export SharedCanopyParameters,
@@ -206,6 +199,7 @@ canopy_components(::CanopyModel) = (
     :photosynthesis,
     :radiative_transfer,
     :autotrophic_respiration,
+    :energy,
 )
 
 """
@@ -559,18 +553,6 @@ function ClimaLSM.make_update_aux(
             β,
             h,
         )
-        # Compute transpiration using T_canopy
-        (canopy_transpiration, shf, lhf) =
-            canopy_turbulent_surface_fluxes(canopy.atmos, canopy, Y, p, t)
-        transpiration .= canopy_transpiration
-        # Transpiration is per unit ground area, not leaf area (mult by LAI)
-        fa.:($i_end) .= PlantHydraulics.transpiration_per_ground_area(
-            hydraulics.transpiration,
-            Y,
-            p,
-            t,
-        )
-
     end
     return update_aux!
 end
@@ -579,156 +561,36 @@ end
     make_compute_exp_tendency(canopy::CanopyModel)
 
 Creates and returns the compute_exp_tendency! for the `CanopyModel`.
-
-This allows for prognostic variables in each canopy component, and
-specifies that they will be stepped explicitly.
 """
-function make_compute_exp_tendency(canopy::CanopyModel)
+function make_compute_exp_tendency(
+    canopy::CanopyModel{
+        FT,
+        <:AutotrophicRespirationModel,
+        <:Union{BeerLambertModel, TwoStreamModel},
+        <:FarquharModel,
+        <:MedlynConductanceModel,
+        <:PlantHydraulicsModel,
+        <:PrescribedCanopyTempModel,
+    },
+) where {FT}
     components = canopy_components(canopy)
     compute_exp_tendency_list = map(
         x -> make_compute_exp_tendency(getproperty(canopy, x), canopy),
         components,
     )
     function compute_exp_tendency!(dY, Y, p, t)
+        # First we need to compute/update in place the boundary fluxes for
+        # the component models.
+        canopy_boundary_fluxes!(p, canopy, canopy.radiation, canopy.atmos, Y, t)
+        # Then we execute the tendency
         for f! in compute_exp_tendency_list
             f!(dY, Y, p, t)
         end
+
     end
     return compute_exp_tendency!
 end
-
-"""
-    canopy_turbulent_surface_fluxes(atmos::PrescribedAtmosphere{FT},
-                          model::CanopyModel,
-                          Y,
-                          p,
-                          t::FT) where {FT}
-
-Computes canopy transpiration using Monin-Obukhov Surface Theory,
-the prescribed atmospheric conditions, and the canopy conductance.
-
-Please note that in the future the SurfaceFluxes.jl code will compute
-fluxes taking into account the canopy conductance, so that
-what is returned by `surface_fluxes` is correct. At present, it does not,
-so we are adjusting for it after the fact here in both ET and LHF.
-"""
-function canopy_turbulent_surface_fluxes(
-    atmos::PrescribedAtmosphere{FT},
-    model::CanopyModel,
-    Y,
-    p,
-    t::FT,
-) where {FT}
-    conditions = surface_fluxes(atmos, model, Y, p, t) # per unit m^2 of leaf
-    return conditions.vapor_flux, conditions.shf, conditions.lhf
-end
-
-"""
-    ClimaLSM.surface_resistance(
-        model::CanopyModel{FT},
-        Y,
-        p,
-        t,
-    ) where {FT}
-Returns the surface resistance field of the
-`CanopyModel` canopy.
-"""
-function ClimaLSM.surface_resistance(model::CanopyModel{FT}, Y, p, t) where {FT}
-    earth_param_set = model.parameters.earth_param_set
-    R = FT(LSMP.gas_constant(earth_param_set))
-    ρ_liq = FT(LSMP.ρ_cloud_liq(earth_param_set))
-    P_air::FT = model.atmos.P(t)
-    T_air::FT = model.atmos.T(t)
-    leaf_conductance = p.canopy.conductance.gs
-    canopy_conductance =
-        upscale_leaf_conductance.(
-            leaf_conductance,
-            p.canopy.hydraulics.area_index.leaf,
-            T_air,
-            R,
-            P_air,
-        )
-    return 1 ./ canopy_conductance # [s/m]
-end
-
-"""
-    ClimaLSM.surface_temperature(model::CanopyModel, Y, p, t)
-
-A helper function which returns the surface temperature for the canopy
-model, which is stored in the aux state.
-"""
-function ClimaLSM.surface_temperature(model::CanopyModel, Y, p, t)
-    return canopy_temperature(model.energy, model, Y, p, t)
-end
-
-"""
-    ClimaLSM.surface_height(model::CanopyModel, Y, _...)
-
-A helper function which returns the surface height for the canopy
-model, which is stored in the parameter struct.
-"""
-function ClimaLSM.surface_height(model::CanopyModel, _...)
-    return model.hydraulics.compartment_surfaces[end]
-end
-
-"""
-    ClimaLSM.surface_specific_humidity(model::CanopyModel, Y, p)
-
-A helper function which returns the surface specific humidity for the canopy
-model, which is stored in the aux state.
-"""
-function ClimaLSM.surface_specific_humidity(
-    model::CanopyModel,
-    Y,
-    p,
-    T_canopy,
-    ρ_canopy,
-)
-    thermo_params =
-        LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    return Thermodynamics.q_vap_saturation_generic.(
-        Ref(thermo_params),
-        T_canopy,
-        ρ_canopy,
-        Ref(Thermodynamics.Liquid()),
-    )
-end
-
-"""
-    ClimaLSM.surface_air_density(model::CanopyModel, Y, p)
-
-A helper function which computes and returns the surface air density for the canopy
-model.
-"""
-function ClimaLSM.surface_air_density(
-    atmos::PrescribedAtmosphere,
-    model::CanopyModel,
-    Y,
-    p,
-    t,
-    T_canopy,
-)
-    thermo_params =
-        LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    ts_in = construct_atmos_ts(atmos, t, thermo_params)
-    return compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_canopy)
-end
-
-"""
-    ClimaLSM.surface_evaporative_scaling(model::CanopyModel, Y, p)
-
-A helper function which computes and returns the surface evaporative scaling
- factor for the canopy model.
-"""
-function ClimaLSM.surface_evaporative_scaling(
-    model::CanopyModel{FT},
-    Y,
-    p,
-) where {FT}
-    beta = FT(1.0)
-    return beta
-end
-
+include("./canopy_boundary_fluxes.jl")
 #Make the canopy model broadcastable
 Base.broadcastable(C::CanopyModel) = tuple(C)
 

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -548,15 +548,6 @@ function make_compute_exp_tendency(model::PlantHydraulicsModel, canopy)
                     eps(FT),
                 )
             if i == 1
-                # All fluxes `fa` are per unit area of ground
-                root_water_flux_per_ground_area!(
-                    fa_roots,
-                    canopy.soil_driver,
-                    model,
-                    Y,
-                    p,
-                    t,
-                )
                 @inbounds @. dY.canopy.hydraulics.ϑ_l.:($$i) =
                     1 / AIdz * (fa_roots - fa.:($$i))
             else

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -1,0 +1,216 @@
+import ClimaLSM:
+    surface_temperature,
+    surface_specific_humidity,
+    surface_air_density,
+    surface_evaporative_scaling,
+    surface_height,
+    surface_resistance
+
+export canopy_turbulent_surface_fluxes
+
+"""
+    canopy_turbulent_surface_fluxes(atmos::PrescribedAtmosphere{FT},
+                          model::CanopyModel,
+                          Y,
+                          p,
+                          t::FT) where {FT}
+
+Computes canopy transpiration using Monin-Obukhov Surface Theory,
+the prescribed atmospheric conditions, and the canopy conductance.
+"""
+function canopy_turbulent_surface_fluxes(
+    atmos::PrescribedAtmosphere{FT},
+    model::CanopyModel,
+    Y,
+    p,
+    t::FT,
+) where {FT}
+    conditions = surface_fluxes(atmos, model, Y, p, t)
+    # We upscaled LHF and E from leaf level to canopy level via the
+    # upscaling of stomatal conductance.
+    # Do we need to upscale SHF? 
+    return conditions.vapor_flux, conditions.shf, conditions.lhf
+end
+
+"""
+    ClimaLSM.surface_resistance(
+        model::CanopyModel{FT},
+        Y,
+        p,
+        t,
+    ) where {FT}
+Returns the surface resistance field of the
+`CanopyModel` canopy.
+"""
+function ClimaLSM.surface_resistance(model::CanopyModel{FT}, Y, p, t) where {FT}
+    earth_param_set = model.parameters.earth_param_set
+    R = FT(LSMP.gas_constant(earth_param_set))
+    ρ_liq = FT(LSMP.ρ_cloud_liq(earth_param_set))
+    P_air::FT = model.atmos.P(t)
+    T_air::FT = model.atmos.T(t)
+    leaf_conductance = p.canopy.conductance.gs
+    canopy_conductance =
+        upscale_leaf_conductance.(
+            leaf_conductance,
+            p.canopy.hydraulics.area_index.leaf,
+            T_air,
+            R,
+            P_air,
+        )
+    return 1 ./ canopy_conductance # [s/m]
+end
+
+"""
+    ClimaLSM.surface_temperature(model::CanopyModel, Y, p, t)
+
+A helper function which returns the temperature for the canopy
+model.
+"""
+function ClimaLSM.surface_temperature(model::CanopyModel, Y, p, t)
+    return canopy_temperature(model.energy, model, Y, p, t)
+end
+
+"""
+    ClimaLSM.surface_height(model::CanopyModel, Y, _...)
+
+A helper function which returns the surface height for the canopy
+model, which is stored in the parameter struct.
+"""
+function ClimaLSM.surface_height(model::CanopyModel, _...)
+    return model.hydraulics.compartment_surfaces[end]
+end
+
+"""
+    ClimaLSM.surface_specific_humidity(model::CanopyModel, Y, p)
+
+A helper function which returns the surface specific humidity for the canopy
+model, which is stored in the aux state.
+"""
+function ClimaLSM.surface_specific_humidity(
+    model::CanopyModel,
+    Y,
+    p,
+    T_canopy,
+    ρ_canopy,
+)
+    thermo_params =
+        LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
+    return Thermodynamics.q_vap_saturation_generic.(
+        Ref(thermo_params),
+        T_canopy,
+        ρ_canopy,
+        Ref(Thermodynamics.Liquid()),
+    )
+end
+
+"""
+    ClimaLSM.surface_air_density(model::CanopyModel, Y, p)
+
+A helper function which computes and returns the surface air density for the canopy
+model.
+"""
+function ClimaLSM.surface_air_density(
+    atmos::PrescribedAtmosphere,
+    model::CanopyModel,
+    Y,
+    p,
+    t,
+    T_canopy,
+)
+    thermo_params =
+        LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
+    ts_in = construct_atmos_ts(atmos, t, thermo_params)
+    return compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_canopy)
+end
+
+
+"""
+    canopy_boundary_fluxes!(p::NamedTuple,
+                            canopy::CanopyModel{
+                                FT,
+                                <:AutotrophicRespirationModel,
+                                <:Union{BeerLambertModel, TwoStreamModel},
+                                <:FarquharModel,
+                                <:MedlynConductanceModel,
+                                <:PlantHydraulicsModel,
+                                <:PrescribedCanopyTempModel,
+                            },
+                            radiation::PrescribedRadiativeFluxes,
+                            atmos::PrescribedAtmosphere,
+                            Y::ClimaCore.Fields.FieldVector,
+                            t,
+                            ) where {FT}
+
+Computes the boundary fluxes for the canopy prognostic
+equations; updates the specific fields in the auxiliary
+state `p` which hold these variables. This function is called
+within the explicit tendency of the canopy model.
+
+- `p.canopy.energy.shf`: Canopy SHF
+- `p.canopy.energy.lhf`: Canopy LHF
+- `p.canopy.hydraulics.fa[end]`: Transpiration
+- `p.canopy.conductance.transpiration`: Transpiration (stored twice; to be addressed in a future PR)
+- `p.canopy.hydraulics.fa_roots`: Root water flux
+- `p.canopy.radiative_transfer.LW_n`: net long wave radiation
+- `p.canopy.radiative_transfer.SW_n`: net short wave radiation
+
+"""
+function canopy_boundary_fluxes!(
+    p::NamedTuple,
+    canopy::CanopyModel{
+        FT,
+        <:AutotrophicRespirationModel,
+        <:Union{BeerLambertModel, TwoStreamModel},
+        <:FarquharModel,
+        <:MedlynConductanceModel,
+        <:PlantHydraulicsModel,
+        <:PrescribedCanopyTempModel,
+    },
+    radiation::PrescribedRadiativeFluxes,
+    atmos::PrescribedAtmosphere,
+    Y::ClimaCore.Fields.FieldVector,
+    t,
+) where {FT}
+
+    root_water_flux = p.canopy.hydraulics.fa_roots
+    fa = p.canopy.hydraulics.fa
+    transpiration = p.canopy.conductance.transpiration
+    shf = p.canopy.energy.shf
+    lhf = p.canopy.energy.lhf
+    i_end = canopy.hydraulics.n_stem + canopy.hydraulics.n_leaf
+
+    # Compute transpiration
+    (canopy_transpiration, canopy_shf, canopy_lhf) =
+        canopy_turbulent_surface_fluxes(atmos, canopy, Y, p, t)
+    transpiration .= canopy_transpiration
+    shf .= canopy_shf
+    lhf .= canopy_lhf
+
+    # Transpiration is per unit ground area, not leaf area (mult by LAI)
+    fa.:($i_end) .= PlantHydraulics.transpiration_per_ground_area(
+        canopy.hydraulics.transpiration,
+        Y,
+        p,
+        t,
+    )
+    # Update the root flux of water per unit ground area in place
+    root_water_flux_per_ground_area!(
+        root_water_flux,
+        canopy.soil_driver,
+        canopy.hydraulics,
+        Y,
+        p,
+        t,
+    )
+
+    canopy_radiant_energy_fluxes!(
+        p,
+        canopy.soil_driver,
+        canopy,
+        canopy.radiation,
+        canopy.parameters.earth_param_set,
+        Y,
+        t,
+    )
+
+end

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -17,6 +17,8 @@ struct PrescribedCanopyTempModel{FT} <: AbstractCanopyEnergyModel{FT} end
 ClimaLSM.auxiliary_vars(model::AbstractCanopyEnergyModel) = (:shf, :lhf)
 ClimaLSM.auxiliary_types(model::AbstractCanopyEnergyModel{FT}) where {FT} =
     (FT, FT)
+ClimaLSM.auxiliary_domain_names(model::AbstractCanopyEnergyModel) =
+    (:surface, :surface)
 
 """
     canopy_temperature(model::PrescribedCanopyTempModel, canopy, Y, p, t)

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -1,7 +1,10 @@
 using ..ClimaLSM.Canopy: AbstractSoilDriver
 
 export BeerLambertParameters,
-    BeerLambertModel, TwoStreamParameters, TwoStreamModel
+    BeerLambertModel,
+    TwoStreamParameters,
+    TwoStreamModel,
+    canopy_radiant_energy_fluxes!
 
 abstract type AbstractRadiationModel{FT} <: AbstractCanopyComponent{FT} end
 
@@ -186,10 +189,10 @@ Base.broadcastable(RT::AbstractRadiationModel) = tuple(RT)
 
 ClimaLSM.name(model::AbstractRadiationModel) = :radiative_transfer
 ClimaLSM.auxiliary_vars(model::Union{BeerLambertModel, TwoStreamModel}) =
-    (:apar, :par, :rpar, :tpar, :anir, :nir, :rnir, :tnir)
+    (:apar, :par, :rpar, :tpar, :anir, :nir, :rnir, :tnir, :LW_n, :SW_n)
 ClimaLSM.auxiliary_types(
     model::Union{BeerLambertModel{FT}, TwoStreamModel{FT}},
-) where {FT} = (FT, FT, FT, FT, FT, FT, FT, FT)
+) where {FT} = (FT, FT, FT, FT, FT, FT, FT, FT, FT, FT)
 ClimaLSM.auxiliary_domain_names(::Union{BeerLambertModel, TwoStreamModel}) = (
     :surface,
     :surface,
@@ -199,4 +202,62 @@ ClimaLSM.auxiliary_domain_names(::Union{BeerLambertModel, TwoStreamModel}) = (
     :surface,
     :surface,
     :surface,
+    :surface,
+    :surface,
 )
+
+"""
+    canopy_radiant_energy_fluxes!(p::NamedTuple,
+                                  s::PrescribedSoil{FT},
+                                  canopy,
+                                  radiation::PrescribedRadiativeFluxes,
+                                  earth_param_set::PSE,
+                                  Y::ClimaCore.Fields.FieldVector,
+                                  t,
+                                 ) where {FT, PSE}
+
+
+Computes and stores the net long and short wave radition, in W/m^2,
+absorbed by the canopy when the canopy is run in standalone mode,
+with a PrescribedSoil conditions.
+
+LW and SW net radiation are stored in `p.canopy.radiative_transfer.LW_n`
+and `p.canopy.radiative_transfer.SW_n`.
+"""
+function canopy_radiant_energy_fluxes!(
+    p::NamedTuple,
+    s::PrescribedSoil{FT},
+    canopy,
+    radiation::PrescribedRadiativeFluxes,
+    earth_param_set::PSE,
+    Y::ClimaCore.Fields.FieldVector,
+    t,
+) where {FT, PSE}
+
+    # Short wave makes use of precomputed APAR and ANIR
+    # in moles of photons per m^2 per s
+    c = FT(LSMP.light_speed(earth_param_set))
+    h = FT(LSMP.planck_constant(earth_param_set))
+    N_a = FT(LSMP.avogadro_constant(earth_param_set))
+    (; α_PAR_leaf, λ_γ_PAR, λ_γ_NIR, ϵ_canopy) =
+        canopy.radiative_transfer.parameters
+    APAR = p.canopy.radiative_transfer.apar
+    ANIR = p.canopy.radiative_transfer.anir
+    energy_per_photon_PAR = h * c / λ_γ_PAR
+    energy_per_photon_NIR = h * c / λ_γ_NIR
+    @. p.canopy.radiative_transfer.SW_n =
+        (energy_per_photon_PAR * N_a * APAR) +
+        (energy_per_photon_NIR * N_a * ANIR)
+
+    # Long wave: use soil conditions from the PrescribedSoil driver
+    T_soil = s.T(t)
+    ϵ_soil = s.ϵ
+    _σ = FT(LSMP.Stefan(earth_param_set))
+    LW_d::FT = canopy.radiation.LW_d(t)
+
+    T_canopy = canopy_temperature(canopy.energy, canopy, Y, p, t)
+    LW_d_canopy = @. (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4
+    LW_u_soil = @. ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy
+    @. p.canopy.radiative_transfer.LW_n =
+        ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 + ϵ_canopy * LW_u_soil
+end

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -360,34 +360,6 @@ end
             @. m += sqrt(dY.canopy.hydraulics.ϑ_l.:($$i)^2.0)
         end
         @test maximum(parent(m)) < 1e-11 # starts in equilibrium
-
-
-        # repeat using the plant hydraulics model directly
-        # make sure it agrees with what we get when use the canopy model ODE
-        Y, p, coords = initialize(model)
-        standalone_dY = similar(Y)
-        for i in 1:(n_stem + n_leaf)
-            Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
-            p.canopy.hydraulics.ψ.:($i) .= NaN
-            p.canopy.hydraulics.fa.:($i) .= NaN
-            standalone_dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
-        end
-        set_initial_aux_state!(p, Y, 0.0)
-        standalone_exp_tendency! =
-            make_compute_exp_tendency(model.hydraulics, model)
-        standalone_exp_tendency!(standalone_dY, Y, p, 0.0)
-
-        m = similar(dY.canopy.hydraulics.ϑ_l.:1)
-        m .= FT(0)
-        for i in 1:(n_stem + n_leaf)
-            @. m += sqrt(
-                (
-                    dY.canopy.hydraulics.ϑ_l.:($$i) -
-                    standalone_dY.canopy.hydraulics.ϑ_l.:($$i)
-                )^2.0,
-            )
-        end
-        @test sum(parent(m)) < eps(FT)
     end
 end
 


### PR DESCRIPTION
## Purpose 
Compute and store the LW radiative fluxes for the canopy in both standalone and integrated mode.

Helper PR before merging #341 

## To-do


## Content
1. Compute and store the net LW and SW radiation for the canopy in `p.canopy.radiative_transfer.LW_n` and `p.canopy.radiative_transfer.SW_n`. In standalone mode, `canopy_radiant_energy_fluxes!` computes and stores these, making use of the PrescribedSoil, while in integrated mode, these are computed/stored in `interactions_update_aux`, and `canopy_radiant_energy_fluxes!` does nothing. These will be needed when we compute the canopy prognostic temperature (not strictly needed in a `PrescribedCanopyTemperature` model)
2. Create a wrapper function`canopy_boundary_fluxes` which computes the net water (and in the future, energy) fluxes for the canopy. This is used inside of the `rhs` function. It is the same regardless of standalone mode vs not, but the internal functions called, like `canopy_radiant_energy_fluxes`, may have different methods.
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [x] I have read and checked the items on the review checklist.
