### PR TITLE
Implement series rescaling bug fix

### DIFF
--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -315,13 +315,11 @@ GPP_daily_avg_model = diurnal_avg(model_GPP)
 GPP_daily_avg_data =
     diurnal_avg(GPP[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)])
 RMSD =
-    StatsBase.rmsd(
-        match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...,
-    ) * 1e6
+    StatsBase.rmsd(match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...,) *
+    1e6
 R² =
     Statistics.cor(
-        match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...,
-    )^2
+        match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...)^2
 
 plt1 = Plots.plot(size = (800, 400))
 Plots.plot!(

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -268,6 +268,20 @@ function diurnal_avg(series)
         [mean([daily_data[i][j] for i in 1:num_days]) for j in 1:daily_points]
     return daily_avgs
 end
+
+# This function scales 2 data series to the same length and matches their
+# indices such that they may be used to compute GOF stats
+function match_indices(model, data)
+    dpm = dt * n / DATA_DT
+    model_per_data = 1
+    if dpm < 1
+        model_per_data = Int64(1 / dpm)
+        dpm = 1
+    end
+    data_per_model = Int64(dpm)
+    return model[1:model_per_data:end], data[1:data_per_model:end]
+end 
+
 # Autotrophic Respiration
 AR = [
     parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] for
@@ -302,13 +316,11 @@ GPP_daily_avg_data =
     diurnal_avg(GPP[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)])
 RMSD =
     StatsBase.rmsd(
-        GPP_daily_avg_model,
-        GPP_daily_avg_data[1:data_per_model:end],
+        match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...,
     ) * 1e6
 R² =
     Statistics.cor(
-        GPP_daily_avg_model,
-        GPP_daily_avg_data[1:data_per_model:end],
+        match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...,
     )^2
 
 plt1 = Plots.plot(size = (800, 400))
@@ -338,8 +350,8 @@ SW_out_model_avg = diurnal_avg(SW_out_model)
 SW_out_data_avg =
     diurnal_avg(FT.(SW_OUT)[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)])
 
-RMSD = StatsBase.rmsd(SW_out_model_avg, SW_out_data_avg[1:data_per_model:end])
-R² = Statistics.cor(SW_out_model_avg, SW_out_data_avg[1:data_per_model:end])^2
+RMSD = StatsBase.rmsd(match_indices(SW_out_model_avg, SW_out_data_avg)...)
+R² = Statistics.cor(match_indices(SW_out_model_avg, SW_out_data_avg)...)^2
 
 plt1 = Plots.plot(size = (1500, 400))
 Plots.plot!(
@@ -364,8 +376,8 @@ LW_out_data_avg =
     diurnal_avg(FT.(LW_OUT)[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)])
 
 
-RMSD = StatsBase.rmsd(LW_out_model_avg, LW_out_data_avg[1:data_per_model:end])
-R² = Statistics.cor(LW_out_model_avg, LW_out_data_avg[1:data_per_model:end])^2
+RMSD = StatsBase.rmsd(match_indices(LW_out_model_avg, LW_out_data_avg)...)
+R² = Statistics.cor(match_indices(LW_out_model_avg, LW_out_data_avg)...)^2
 
 plt1 = Plots.plot(size = (1500, 400))
 Plots.plot!(
@@ -396,8 +408,8 @@ ET_avg_model = diurnal_avg(T .+ E)
 ET_avg_data =
     diurnal_avg(measured_T[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)])
 
-RMSD = StatsBase.rmsd(ET_avg_model, ET_avg_data[1:data_per_model:end])
-R² = Statistics.cor(ET_avg_model, ET_avg_data[1:data_per_model:end])^2
+RMSD = StatsBase.rmsd(match_indices(ET_avg_model, ET_avg_data)...)
+R² = Statistics.cor(match_indices(ET_avg_model, ET_avg_data)...)^2
 
 plt1 = Plots.plot(size = (800, 400))
 Plots.plot!(
@@ -495,8 +507,8 @@ SHF_avg_model = diurnal_avg(SHF)
 SHF_avg_data =
     diurnal_avg(H_CORR[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)])
 
-RMSD = StatsBase.rmsd(SHF_avg_model, SHF_avg_data[1:data_per_model:end])
-R² = Statistics.cor(SHF_avg_model, SHF_avg_data[1:data_per_model:end])^2
+RMSD = StatsBase.rmsd(match_indices(SHF_avg_model, SHF_avg_data)...)
+R² = Statistics.cor(match_indices(SHF_avg_model, SHF_avg_data)...)^2
 
 plt1 = Plots.plot(size = (800, 400))
 Plots.plot!(

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -275,10 +275,10 @@ function match_indices(model, data)
     dpm = dt * n / DATA_DT
     model_per_data = 1
     if dpm < 1
-        model_per_data = Int64(1 / dpm)
+        model_per_data = round(Int64, 1 / dpm)
         dpm = 1
     end
-    data_per_model = Int64(dpm)
+    data_per_model = round(Int64, dpm)
     return model[1:model_per_data:end], data[1:data_per_model:end]
 end
 

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -315,11 +315,9 @@ GPP_daily_avg_model = diurnal_avg(model_GPP)
 GPP_daily_avg_data =
     diurnal_avg(GPP[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)])
 RMSD =
-    StatsBase.rmsd(match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...,) *
+    StatsBase.rmsd(match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...) *
     1e6
-R² =
-    Statistics.cor(
-        match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...)^2
+R² = Statistics.cor(match_indices(GPP_daily_avg_model, GPP_daily_avg_data)...)^2
 
 plt1 = Plots.plot(size = (800, 400))
 Plots.plot!(

--- a/experiments/integrated/ozark/ozark.jl
+++ b/experiments/integrated/ozark/ozark.jl
@@ -280,7 +280,7 @@ function match_indices(model, data)
     end
     data_per_model = Int64(dpm)
     return model[1:model_per_data:end], data[1:data_per_model:end]
-end 
+end
 
 # Autotrophic Respiration
 AR = [


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
--> This is a very simple PR to fix an issue with data scaling for calculating the GOF statistics in the experiment code. Before, running an experiment with a different data rate than the Ozark site didn't work.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [ ] Verify the code doesn't need additional changes following the canopy energy equation PR which is soon to be merged


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- New function, match_indices implemented within experiment to rescale each data series with respect to each other

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
