### PR TITLE
add boundary variables for the soil model

### DIFF
--- a/docs/src/APIs/ClimaLSM.md
+++ b/docs/src/APIs/ClimaLSM.md
@@ -12,9 +12,9 @@ ClimaLSM.LandHydrology
 ClimaLSM.make_interactions_update_aux
 ClimaLSM.initialize_interactions
 ClimaLSM.land_components
-ClimaLSM.interaction_vars
-ClimaLSM.interaction_types
-ClimaLSM.interaction_domain_names
+ClimaLSM.lsm_aux_vars
+ClimaLSM.lsm_aux_types
+ClimaLSM.lsm_aux_domain_names
 ClimaLSM.domain_name
 ```
 

--- a/docs/src/APIs/Soil.md
+++ b/docs/src/APIs/Soil.md
@@ -79,6 +79,9 @@ ClimaLSM.Soil.TemperatureStateBC
 ClimaLSM.Soil.FreeDrainage
 ClimaLSM.Soil.RichardsAtmosDrivenFluxBC
 ClimaLSM.Soil.AtmosDrivenFluxBC
+ClimaLSM.Soil.boundary_vars
+ClimaLSM.Soil.boundary_var_domain_names
+ClimaLSM.Soil.boundary_var_types
 ```
 
 ## Soil Source Types

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -355,7 +355,10 @@ for float_type in (Float32, Float64)
         ##  Soil water balance ##
 
         # Evaporation
-        E = [parent(sv.saveval[k].soil_evap)[1] for k in 2:length(sol.t)]
+        E = [
+            parent(sv.saveval[k].soil.sfc_conditions.vapor_flux)[1] for
+            k in 2:length(sol.t)
+        ]
         # Root sink term: a positive root extraction is a sink term for soil; add minus sign
         root_sink =
             [sum(-1 .* sv.saveval[k].root_extraction) for k in 2:length(sol.t)]
@@ -455,15 +458,18 @@ for float_type in (Float32, Float64)
         # Energy of liquid water infiltrating soil is ignored in our model.
 
         # Turbulent fluxes
-        LHF = [parent(sv.saveval[k].soil_lhf)[1] for k in 2:length(sol.t)]
-        SHF = [parent(sv.saveval[k].soil_shf)[1] for k in 2:length(sol.t)]
+        LHF = [
+            parent(sv.saveval[k].soil.sfc_conditions.lhf)[1] for
+            k in 2:length(sol.t)
+        ]
+        SHF = [
+            parent(sv.saveval[k].soil.sfc_conditions.shf)[1] for
+            k in 2:length(sol.t)
+        ]
         # Radiation is computed in LW and SW components
         # with positive numbers indicating the soil gaining energy.
         soil_Rn =
-            -1 .* [
-                parent(sv.saveval[k].soil_LW_n .+ sv.saveval[k].soil_SW_n)[1]
-                for k in 2:length(sol.t)
-            ]
+            -1 .* [parent(sv.saveval[k].soil.R_n)[1] for k in 2:length(sol.t)]
         # Root sink term: a positive root extraction is a sink term for soil; add minus sign
         root_sink_energy = [
             sum(-1 .* sv.saveval[k].root_energy_extraction) for

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -342,8 +342,18 @@ ClimaLSM.prognostic_domain_names(soil::EnergyHydrology) =
 A function which returns the names of the auxiliary variables
 of `EnergyHydrology`.
 """
-ClimaLSM.auxiliary_vars(soil::EnergyHydrology) =
-    (:K, :ψ, :θ_l, :T, :κ, :top_bc, :bottom_bc)
+ClimaLSM.auxiliary_vars(soil::EnergyHydrology) = (
+    :K,
+    :ψ,
+    :θ_l,
+    :T,
+    :κ,
+    boundary_vars(soil.boundary_conditions.top, ClimaLSM.TopBoundary())...,
+    boundary_vars(
+        soil.boundary_conditions.bottom,
+        ClimaLSM.BottomBoundary(),
+    )...,
+)
 
 """
     auxiliary_types(soil::EnergyHydrology{FT}) where {FT}
@@ -357,8 +367,16 @@ ClimaLSM.auxiliary_types(soil::EnergyHydrology{FT}) where {FT} = (
     FT,
     FT,
     FT,
-    NamedTuple{(:water, :heat), Tuple{FT, FT}},
-    NamedTuple{(:water, :heat), Tuple{FT, FT}},
+    boundary_var_types(
+        soil,
+        soil.boundary_conditions.top,
+        ClimaLSM.TopBoundary(),
+    )...,
+    boundary_var_types(
+        soil,
+        soil.boundary_conditions.bottom,
+        ClimaLSM.BottomBoundary(),
+    )...,
 )
 
 ClimaLSM.auxiliary_domain_names(soil::EnergyHydrology) = (
@@ -367,8 +385,14 @@ ClimaLSM.auxiliary_domain_names(soil::EnergyHydrology) = (
     :subsurface,
     :subsurface,
     :subsurface,
-    :surface,
-    :surface,
+    boundary_var_domain_names(
+        soil.boundary_conditions.top,
+        ClimaLSM.TopBoundary(),
+    )...,
+    boundary_var_domain_names(
+        soil.boundary_conditions.bottom,
+        ClimaLSM.BottomBoundary(),
+    )...,
 )
 """
     make_update_aux(model::EnergyHydrology)

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -25,195 +25,133 @@ for FT in (Float32, Float64)
         zmax = FT(0)
         zmin = FT(-1)
         nelems = 20
-        lsm_domain = HybridBox(;
-            xlim = (FT(0), FT(1)),
-            ylim = (FT(0), FT(1)),
-            zlim = (zmin, zmax),
-            nelements = (1, 1, nelems),
-            npolynomial = 1,
-            periodic = (true, true),
-        )
+        lsm_domains = [
+            HybridBox(;
+                xlim = (FT(0), FT(1)),
+                ylim = (FT(0), FT(1)),
+                zlim = (zmin, zmax),
+                nelements = (1, 1, nelems),
+                npolynomial = 1,
+                periodic = (true, true),
+            ),
+            Column(; zlim = (zmin, zmax), nelements = nelems),
+        ]
         soil_ps =
             Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
-        soil_args = (; domain = lsm_domain, parameters = soil_ps)
-        surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
-
         land_args = (; precip = precipitation)
-
-        land = LandHydrology{FT}(;
-            land_args = land_args,
-            soil_model_type = Soil.RichardsModel{FT},
-            soil_args = soil_args,
-            surface_water_model_type = Pond.PondModel{FT},
-            surface_water_args = surface_water_args,
-        )
-        Y, p, coords = initialize(land)
-        # test that the dss buffers are correctly added
-        @test propertynames(p) == (
-            :soil_infiltration,
-            :soil,
-            :surface_water,
-            :dss_buffer_3d,
-            :dss_buffer_2d,
-        )
-        @test typeof(p.dss_buffer_3d) == typeof(
-            ClimaCore.Spaces.create_dss_buffer(
-                ClimaCore.Fields.zeros(land.soil.domain.space.subsurface),
-            ),
-        )
-        @test typeof(p.dss_buffer_2d) == typeof(
-            ClimaCore.Spaces.create_dss_buffer(
-                ClimaCore.Fields.zeros(land.surface_water.domain.space.surface),
-            ),
-        )
-        function init_soil!(Ysoil, coords, params)
-            (; ν, hydrology_cm, θ_r) = params
-            (; α, n) = hydrology_cm
-            let ν = ν, θ_r = θ_r, n = vg_n, α = vg_α
-                function hydrostatic_profile(z::FT) where {FT}
-                    m = 1 - 1 / n
-                    #unsaturated zone only, assumes water table starts at z_∇
-                    z_∇ = FT(-1)# matches zmin
-                    S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-                    ϑ_l = S * (ν - θ_r) + θ_r
-                    return FT(ϑ_l)
+        for lsm_domain in lsm_domains
+            soil_args = (; domain = lsm_domain, parameters = soil_ps)
+            surface_water_args = (;)
+            land = LandHydrology{FT}(;
+                land_args = land_args,
+                soil_model_type = Soil.RichardsModel{FT},
+                soil_args = soil_args,
+                surface_water_model_type = Pond.PondModel{FT},
+                surface_water_args = surface_water_args,
+            )
+            Y, p, coords = initialize(land)
+            function init_soil!(Ysoil, coords, params)
+                (; ν, hydrology_cm, θ_r) = params
+                (; α, n) = hydrology_cm
+                let ν = ν, θ_r = θ_r, n = vg_n, α = vg_α
+                    function hydrostatic_profile(z::FT) where {FT}
+                        m = 1 - 1 / n
+                        #unsaturated zone only, assumes water table starts at z_∇
+                        z_∇ = FT(-1)# matches zmin
+                        S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
+                        ϑ_l = S * (ν - θ_r) + θ_r
+                        return FT(ϑ_l)
+                    end
+                    Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z)
                 end
-                Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z)
             end
-        end
-        init_soil!(Y, coords.subsurface, land.soil.parameters)
-        # initialize the pond height to zero
-        Y.surface_water.η .= FT(0)
-        dY = similar(Y)
+            init_soil!(Y, coords.subsurface, land.soil.parameters)
+            # initialize the pond height to zero
+            Y.surface_water.η .= FT(0)
+            dY = similar(Y)
 
-        exp_tendency! = make_exp_tendency(land)
-        t = Float64(0)
-        dt = Float64(1)
-        # set aux state values to those corresponding with Y(t=0)
-        set_initial_aux_state! = make_set_initial_aux_state(land)
-        set_initial_aux_state!(p, Y, t)
-        # integrate
-        for step in 1:10
-            exp_tendency!(dY, Y, p, t)
-            t = t + dt
-            @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
-        end
-        # it running is the test
+            exp_tendency! = make_exp_tendency(land)
+            t = Float64(0)
+            dt = Float64(1)
+            # set aux state values to those corresponding with Y(t=0)
+            set_initial_aux_state! = make_set_initial_aux_state(land)
+            set_initial_aux_state!(p, Y, t)
+            @test p.soil.top_bc.water == p.soil_infiltration
 
-        # Infiltration at point test
+            if typeof(lsm_domain) <: ClimaLSM.HybridBox
+                # test that the dss buffers are correctly added
+                @test propertynames(p) == (
+                    :soil_infiltration,
+                    :soil,
+                    :surface_water,
+                    :dss_buffer_3d,
+                    :dss_buffer_2d,
+                )
+                @test typeof(p.dss_buffer_3d) == typeof(
+                    ClimaCore.Spaces.create_dss_buffer(
+                        ClimaCore.Fields.zeros(
+                            land.soil.domain.space.subsurface,
+                        ),
+                    ),
+                )
+                @test typeof(p.dss_buffer_2d) == typeof(
+                    ClimaCore.Spaces.create_dss_buffer(
+                        ClimaCore.Fields.zeros(
+                            land.surface_water.domain.space.surface,
+                        ),
+                    ),
+                )
 
-        η = FT.([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])
-        i_c = FT.([2.0, 2.0, -2.0, -2.0, 2.0, 2.0])
-        P = FT.([3.0, -1.0, 3.0, -3.0, 1.0, 3.0])
-        iap = FT.([2.0, -1.0, -2.0, -3.0, 2.0, 2.0])
-        @test infiltration_at_point.(η, i_c, P) ≈ iap
+                land_prognostic_vars = prognostic_vars(land)
+                land_prognostic_types = prognostic_types(land)
+                land_prognostic_domain_names = prognostic_domain_names(land)
 
-        land_prognostic_vars = prognostic_vars(land)
-        land_prognostic_types = prognostic_types(land)
-        land_prognostic_domain_names = prognostic_domain_names(land)
+                land_auxiliary_vars = auxiliary_vars(land)
+                land_auxiliary_types = auxiliary_types(land)
+                land_auxiliary_domain_names = auxiliary_domain_names(land)
 
-        land_auxiliary_vars = auxiliary_vars(land)
-        land_auxiliary_types = auxiliary_types(land)
-        land_auxiliary_domain_names = auxiliary_domain_names(land)
-
-        # prognostic vars
-        @test land_prognostic_vars.soil == prognostic_vars(land.soil)
-        @test land_prognostic_vars.surface_water ==
-              prognostic_vars(land.surface_water)
-        # auxiliary vars
-        @test land_auxiliary_vars.soil == auxiliary_vars(land.soil)
-        @test land_auxiliary_vars.surface_water ==
-              auxiliary_vars(land.surface_water)
-        @test land_auxiliary_vars.lsm_aux == ClimaLSM.lsm_aux_vars(land)
-        # prognostic types
-        @test land_prognostic_types.soil == prognostic_types(land.soil)
-        @test land_prognostic_types.surface_water ==
-              prognostic_types(land.surface_water)
-        # auxiliary types
-        @test land_auxiliary_types.soil == auxiliary_types(land.soil)
-        @test land_auxiliary_types.surface_water ==
-              auxiliary_types(land.surface_water)
-        @test land_auxiliary_types.lsm_aux == ClimaLSM.lsm_aux_types(land)
-        # prognostic domain names
-        @test land_prognostic_domain_names.soil ==
-              prognostic_domain_names(land.soil)
-        @test land_prognostic_domain_names.surface_water ==
-              prognostic_domain_names(land.surface_water)
-        # auxiliary domain names
-        @test land_auxiliary_domain_names.soil ==
-              auxiliary_domain_names(land.soil)
-        @test land_auxiliary_domain_names.surface_water ==
-              auxiliary_domain_names(land.surface_water)
-        @test land_auxiliary_domain_names.lsm_aux ==
-              ClimaLSM.lsm_aux_domain_names(land)
-    end
-
-
-    @testset "Pond soil Single Column LSM integration test, FT = $FT" begin
-        function precipitation(t)
-            if t < 20
-                precip = -1e-8
+                # prognostic vars
+                @test land_prognostic_vars.soil == prognostic_vars(land.soil)
+                @test land_prognostic_vars.surface_water ==
+                      prognostic_vars(land.surface_water)
+                # auxiliary vars
+                @test land_auxiliary_vars.soil == auxiliary_vars(land.soil)
+                @test land_auxiliary_vars.surface_water ==
+                      auxiliary_vars(land.surface_water)
+                @test land_auxiliary_vars.lsm_aux == ClimaLSM.lsm_aux_vars(land)
+                # prognostic types
+                @test land_prognostic_types.soil == prognostic_types(land.soil)
+                @test land_prognostic_types.surface_water ==
+                      prognostic_types(land.surface_water)
+                # auxiliary types
+                @test land_auxiliary_types.soil == auxiliary_types(land.soil)
+                @test land_auxiliary_types.surface_water ==
+                      auxiliary_types(land.surface_water)
+                @test land_auxiliary_types.lsm_aux ==
+                      ClimaLSM.lsm_aux_types(land)
+                # prognostic domain names
+                @test land_prognostic_domain_names.soil ==
+                      prognostic_domain_names(land.soil)
+                @test land_prognostic_domain_names.surface_water ==
+                      prognostic_domain_names(land.surface_water)
+                # auxiliary domain names
+                @test land_auxiliary_domain_names.soil ==
+                      auxiliary_domain_names(land.soil)
+                @test land_auxiliary_domain_names.surface_water ==
+                      auxiliary_domain_names(land.surface_water)
+                @test land_auxiliary_domain_names.lsm_aux ==
+                      ClimaLSM.lsm_aux_domain_names(land)
             else
-                precip = t < 100 ? -5e-5 : 0.0
-            end
-            return precip
-        end
-        ν = FT(0.495)
-        K_sat = FT(0.0443 / 3600 / 100) # m/s
-        S_s = FT(1e-3) #inverse meters
-        vg_n = FT(2.0)
-        vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
-        θ_r = FT(0)
-        zmax = FT(0)
-        zmin = FT(-1)
-        nelems = 20
-        lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-
-        soil_ps =
-            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
-        soil_args = (; domain = lsm_domain, parameters = soil_ps)
-        surface_water_args = (; domain = obtain_surface_domain(lsm_domain))
-
-        land_args = (; precip = precipitation)
-
-        land = LandHydrology{FT}(;
-            land_args = land_args,
-            soil_model_type = Soil.RichardsModel{FT},
-            soil_args = soil_args,
-            surface_water_model_type = Pond.PondModel{FT},
-            surface_water_args = surface_water_args,
-        )
-        Y, p, coords = initialize(land)
-        @test propertynames(p) == (:soil_infiltration, :soil, :surface_water)
-        function init_soil!(Ysoil, coords, params)
-            (; ν, hydrology_cm, θ_r) = params
-            (; α, n) = hydrology_cm
-            let ν = ν, θ_r = θ_r, n = vg_n, α = vg_α
-                function hydrostatic_profile(z::FT) where {FT}
-                    m = 1 - 1 / n
-                    #unsaturated zone only, assumes water table starts at z_∇
-                    z_∇ = FT(-1)# matches zmin
-                    S = FT((FT(1) + (α * (z - z_∇))^n)^(-m))
-                    ϑ_l = S * (ν - θ_r) + θ_r
-                    return FT(ϑ_l)
-                end
-                Ysoil.soil.ϑ_l .= hydrostatic_profile.(coords.z)
+                @test propertynames(p) ==
+                      (:soil_infiltration, :soil, :surface_water)
             end
         end
-        init_soil!(Y, coords.subsurface, land.soil.parameters)
-        # initialize the pond height to zero
-        Y.surface_water.η .= FT(0)
-        dY = similar(Y)
-        exp_tendency! = make_exp_tendency(land)
-        t = Float64(0)
-        dt = Float64(1)
-        for step in 1:10
-            exp_tendency!(dY, Y, p, t)
-            t = t + dt
-            @. Y.surface_water.η = dY.surface_water.η * dt + Y.surface_water.η
-        end
-
-        # it running is the test
     end
+
+    # Infiltration at point test
+    η = FT.([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])
+    i_c = FT.([2.0, 2.0, -2.0, -2.0, 2.0, 2.0])
+    P = FT.([3.0, -1.0, 3.0, -3.0, 1.0, 3.0])
+    iap = FT.([2.0, -1.0, -2.0, -3.0, 2.0, 2.0])
+    @test infiltration_at_point.(η, i_c, P) ≈ iap
 end

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -119,6 +119,19 @@ for FT in (Float32, Float64)
             )
 
             Y, p, coords = initialize(model)
+            @test propertynames(p.soil.sfc_conditions) ==
+                  (:lhf, :shf, :vapor_flux, :r_ae)
+            @test propertynames(p.soil) == (
+                :K,
+                :ψ,
+                :θ_l,
+                :T,
+                :κ,
+                :sfc_conditions,
+                :R_n,
+                :top_bc,
+                :bottom_bc,
+            )
             function init_soil!(Y, z, params)
                 ν = params.ν
                 FT = eltype(ν)
@@ -139,8 +152,8 @@ for FT in (Float32, Float64)
             init_soil!(Y, coords.subsurface.z, model.parameters)
             set_initial_aux_state! = make_set_initial_aux_state(model)
             set_initial_aux_state!(p, Y, t)
-
-
+            tendency! = make_exp_tendency(model)
+            tendency!(similar(Y), Y, p, t)
             face_space = ClimaLSM.Domains.obtain_face_space(
                 model.domain.space.subsurface,
             )
@@ -212,6 +225,8 @@ for FT in (Float32, Float64)
                 p,
                 t,
             )
+            @test R_n == p.soil.R_n
+            @test conditions == p.soil.sfc_conditions
 
             fluxes = ClimaLSM.Soil.soil_boundary_fluxes(
                 top_bc,


### PR DESCRIPTION
## Purpose 
Adds the ability to add boundary condition specific variables to the cache/aux state for the soil model. This is not required for other standalone models currently. This 
1. is required for runoff, since that requires additional global parameter fields (assuming these will be stored in aux!)
2.  adds clarity in atmos-driven soil runs regarding where soil SHF, LHF, E, Rn get stored [now in `p.soil` instead of `p`]

## Content
Source files changed: `soil_canopy_model.jl`, `Soil/boundary_conditions.jl`, `Soil/rre.jl`, `Soil/energy_hydrology.jl`
Tests added
Changes propagated to experiments and docs

Source code changes:
1. Add `boundary_var` types, names, and domains functions (soil standalone files). This follows the style we use for setting aux variables for any model, but dispatches off of the type of BC set for the soil model. The default is to have only the top_bc and bottom_bc as variables.
2. These aux vars are updated prior in `update_boundary_fluxes!`
3. Removes the "soil_SHF", "soil_LHF" etc. fields from the interaction variables of the integrated model, since these can now be stored in `p.soil` instead of in `p` directly.



Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
