### PR TITLE
cuda driver, aqua fixes

### DIFF
--- a/.buildkite/JuliaProject.toml
+++ b/.buildkite/JuliaProject.toml
@@ -5,7 +5,7 @@ HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 
 [preferences.CUDA_Driver_jll]
- compat = false
+compat = false
 
 [preferences.CUDA_Runtime_jll]
 version = "12.2"

--- a/.buildkite/JuliaProject.toml
+++ b/.buildkite/JuliaProject.toml
@@ -1,7 +1,11 @@
 [extras]
+CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+
+[preferences.CUDA_Driver_jll]
+ compat = false
 
 [preferences.CUDA_Runtime_jll]
 version = "12.2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,6 +20,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
+Aqua = "0.8"
 CLIMAParameters = "0.7"
 DelimitedFiles = "1"
 Insolation = "0.7"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -27,8 +27,7 @@ end
     Aqua.test_stale_deps(ClimaLSM)
     Aqua.test_deps_compat(ClimaLSM)
     Aqua.test_project_extras(ClimaLSM)
-    Aqua.test_project_toml_formatting(ClimaLSM)
-    Aqua.test_piracy(ClimaLSM)
+    Aqua.test_piracies(ClimaLSM)
 end
 
 nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #390 

as of 16 Nov, the reserved CliMA GPU node is back in action, which will increase the frequency of segmentation faults fixed by this PR

also updates for Aqua.jl v0.8 and adds a compat entry for it