### PR TITLE
Kd/unify bc computation

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -32,6 +32,7 @@ ClimaLSM.make_imp_tendency
 ClimaLSM.make_compute_exp_tendency
 ClimaLSM.make_compute_imp_tendency
 ClimaLSM.make_update_aux
+ClimaLSM.make_update_boundary_fluxes
 ClimaLSM.make_set_initial_aux_state
 ClimaLSM.prognostic_vars
 ClimaLSM.prognostic_types

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -441,8 +441,10 @@ function soil_boundary_fluxes(
         t,
         model.parameters,
     )
-    G = @. -p.soil_LW_n - p.soil_SW_n + p.soil_lhf + p.soil_shf
-    return infiltration, G
+    return @. ClimaLSM.Soil.create_soil_bc_named_tuple(
+        infiltration,
+        -p.soil_LW_n - p.soil_SW_n + p.soil_lhf + p.soil_shf,
+    )
 end
 
 

--- a/src/shared_utilities/implicit_tendencies.jl
+++ b/src/shared_utilities/implicit_tendencies.jl
@@ -17,9 +17,11 @@ used as `Wfact!` in `ClimaTimeSteppers.jl` and `SciMLBase.jl`.
 """
 function make_tendency_jacobian(model::AbstractModel)
     update_aux! = make_update_aux(model)
+    update_boundary_fluxes! = make_update_boundary_fluxes(model)
     update_jacobian! = make_update_jacobian(model)
     function tendency_jacobian!(W, Y, p, dtγ, t)
         update_aux!(p, Y, t)
+        update_boundary_fluxes!(p, Y, t)
         update_jacobian!(W, Y, p, dtγ, t)
     end
     return tendency_jacobian!

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -8,6 +8,7 @@ export AbstractModel,
     make_update_aux,
     initialize_prognostic,
     initialize_auxiliary,
+    make_update_boundary_fluxes,
     initialize_vars,
     initialize,
     prognostic_vars,
@@ -131,6 +132,17 @@ Return an `update_aux!` function that updates auxiliary parameters `p`.
 function make_update_aux(model::AbstractModel)
     function update_aux!(p, Y, t) end
     return update_aux!
+end
+
+"""
+    make_update_boundary_fluxes(model::AbstractModel)
+
+Return an `update_boundary_fluxes!` function that updates the auxiliary parameters in `p`
+corresponding to boundary fluxes or interactions between componets..
+"""
+function make_update_boundary_fluxes(model::AbstractModel)
+    function update_boundary_fluxes!(p, Y, t) end
+    return update_boundary_fluxes!
 end
 
 """

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -70,6 +70,7 @@ import ClimaLSM:
     make_update_aux,
     make_compute_exp_tendency,
     make_compute_imp_tendency,
+    make_update_boundary_fluxes,
     make_update_jacobian,
     prognostic_vars,
     auxiliary_vars,

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -17,6 +17,7 @@ import ClimaLSM:
     prognostic_domain_names,
     initialize_prognostic,
     initialize_auxiliary,
+    make_update_boundary_fluxes,
     make_update_aux,
     make_compute_exp_tendency,
     make_set_initial_aux_state
@@ -582,10 +583,11 @@ function make_compute_exp_tendency(
         x -> make_compute_exp_tendency(getproperty(canopy, x), canopy),
         components,
     )
+    update_boundary_fluxes! = make_update_boundary_fluxes(canopy)
     function compute_exp_tendency!(dY, Y, p, t)
         # First we need to compute/update in place the boundary fluxes for
         # the component models.
-        canopy_boundary_fluxes!(p, canopy, canopy.radiation, canopy.atmos, Y, t)
+        update_boundary_fluxes!(p, Y, t)
         # Then we execute the tendency
         for f! in compute_exp_tendency_list
             f!(dY, Y, p, t)

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -140,6 +140,12 @@ function ClimaLSM.surface_air_density(
     return compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_canopy)
 end
 
+function make_update_boundary_fluxes(canopy::CanopyModel)
+    function update_boundary_fluxes!(p, Y, t)
+        canopy_boundary_fluxes!(p, canopy, canopy.radiation, canopy.atmos, Y, t)
+    end
+    return update_boundary_fluxes!
+end
 
 """
     canopy_boundary_fluxes!(p::NamedTuple,

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -213,17 +213,17 @@ for FT in (Float32, Float64)
                 t,
             )
 
-            (computed_water_flux, computed_energy_flux) =
-                ClimaLSM.Soil.soil_boundary_fluxes(
-                    top_bc,
-                    ClimaLSM.TopBoundary(),
-                    model,
-                    nothing,
-                    Y,
-                    p,
-                    t,
-                )
-
+            fluxes = ClimaLSM.Soil.soil_boundary_fluxes(
+                top_bc,
+                ClimaLSM.TopBoundary(),
+                model,
+                nothing,
+                Y,
+                p,
+                t,
+            )
+            computed_water_flux = fluxes.water
+            computed_energy_flux = fluxes.heat
             (; ν, θ_r, d_ds) = model.parameters
             _D_vapor = FT(LSMP.D_vapor(model.parameters.earth_param_set))
             S_l_sfc = ClimaLSM.Domains.top_center_to_surface(


### PR DESCRIPTION
## Purpose 
-Renames the functions in the canopy and soil model which compute the actual fluxes used in the tendency.
-Allocates space for these in `aux`
-updates the values stored in these pre-allocated spaces with `update_boundary_fluxes!`, which must be called in tendencies and jacobian computations


## To-do
Future PR (more nebulous)
- move outside of the tendency function, but still call after update_aux! and before the tendency evaluation
- define a method of `make_update_boundary_fluxes` for SoilCanopyModel (and other integrated models, or is there a default?)
- does this take the place of interactions update aux?  yes?
- add an explanation of what is in aux and when it is updated (tutorial) and docs


## Content

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [x] I have read and checked the items on the review checklist.
