### PR TITLE
Optimality model for Vcmax

### DIFF
--- a/docs/src/APIs/canopy/Photosynthesis.md
+++ b/docs/src/APIs/canopy/Photosynthesis.md
@@ -8,6 +8,7 @@ CurrentModule = ClimaLSM.Canopy
 
 ```@docs
 ClimaLSM.Canopy.FarquharParameters
+ClimaLSM.Canopy.OptimalityFarquharParameters
 ```
 
 ## Methods
@@ -23,6 +24,7 @@ ClimaLSM.Canopy.C4
 ClimaLSM.Canopy.max_electron_transport
 ClimaLSM.Canopy.electron_transport
 ClimaLSM.Canopy.net_photosynthesis
+ClimaLSM.Canopy.optimality_max_photosynthetic_rates
 ClimaLSM.Canopy.moisture_stress
 ClimaLSM.Canopy.dark_respiration
 ClimaLSM.Canopy.compute_GPP

--- a/src/standalone/Vegetation/autotrophic_respiration.jl
+++ b/src/standalone/Vegetation/autotrophic_respiration.jl
@@ -80,7 +80,7 @@ function compute_autrophic_respiration(
     (; ne, ηsl, σl, μr, μs, f1, f2) = model.parameters
 
     Nl, Nr, Ns = nitrogen_content(ne, Vcmax25, LAI, RAI, ηsl, h, σl, μr, μs)
-    Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns, f1)
+    Rpm = plant_respiration_maintenance.(Rd, β, Nl, Nr, Ns, f1)
     Rg = plant_respiration_growth(f2, GPP, Rpm)
     Ra = Rpm + Rg # Should this be a function in canopy_parameterizations.jl or is it ok here?
     return Ra

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -153,7 +153,7 @@ end
                                 FT,
                                 <:AutotrophicRespirationModel,
                                 <:Union{BeerLambertModel, TwoStreamModel},
-                                <:FarquharModel,
+                                <:Union{FarquharModel,OptimalityFarquharModel},
                                 <:MedlynConductanceModel,
                                 <:PlantHydraulicsModel,
                                 <:Union{PrescribedCanopyTempModel,BigLeafEnergyModel}
@@ -184,7 +184,7 @@ function canopy_boundary_fluxes!(
         FT,
         <:AutotrophicRespirationModel,
         <:Union{BeerLambertModel, TwoStreamModel},
-        <:FarquharModel,
+        <:Union{FarquharModel, OptimalityFarquharModel},
         <:MedlynConductanceModel,
         <:PlantHydraulicsModel,
         <:Union{PrescribedCanopyTempModel, BigLeafEnergyModel},

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -8,6 +8,7 @@ export plant_absorbed_pfd,
     light_assimilation,
     max_electron_transport,
     electron_transport,
+    optimality_max_photosynthetic_rates,
     net_photosynthesis,
     moisture_stress,
     dark_respiration,
@@ -569,6 +570,60 @@ function electron_transport(APAR::FT, Jmax::FT, θj::FT, ϕ::FT) where {FT}
     return J
 end
 
+"""
+optimality_max_photosynthetic_rates(APAR::FT,  θj::FT, ϕ::FT, oi::FT, ci::FT, Γstar::FT, Kc::FT, Ko::FT)
+
+Computes the photosynthesis rates Vcmax and Jmax in
+mol/m^2/s given absorbed photosynthetically active radiation (`APAR`),
+an empirical "curvature parameter" (`θj`; Bonan Eqn 11.21)
+ the quantum yield of photosystem II (`ϕ`), the intercellular
+o2 content (`oi`), the intercellular CO2 concentration (ci),
+Γstar, and Kc and Ko.
+
+See Smith et al. 2019.
+"""
+function optimality_max_photosynthetic_rates(
+    APAR::FT,
+    θj::FT,
+    ϕ::FT,
+    oi::FT,
+    ci::FT,
+    Γstar::FT,
+    Kc::FT,
+    Ko::FT,
+    c::FT,
+) where {FT}
+    # Light utilization of APAR
+    IPSII = ϕ * APAR / 2
+
+    mc = (ci - Γstar) / (ci + Kc * (1 + oi / Ko))
+    m = (ci - Γstar) / (ci + 2 * Γstar)
+
+    # Corrected form of ω, see https://github.com/SmithEcophysLab/optimal_vcmax_R/issues/3
+    if ((θj < 1) & (8 * c > m) & (4 * c < m) & (m / c < 8 * θj)) |
+       ((θj > 1) & (4 * c > m))
+        ω =
+            (
+                -2 + 4 * θj - sqrt(
+                    ((-1 + θj) * (m - 8 * c * θj)^2) / (c * (-m + 4 * c * θj)),
+                )
+            ) / 2
+    elseif ((θj < 1) & (8 * c < m)) |
+           ((m / c > 8 * θj) & (8 * c > m) & (4 * c < m))
+        ω =
+            (
+                -2 +
+                4 * θj +
+                sqrt(((-1 + θj) * (m - 8 * c * θj)^2) / (c * (-m + 4 * c * θj)))
+            ) / 2
+    else
+        ω = FT(0)
+    end
+    ωstar = 1 + ω - sqrt((1 + ω)^2 - 4 * θj * ω)
+    Jmax = IPSII * ω
+    Vcmax = mc > eps(FT) ? IPSII * (m / mc) * ωstar / (8 * θj) : FT(0)
+    return Jmax, Vcmax
+end
 
 """
     net_photosynthesis(Ac::FT,

--- a/src/standalone/Vegetation/optimality_farquhar.jl
+++ b/src/standalone/Vegetation/optimality_farquhar.jl
@@ -1,0 +1,206 @@
+export OptimalityFarquharParameters, OptimalityFarquharModel
+
+
+"""
+    OptimalityFarquharParameters{FT<:AbstractFloat}
+
+The required parameters for the optimality Farquhar photosynthesis model.
+Currently, only C3 photosynthesis is supported.
+$(DocStringExtensions.FIELDS)
+"""
+struct OptimalityFarquharParameters{FT <: AbstractFloat}
+    "Photosynthesis mechanism: C3 only"
+    mechanism::C3
+    "Γstar at 25 °C (mol/mol)"
+    Γstar25::FT
+    "Michaelis-Menten parameter for CO2 at 25 °C (mol/mol)"
+    Kc25::FT
+    "Michaelis-Menten parameter for O2 at 25 °C (mol/mol)"
+    Ko25::FT
+    "Energy of activation for CO2 (J/mol)"
+    ΔHkc::FT
+    "Energy of activation for oxygen (J/mol)"
+    ΔHko::FT
+    "Energy of activation for Vcmax (J/mol)"
+    ΔHVcmax::FT
+    "Energy of activation for Γstar (J/mol)"
+    ΔHΓstar::FT
+    "Energy of activation for Jmax (J/mol)"
+    ΔHJmax::FT
+    "Energy of activation for Rd (J/mol)"
+    ΔHRd::FT
+    "Reference temperature equal to 25 degrees Celsius (K)"
+    To::FT
+    "Intercellular O2 concentration (mol/mol); taken to be constant"
+    oi::FT
+    "Quantum yield of photosystem II (Bernacchi, 2003; unitless)"
+    ϕ::FT
+    "Curvature parameter, a fitting constant to compute J, unitless"
+    θj::FT
+    "Constant factor appearing the dark respiration term, equal to 0.015."
+    f::FT
+    "Fitting constant to compute the moisture stress factor (Pa^{-1})"
+    sc::FT
+    "Fitting constant to compute the moisture stress factor (Pa)"
+    pc::FT
+    "Constant describing cost of maintaining electron transport (unitless)"
+    c::FT
+end
+
+"""
+    function OptimalityFarquharParameters{FT}(
+        oi = FT(0.209),
+        ϕ = FT(0.6),
+        θj = FT(0.9),
+        f = FT(0.015),
+        sc = FT(5e-6),
+        pc = FT(-2e6),
+        Γstar25 = FT(4.275e-5),
+        Kc25 = FT(4.049e-4),
+        Ko25 = FT(0.2874),
+        To = FT(298.15),
+        ΔHkc = FT(79430),
+        ΔHko = FT(36380),
+        ΔHVcmax = FT(58520),
+        ΔHΓstar = FT(37830),
+        ΔHJmax = FT(43540),
+        ΔHRd = FT(46390),
+        c = FT(0.05336251)
+    )
+A constructor supplying default values for the FarquharParameters struct.
+"""
+function OptimalityFarquharParameters{FT}(;
+    oi = FT(0.209),
+    ϕ = FT(0.6),
+    θj = FT(0.9),
+    f = FT(0.015),
+    sc = FT(5e-6),
+    pc = FT(-2e6),
+    Γstar25 = FT(4.275e-5),
+    Kc25 = FT(4.049e-4),
+    Ko25 = FT(0.2874),
+    To = FT(298.15),
+    ΔHkc = FT(79430),
+    ΔHko = FT(36380),
+    ΔHVcmax = FT(58520),
+    ΔHΓstar = FT(37830),
+    ΔHJmax = FT(43540),
+    ΔHRd = FT(46390),
+    c = FT(0.05336251),
+) where {FT}
+    mechanism = C3()
+    return OptimalityFarquharParameters{FT}(
+        mechanism,
+        Γstar25,
+        Kc25,
+        Ko25,
+        ΔHkc,
+        ΔHko,
+        ΔHVcmax,
+        ΔHΓstar,
+        ΔHJmax,
+        ΔHRd,
+        To,
+        oi,
+        ϕ,
+        θj,
+        f,
+        sc,
+        pc,
+        c,
+    )
+end
+
+"""
+    OptimalityFarquharModel{FT} <: AbstractPhotosynthesisModel{FT}
+
+Optimality model of Smith et al. (2019) for estimating Vcmax, based on the assumption that Aj = Ac.
+Smith et al. (2019). Global photosynthetic capacity is optimized to the environment. Ecology Letters, 22(3), 506–517. https://doi.org/10.1111/ele.13210
+"""
+struct OptimalityFarquharModel{FT} <: AbstractPhotosynthesisModel{FT}
+    "Required parameters for the Optimality based Farquhar model of Smith et al. (2019)"
+    parameters::OptimalityFarquharParameters{FT}
+end
+
+ClimaLSM.auxiliary_vars(model::OptimalityFarquharModel) =
+    (:An, :GPP, :Rd, :Vcmax25)
+ClimaLSM.auxiliary_types(model::OptimalityFarquharModel{FT}) where {FT} =
+    (FT, FT, FT, FT)
+ClimaLSM.auxiliary_domain_names(::OptimalityFarquharModel) =
+    (:surface, :surface, :surface, :surface)
+
+"""
+    update_photosynthesis!(Rd, An, Vcmax25,
+        model::OptimalityFarquharModel,
+        T,
+        APAR,
+        β,
+        medlyn_factor,
+        c_co2,
+        R,
+    )
+
+Computes the net photosynthesis rate `An` for the Optimality Farquhar model, along with the
+dark respiration `Rd`, and the value of `Vcmax25`, and updates them in place.
+        
+ To do so, we require the canopy leaf temperature `T`, Medlyn factor, `APAR` in
+photons per m^2 per second, CO2 concentration in the atmosphere,
+moisture stress factor `β` (unitless), and the universal gas constant
+`R`.
+"""
+function update_photosynthesis!(
+    Rd,
+    An,
+    Vcmax25,
+    model::OptimalityFarquharModel,
+    T,
+    APAR,
+    β,
+    medlyn_factor,
+    c_co2,
+    R,
+)
+    (;
+        Γstar25,
+        ΔHVcmax,
+        ΔHΓstar,
+        f,
+        ΔHRd,
+        To,
+        θj,
+        ϕ,
+        mechanism,
+        oi,
+        Kc25,
+        Ko25,
+        ΔHkc,
+        ΔHko,
+        c,
+    ) = model.parameters
+
+    Γstar = co2_compensation.(Γstar25, ΔHΓstar, T, To, R)
+    ci = intercellular_co2.(c_co2, Γstar, medlyn_factor)# may change?
+    Kc = MM_Kc.(Kc25, ΔHkc, T, To, R)
+    Ko = MM_Ko.(Ko25, ΔHko, T, To, R)
+    rates =
+        optimality_max_photosynthetic_rates.(
+            APAR,
+            θj,
+            ϕ,
+            oi,
+            ci,
+            Γstar,
+            Kc,
+            Ko,
+            c,
+        )
+    Jmax = rates.:1
+    Vcmax = rates.:2
+    J = electron_transport.(APAR, Jmax, θj, ϕ)
+    Aj = light_assimilation.(mechanism, J, ci, Γstar)
+    Ac = rubisco_assimilation.(mechanism, Vcmax, ci, Γstar, Kc, Ko, oi)
+
+    @. Vcmax25 = Vcmax / arrhenius_function(T, To, R, ΔHVcmax)
+    @. Rd = dark_respiration(Vcmax25, β, f, ΔHRd, T, To, R)
+    @. An = net_photosynthesis(Ac, Aj, Rd, β)
+end


### PR DESCRIPTION
## Purpose 
Closes #215 
Adds Farquhar optimality model of Smith et al. 2019. This model removes Vcmax25 as a parameter and instead computes it each timestep.

## To-do
[X] Test with ozark site and make sure output looks reasonable (offline) - do we want to have this running?
[X] add more unit tests
Future PR. - add intercellular concentration optimality model - see #419 


## Content
Adds Vcmax25 to aux
Adds OptimalityFarquharModel and Parameters
Adds update_photosynthesis! function which dispatches off of the photosynthesis model type and updates An, Rd, and Vcmax25 in place.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
