### PR TITLE
Restore Experiments Plots

### DIFF
--- a/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
+++ b/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
@@ -185,13 +185,17 @@ radiation = ClimaLSM.PrescribedRadiativeFluxes(
     θs = zenith_angle,
 )
 
+# Start and end dates of data in MODIS format
+modis_start_date = "A$(Dates.year(UTC_DATETIME[1]))$(lpad(Dates.dayofyear(UTC_DATETIME[1]), 3, "0"))"
+modis_end_date = "A$(Dates.year(UTC_DATETIME[end]))$(lpad(Dates.dayofyear(UTC_DATETIME[end]), 3, "0"))"
+
 MODIS_LAI = single_col_data_matrix(
     parse_response(
         check_response(
             send_get_subset(
                 "MCD15A2H",
-                "A2005000",
-                "A2006000",
+                modis_start_date,
+                modis_end_date,
                 site_ID,
                 band = "Lai_500m",
             ),

--- a/experiments/integrated/fluxnet/plot_utils.jl
+++ b/experiments/integrated/fluxnet/plot_utils.jl
@@ -54,6 +54,7 @@ function plot_daily_avg(
     num_days::Int64,
     unit::String,
     savedir::String,
+    label::String = "data",
 )
     # Rescale the data and take the average diurnal cycle
     data_hh_avg =
@@ -65,7 +66,7 @@ function plot_daily_avg(
         plt,
         0.5:0.5:24,
         data_hh_avg,
-        label = "Data",
+        label = label,
         xlabel = "Hour of day",
         ylabel = "$var_name $(unit)",
         title = "$var_name",


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Following #369, there are a couple issues left to be resolved by this PR, including restoring the ground heat flux plots to what they were before, fixing the labels for Harvard plots (plots when the data is missing), and fixing the start and end dates of MODIS LAI data fetching.

##TODO:

- [ ] View Buildkite plots for all sites to ensure that the plotting corrections are correct.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Harvard plots relabelled to report model is being plotted
- MODIS LAI fetched based on the data date column (before was always 2005)
- Ground heat flux plot restored to what it was prior to being reverted by #369


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
