### PR TITLE
Renaming

### DIFF
--- a/docs/src/APIs/canopy/Canopy.md
+++ b/docs/src/APIs/canopy/Canopy.md
@@ -14,7 +14,7 @@ ClimaLSM.Canopy.SharedCanopyParameters
 
 ```@docs
 ClimaLSM.Canopy.DiagnosticTranspiration
-ClimaLSM.Canopy.canopy_turbulent_surface_fluxes
+ClimaLSM.Canopy.canopy_turbulent_fluxes
 ```
 
 ## Canopy Model Soil Drivers

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -65,7 +65,8 @@ ClimaLSM.PrescribedAtmosphere
 ClimaLSM.PrescribedRadiativeFluxes
 ClimaLSM.AbstractAtmosphericDrivers
 ClimaLSM.AbstractRadiativeDrivers
-ClimaLSM.surface_fluxes_at_a_point
+ClimaLSM.turbulent_fluxes
+ClimaLSM.turbulent_fluxes_at_a_point
 ClimaLSM.radiative_fluxes_at_a_point
 ClimaLSM.construct_atmos_ts
 ClimaLSM.surface_air_density

--- a/docs/tutorials/standalone/Bucket/coupled_bucket.jl
+++ b/docs/tutorials/standalone/Bucket/coupled_bucket.jl
@@ -49,13 +49,12 @@
 # To begin, let's import some necessary abstract and concrete types, as well as methods.
 using ClimaLSM
 using ClimaLSM: AbstractAtmosphericDrivers, AbstractRadiativeDrivers
-using ClimaLSM.Bucket: BucketModel
-
-import ClimaLSM.Bucket:
-    surface_fluxes,
+import ClimaLSM:
+    turbulent_fluxes,
     surface_air_density,
     liquid_precipitation,
     snow_precipitation
+using ClimaLSM.Bucket: BucketModel
 
 FT = Float32;
 # # Turbulent Surface Fluxes and Radiation
@@ -69,9 +68,9 @@ FT = Float32;
 
 # These are stored in the [BucketModel](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.BucketModel) object,
 # along with [BucketParameters](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.BucketParameters).
-# In order to compute turbulent surface fluxes, we call [surface_fluxes](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.surface_fluxes),
-# with arguments including `prescribed_atmosphere`. Since this argument is of the type `PrescribedAtmosphere`, the method of `surface_fluxes` which is executed is one which computes the turbulent surface fluxes
-# using MOST. We have a similar function for [net_radiation](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.net_radiation) and which computes the net radiation based on the prescribed downwelling radiative fluxes, stored in an argument
+# In order to compute turbulent surface fluxes, we call [turbulent_fluxes](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.turbulent_fluxes),
+# with arguments including `prescribed_atmosphere`. Since this argument is of the type `PrescribedAtmosphere`, the method of `turbulent_fluxes` which is executed is one which computes the turbulent surface fluxes
+# using MOST. We have a similar function for [net_radiation](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.net_radiation) and which computes the net radiation based on the prescribed downwelling radiative fluxes, stored in an argument
 # `prescribed_radiation`, which is of type `PrescribedRadiation`.
 
 # In the coupled case, we want different behavior. Inside coupler source code, we define new ``coupled`` types to
@@ -80,8 +79,8 @@ FT = Float32;
 struct CoupledAtmosphere{FT} <: AbstractAtmosphericDrivers{FT} end
 struct CoupledRadiativeFluxes{FT} <: AbstractRadiativeDrivers{FT} end
 
-# Then, we define a new method for `surface_fluxes` and `net_radiation` which dispatch for these types:
-function ClimaLSM.Bucket.surface_fluxes(
+# Then, we define a new method for `turbulent_fluxes` and `net_radiation` which dispatch for these types:
+function ClimaLSM.turbulent_fluxes(
     atmos::CoupledAtmosphere{FT},
     model::BucketModel{FT},
     p,
@@ -94,7 +93,7 @@ function ClimaLSM.Bucket.surface_fluxes(
 end
 
 
-function ClimaLSM.Bucket.net_radiation(
+function ClimaLSM.net_radiation(
     radiation::CoupledRadiativeFluxes{FT},
     model::BucketModel{FT},
     p,
@@ -110,9 +109,9 @@ end
 # # Precipitation and surface air density
 # Within the right hand side/ODE function calls for the bucket model, we need both the liquid/snow precipitation
 # and the surface air density (for computing specific humidity at the surface). In standalone runs,
-# we call the functions [`surface_air_density`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.surface_air_density),
-#  [`liquid_precipitation`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.liquid_precipitation), and
-# [`snow_precipitation`](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.snow_precipitation).
+# we call the functions [`surface_air_density`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.surface_air_density),
+#  [`liquid_precipitation`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.liquid_precipitation), and
+# [`snow_precipitation`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.snow_precipitation).
 # When the `atmos` type is `PrescribedAtmosphere`, these
 # return the prescribed values for these quantities.
 
@@ -127,11 +126,11 @@ function ClimaLSM.surface_air_density(
     return p.bucket.ρ_sfc
 end
 
-function ClimaLSM.Bucket.liquid_precipitation(atmos::CoupledAtmosphere, p, _)
+function ClimaLSM.liquid_precipitation(atmos::CoupledAtmosphere, p, _)
     return p.bucket.P_liq
 end
 
-function ClimaLSM.Bucket.snow_precipitation(atmos::CoupledAtmosphere, p, _)
+function ClimaLSM.snow_precipitation(atmos::CoupledAtmosphere, p, _)
     return p.bucket.P_snow
 end
 

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -445,7 +445,7 @@ T =
     ] .* (1e3 * 24 * 3600)
 E =
     [
-        parent(sv.saveval[k].soil.sfc_conditions.vapor_flux)[1] for
+        parent(sv.saveval[k].soil.turbulent_fluxes.vapor_flux)[1] for
         k in 1:length(sol.t)
     ] .* (1e3 * 24 * 3600)
 ET_model = T .+ E
@@ -469,8 +469,9 @@ else
 end
 
 # Sensible Heat Flux
-SHF_soil =
-    [parent(sv.saveval[k].soil.sfc_conditions.shf)[1] for k in 1:length(sol.t)]
+SHF_soil = [
+    parent(sv.saveval[k].soil.turbulent_fluxes.shf)[1] for k in 1:length(sol.t)
+]
 SHF_canopy =
     [parent(sv.saveval[k].canopy.energy.shf)[1] for k in 1:length(sol.t)]
 SHF_model = SHF_soil + SHF_canopy
@@ -499,8 +500,9 @@ else
 end
 
 # Latent Heat Flux
-LHF_soil =
-    [parent(sv.saveval[k].soil.sfc_conditions.lhf)[1] for k in 1:length(sol.t)]
+LHF_soil = [
+    parent(sv.saveval[k].soil.turbulent_fluxes.lhf)[1] for k in 1:length(sol.t)
+]
 LHF_canopy =
     [parent(sv.saveval[k].canopy.energy.lhf)[1] for k in 1:length(sol.t)]
 LHF_model = LHF_soil + LHF_canopy
@@ -593,8 +595,8 @@ first_layer_flux = [
 ]
 G_model = [
     (
-        parent(sv.saveval[k].soil.sfc_conditions.shf)[1] +
-        parent(sv.saveval[k].soil.sfc_conditions.lhf)[1] -
+        parent(sv.saveval[k].soil.turbulent_fluxes.shf)[1] +
+        parent(sv.saveval[k].soil.turbulent_fluxes.lhf)[1] -
         parent(sv.saveval[k].soil.R_n)[1]
     ) for k in 1:length(sol.t)
 ]

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -356,7 +356,7 @@ for float_type in (Float32, Float64)
 
         # Evaporation
         E = [
-            parent(sv.saveval[k].soil.sfc_conditions.vapor_flux)[1] for
+            parent(sv.saveval[k].soil.turbulent_fluxes.vapor_flux)[1] for
             k in 2:length(sol.t)
         ]
         # Root sink term: a positive root extraction is a sink term for soil; add minus sign
@@ -459,11 +459,11 @@ for float_type in (Float32, Float64)
 
         # Turbulent fluxes
         LHF = [
-            parent(sv.saveval[k].soil.sfc_conditions.lhf)[1] for
+            parent(sv.saveval[k].soil.turbulent_fluxes.lhf)[1] for
             k in 2:length(sol.t)
         ]
         SHF = [
-            parent(sv.saveval[k].soil.sfc_conditions.shf)[1] for
+            parent(sv.saveval[k].soil.turbulent_fluxes.shf)[1] for
             k in 2:length(sol.t)
         ]
         # Radiation is computed in LW and SW components

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -184,11 +184,11 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
         (; ν, θ_r, d_ds) = soil.parameters
         _D_vapor = FT(LSMP.D_vapor(soil.parameters.earth_param_set))
         evap = [
-            parent(sv.saveval[k].soil.sfc_conditions.vapor_flux)[1] for
+            parent(sv.saveval[k].soil.turbulent_fluxes.vapor_flux)[1] for
             k in 1:length(sol.t)
         ]
         r_ae = [
-            parent(sv.saveval[k].soil.sfc_conditions.r_ae)[1] for
+            parent(sv.saveval[k].soil.turbulent_fluxes.r_ae)[1] for
             k in 1:length(sol.t)
         ]
         T_soil = [parent(sv.saveval[k].soil.T)[end] for k in 1:length(sol.t)]

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -417,10 +417,10 @@ function soil_boundary_fluxes(
     t,
 ) where {FT}
     bc = soil.boundary_conditions.top
-    soil_conditions = surface_fluxes(bc.atmos, soil, Y, p, t)
+    soil_conditions = turbulent_fluxes(bc.atmos, soil, Y, p, t)
     infiltration = soil_surface_infiltration(
         bc.runoff,
-        FT.(bc.atmos.liquid_precip(t)) .+ p.soil.sfc_conditions.vapor_flux,
+        FT.(bc.atmos.liquid_precip(t)) .+ p.soil.turbulent_fluxes.vapor_flux,
         Y,
         p,
         t,
@@ -428,7 +428,7 @@ function soil_boundary_fluxes(
     )
     return @. ClimaLSM.Soil.create_soil_bc_named_tuple(
         infiltration,
-        -p.soil.R_n + p.soil.sfc_conditions.lhf + p.soil.sfc_conditions.shf,
+        -p.soil.R_n + p.soil.turbulent_fluxes.lhf + p.soil.turbulent_fluxes.shf,
     )
 end
 

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -11,9 +11,9 @@ export AbstractAtmosphericDrivers,
     PrescribedRadiativeFluxes,
     compute_ρ_sfc,
     construct_atmos_ts,
-    surface_fluxes,
+    turbulent_fluxes,
     net_radiation,
-    surface_fluxes_at_a_point,
+    turbulent_fluxes_at_a_point,
     liquid_precipitation,
     snow_precipitation,
     vapor_pressure_deficit,
@@ -133,7 +133,7 @@ end
 
 
 """
-    surface_fluxes(atmos::PrescribedAtmosphere{FT},
+    turbulent_fluxes(atmos::PrescribedAtmosphere{FT},
                    model::AbstractModel{FT},
                    Y::ClimaCore.Fields.FieldVector,
                    p::NamedTuple,
@@ -148,7 +148,7 @@ Positive fluxes indicate flow from the ground to the atmosphere.
 It solves for these given atmospheric conditions, stored in `atmos`,
 model parameters, and the surface conditions.
 """
-function surface_fluxes(
+function turbulent_fluxes(
     atmos::PrescribedAtmosphere{FT},
     model::AbstractModel{FT},
     Y::ClimaCore.Fields.FieldVector,
@@ -162,7 +162,7 @@ function surface_fluxes(
     h_sfc = FT.(surface_height(model, Y, p))
     r_sfc = FT.(surface_resistance(model, Y, p, t))
     d_sfc = FT.(displacement_height(model, Y, p))
-    return surface_fluxes_at_a_point.(
+    return turbulent_fluxes_at_a_point.(
         T_sfc,
         q_sfc,
         ρ_sfc,
@@ -177,7 +177,7 @@ function surface_fluxes(
 end
 
 """
-    surface_fluxes_at_a_point(T_sfc::FT,
+    turbulent_fluxes_at_a_point(T_sfc::FT,
                               q_sfc::FT,
                               ρ_sfc::FT,
                               β_sfc::FT,
@@ -203,7 +203,7 @@ and roughness lengths `z_0m, z_0b`.
 This returns an energy flux and a liquid water volume flux, stored in
 a tuple with self explanatory keys.
 """
-function surface_fluxes_at_a_point(
+function turbulent_fluxes_at_a_point(
     T_sfc::FT,
     q_sfc::FT,
     ρ_sfc::FT,

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -20,7 +20,7 @@ using ClimaLSM:
     AbstractRadiativeDrivers,
     liquid_precipitation,
     snow_precipitation,
-    surface_fluxes,
+    turbulent_fluxes,
     net_radiation,
     construct_atmos_ts,
     compute_ρ_sfc,
@@ -554,9 +554,9 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
             )
 
         # Compute turbulent surface fluxes
-        conditions = surface_fluxes(model.atmos, model, Y, p, t)
-        p.bucket.turbulent_energy_flux .= conditions.lhf .+ conditions.shf
-        p.bucket.evaporation .= conditions.vapor_flux
+        turb_fluxes = turbulent_fluxes(model.atmos, model, Y, p, t)
+        p.bucket.turbulent_energy_flux .= turb_fluxes.lhf .+ turb_fluxes.shf
+        p.bucket.evaporation .= turb_fluxes.vapor_flux
 
         # Radiative fluxes
         p.bucket.R_n .= net_radiation(model.radiation, model, Y, p, t)

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -248,7 +248,7 @@ net radiation to the auxiliary variables.
 These variables are updated in place in `soil_boundary_fluxes`.
 """
 boundary_vars(bc::AtmosDrivenFluxBC, ::ClimaLSM.TopBoundary) =
-    (:sfc_conditions, :R_n, :top_bc)
+    (:turbulent_fluxes, :R_n, :top_bc)
 
 """
     boundary_var_domain_names(::AtmosDrivenFluxBC, ::ClimaLSM.TopBoundary))
@@ -313,7 +313,7 @@ If you wish to compute surface fluxes taking into account the
 presence of a canopy, snow, etc, as in a land surface model,
 this is not the correct method to be using.
 
-This function calls the `surface_fluxes` and `net_radiation`
+This function calls the `turbulent_fluxes` and `net_radiation`
 functions, which use the soil surface conditions as well as
 the prescribed atmos and radiation conditions in order to
 compute the surface fluxes using Monin Obukhov Surface Theory.
@@ -331,13 +331,13 @@ function soil_boundary_fluxes(
     t,
 ) where {FT}
 
-    p.soil.sfc_conditions .= surface_fluxes(bc.atmos, model, Y, p, t)
+    p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, model, Y, p, t)
     p.soil.R_n .= net_radiation(bc.radiation, model, Y, p, t)
     # We are ignoring sublimation for now
     precip = FT.(bc.atmos.liquid_precip(t))
     infiltration = soil_surface_infiltration(
         bc.runoff,
-        precip .+ p.soil.sfc_conditions.vapor_flux,
+        precip .+ p.soil.turbulent_fluxes.vapor_flux,
         Y,
         p,
         model.parameters,
@@ -345,7 +345,7 @@ function soil_boundary_fluxes(
     # We do not model the energy flux from infiltration
     return @. create_soil_bc_named_tuple(
         infiltration,
-        p.soil.R_n + p.soil.sfc_conditions.lhf + p.soil.sfc_conditions.shf,
+        p.soil.R_n + p.soil.turbulent_fluxes.lhf + p.soil.turbulent_fluxes.shf,
     )
 end
 

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -7,7 +7,7 @@ import ClimaLSM:
     surface_resistance,
     displacement_height
 
-export canopy_turbulent_surface_fluxes
+export canopy_turbulent_fluxes
 
 
 """
@@ -23,7 +23,7 @@ function ClimaLSM.displacement_height(model::CanopyModel{FT}, Y, p) where {FT}
 end
 
 """
-    canopy_turbulent_surface_fluxes(atmos::PrescribedAtmosphere{FT},
+    canopy_turbulent_fluxes(atmos::PrescribedAtmosphere{FT},
                           model::CanopyModel,
                           Y,
                           p,
@@ -32,14 +32,14 @@ end
 Computes canopy transpiration using Monin-Obukhov Surface Theory,
 the prescribed atmospheric conditions, and the canopy conductance.
 """
-function canopy_turbulent_surface_fluxes(
+function canopy_turbulent_fluxes(
     atmos::PrescribedAtmosphere{FT},
     model::CanopyModel,
     Y,
     p,
     t,
 ) where {FT}
-    conditions = surface_fluxes(atmos, model, Y, p, t)
+    conditions = turbulent_fluxes(atmos, model, Y, p, t)
     # We upscaled LHF and E from leaf level to canopy level via the
     # upscaling of stomatal conductance.
     # Do we need to upscale SHF?
@@ -205,7 +205,7 @@ function canopy_boundary_fluxes!(
 
     # Compute transpiration
     (canopy_transpiration, canopy_shf, canopy_lhf, r_ae) =
-        canopy_turbulent_surface_fluxes(atmos, canopy, Y, p, t)
+        canopy_turbulent_fluxes(atmos, canopy, Y, p, t)
     transpiration .= canopy_transpiration
     shf .= canopy_shf
     lhf .= canopy_lhf

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -119,7 +119,7 @@ for FT in (Float32, Float64)
             )
 
             Y, p, coords = initialize(model)
-            @test propertynames(p.soil.sfc_conditions) ==
+            @test propertynames(p.soil.turbulent_fluxes) ==
                   (:lhf, :shf, :vapor_flux, :r_ae)
             @test propertynames(p.soil) == (
                 :K,
@@ -127,7 +127,7 @@ for FT in (Float32, Float64)
                 :θ_l,
                 :T,
                 :κ,
-                :sfc_conditions,
+                :turbulent_fluxes,
                 :R_n,
                 :top_bc,
                 :bottom_bc,
@@ -211,7 +211,7 @@ for FT in (Float32, Float64)
                 ρ_sfc,
             ) == q_sfc
 
-            conditions = ClimaLSM.surface_fluxes(
+            conditions = ClimaLSM.turbulent_fluxes(
                 model.boundary_conditions.top.atmos,
                 model,
                 Y,
@@ -226,7 +226,7 @@ for FT in (Float32, Float64)
                 t,
             )
             @test R_n == p.soil.R_n
-            @test conditions == p.soil.sfc_conditions
+            @test conditions == p.soil.turbulent_fluxes
 
             fluxes = ClimaLSM.Soil.soil_boundary_fluxes(
                 top_bc,

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -209,7 +209,7 @@ for FT in (Float32, Float64)
         # @test p.canopy.autotrophic_respiration.Ra ==
         exp_tendency!(dY, Y, p, t0)
         (evapotranspiration, shf, lhf) =
-            ClimaLSM.Canopy.canopy_turbulent_surface_fluxes(
+            ClimaLSM.Canopy.canopy_turbulent_fluxes(
                 canopy.atmos,
                 canopy,
                 Y,
@@ -272,7 +272,7 @@ for FT in (Float32, Float64)
 
         VPD = es .- ea
 
-        conditions = surface_fluxes(atmos, canopy, Y, p, t0) #Per unit m^2 of leaf
+        conditions = turbulent_fluxes(atmos, canopy, Y, p, t0) #Per unit m^2 of leaf
         r_ae = Array(parent(conditions.r_ae))[1] # s/m
         ga = 1 / r_ae
         γ = FT(66)
@@ -667,7 +667,7 @@ for FT in (Float32, Float64)
         dY = similar(Y)
         exp_tendency!(dY, Y, p, t0)
         (evapotranspiration, shf, lhf) =
-            canopy_turbulent_surface_fluxes(canopy.atmos, canopy, Y, p, t0)
+            canopy_turbulent_fluxes(canopy.atmos, canopy, Y, p, t0)
         @test p.canopy.hydraulics.fa.:1 == evapotranspiration
         @test p.canopy.energy.lhf == lhf
         @test p.canopy.energy.shf == shf


### PR DESCRIPTION
## Purpose 
Rename "sfc_conditions" and "surface_fluxes" to "turbulent_fluxes", "canopy_turbulent_surface_fluxes" to "canopy_turbulent_fluxes"


## To-do

## Content
Renaming in src, docs, experiments, and tests

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [ ] I have read and checked the items on the review checklist.
