### PR TITLE
add driver variables to cache

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -58,6 +58,7 @@ ClimaLSM.make_tendency_jacobian
 ClimaLSM.make_update_jacobian
 ClimaLSM.∂tendencyBC∂Y
 ClimaLSM.AbstractTridiagonalW
+ClimaLSM.get_drivers
 ```
 
 ## Drivers

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -585,3 +585,8 @@ function Canopy.canopy_radiant_energy_fluxes!(
 ) where {FT, PSE}
     nothing
 end
+
+
+function ClimaLSM.get_drivers(model::SoilCanopyModel)
+    return (model.canopy.atmos, model.canopy.radiation)
+end

--- a/src/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/src/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -85,3 +85,17 @@ model from the prognostic liquid and ice fractions.
 function soil_moisture(driver::PrognosticMet, p, Y, t, z)
     return p.soil.θ_l
 end
+
+
+function ClimaLSM.get_drivers(model::LandSoilBiogeochemistry)
+    bc = model.soil.boundary_conditions.top
+    if typeof(bc) <: AtmosDrivenFluxBC{
+        <:PrescribedAtmosphere,
+        <:AbstractRadiativeDrivers,
+        <:Soil.AbstractRunoffModel,
+    }
+        return (bc.atmos, bc.radiation)
+    else
+        return (model.soilco2.driver.atmos, nothing)
+    end
+end

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -48,7 +48,8 @@ import ClimaLSM:
     surface_evaporative_scaling,
     surface_albedo,
     surface_emissivity,
-    surface_height
+    surface_height,
+    get_drivers
 export BucketModelParameters,
     BucketModel,
     BulkAlbedoFunction,
@@ -622,6 +623,10 @@ function next_albedo(
         sim_date,
         axes(Y.bucket.W),
     )
+end
+
+function ClimaLSM.get_drivers(model::BucketModel)
+    return (model.atmos, model.radiation)
 end
 
 include("./bucket_parameterizations.jl")

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -565,6 +565,10 @@ function ClimaLSM.boundary_flux(
     return ClimaLSM.diffusive_flux(D_c, C_c, C_bc, Δz)
 end
 
+function ClimaLSM.get_drivers(model::SoilCO2Model)
+    return (model.driver.atmos, nothing)
+end
+
 include("./co2_parameterizations.jl")
 
 end # module

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -88,7 +88,8 @@ import ClimaLSM:
     surface_emissivity,
     surface_air_density,
     surface_height,
-    surface_resistance
+    surface_resistance,
+    get_drivers
 export RichardsModel,
     RichardsParameters,
     RichardsTridiagonalW,

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -696,3 +696,16 @@ function ClimaLSM.surface_height(model::EnergyHydrology{FT}, Y, p) where {FT}
     )
     return z_sfc
 end
+
+function ClimaLSM.get_drivers(model::EnergyHydrology)
+    bc = model.boundary_conditions.top
+    if typeof(bc) <: AtmosDrivenFluxBC{
+        <:PrescribedAtmosphere,
+        <:AbstractRadiativeDrivers,
+        <:AbstractRunoffModel,
+    }
+        return (bc.atmos, bc.radiation)
+    else
+        return (nothing, nothing)
+    end
+end

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -20,7 +20,8 @@ import ClimaLSM:
     make_update_boundary_fluxes,
     make_update_aux,
     make_compute_exp_tendency,
-    make_set_initial_cache
+    make_set_initial_cache,
+    get_drivers
 
 using ClimaLSM.Domains: Point, Plane, SphericalSurface
 export SharedCanopyParameters,
@@ -626,6 +627,11 @@ function make_compute_exp_tendency(
     end
     return compute_exp_tendency!
 end
+function ClimaLSM.get_drivers(model::CanopyModel)
+    return (model.atmos, model.radiation)
+end
+
+
 include("./canopy_boundary_fluxes.jl")
 
 #Make the canopy model broadcastable

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -123,7 +123,8 @@ for FT in (Float32, Float64)
             soilco2_args = soilco2_args,
         )
         Y, p, coords = initialize(model)
-
+        @test propertynames(p.drivers) ==
+              (:P_liq, :P_snow, :T, :P, :u, :q, :c_co2)
         function init_soil!(Y, z, params)
             ν = params.ν
             FT = eltype(Y.soil.ϑ_l)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,9 @@ end
 @safetestset "Variable types tests" begin
     include("shared_utilities/variable_types.jl")
 end
+@safetestset "Driver tests" begin
+    include("shared_utilities/drivers.jl")
+end
 
 # Standalone Bucket model tests
 gpu_broken || @safetestset "Bucket albedo types tests" begin

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -1,0 +1,29 @@
+using ClimaCore
+using Test
+using StaticArrays
+using ClimaLSM
+
+FT = Float32
+@testset "Default model, FT = $FT" begin
+    pa = ClimaLSM.PrescribedAtmosphere(
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        FT(1);
+    )
+    pr = ClimaLSM.PrescribedRadiativeFluxes(FT, nothing, nothing, nothing)
+    coords = (; surface = [1, 2, 3])
+    @test ClimaLSM.initialize_drivers(nothing, nothing, coords) == (;)
+    pa_keys = (:P_liq, :P_snow, :T, :P, :u, :q, :c_co2)
+    pa_vals = ([zeros(FT, 3) for k in pa_keys]...,)
+    @test ClimaLSM.initialize_drivers(pa, nothing, coords) ==
+          NamedTuple{pa_keys}(pa_vals)
+    papr_keys = (:P_liq, :P_snow, :T, :P, :u, :q, :c_co2, :SW_d, :LW_d, :θs)
+    papr_vals = ([zeros(FT, 3) for k in papr_keys]...,)
+    @test ClimaLSM.initialize_drivers(pa, pr, coords) ==
+          NamedTuple{papr_keys}(papr_vals)
+end

--- a/test/shared_utilities/variable_types.jl
+++ b/test/shared_utilities/variable_types.jl
@@ -48,6 +48,9 @@ FT = Float32
     dm_update_aux! = make_update_aux(dm)
     @test dm_update_aux!(x[1], x[2], x[3]) == nothing
     @test x == [0, 1, 2, 3]
+
+    @test ClimaLSM.get_drivers(dm) == (nothing, nothing)
+    @test ClimaLSM.add_drivers_to_cache((;), dm, nothing) == (;)
 end
 
 @testset "Default ImEx model, FT = $FT" begin

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -94,6 +94,8 @@ for FT in (Float32, Float64)
             )
             # Initial conditions with no moisture
             Y, p, coords = initialize(model)
+            @test propertynames(p.drivers) ==
+                  (:P_liq, :P_snow, :T, :P, :u, :q, :c_co2, :SW_d, :LW_d, :θs)
             # test if the correct dss buffers were added to aux.
             # We only need to add a dss buffer when there is a horizontal
             # space (spectral element space). So, we check that it is added
@@ -114,7 +116,7 @@ for FT in (Float32, Float64)
                     ),
                 )
             else
-                @test propertynames(p) == (:bucket,)
+                @test propertynames(p) == (:bucket, :drivers)
             end
 
 

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -119,6 +119,8 @@ for FT in (Float32, Float64)
             )
 
             Y, p, coords = initialize(model)
+            @test propertynames(p.drivers) ==
+                  (:P_liq, :P_snow, :T, :P, :u, :q, :c_co2, :SW_d, :LW_d, :θs)
             @test propertynames(p.soil.turbulent_fluxes) ==
                   (:lhf, :shf, :vapor_flux, :r_ae)
             @test propertynames(p.soil) == (

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -182,11 +182,12 @@ for FT in (Float32, Float64)
             radiation = radiation,
         )
         Y, p, coords = ClimaLSM.initialize(canopy)
-
+        @test propertynames(p.drivers) ==
+              (:P_liq, :P_snow, :T, :P, :u, :q, :c_co2, :SW_d, :LW_d, :θs)
         # Check that structure of Y is value (will error if not)
         @test !isnothing(zero(Y))
         @test typeof(canopy.energy) == PrescribedCanopyTempModel{FT}
-        @test propertynames(p) == (:canopy,)
+        @test propertynames(p) == (:canopy, :drivers)
         for component in ClimaLSM.Canopy.canopy_components(canopy)
             # Only hydraulics has a prognostic variable
             if component == :hydraulics
@@ -649,7 +650,7 @@ for FT in (Float32, Float64)
 
         # Check that structure of Y is value (will error if not)
         @test !isnothing(zero(Y))
-        @test propertynames(p) == (:canopy,)
+        @test propertynames(p) == (:canopy, :drivers)
         for component in ClimaLSM.Canopy.canopy_components(canopy)
             # Only hydraulics has a prognostic variable
             if component == :hydraulics

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -347,9 +347,9 @@ for FT in (Float32, Float64)
 
             Y, p, coords = initialize(model)
             if typeof(domain) <: ClimaLSM.Domains.Point
-                @test propertynames(p) == (:canopy,)
+                @test propertynames(p) == (:canopy, :drivers)
             elseif typeof(domain) <: ClimaLSM.Domains.Plane
-                @test propertynames(p) == (:canopy, :dss_buffer_2d)
+                @test propertynames(p) == (:canopy, :dss_buffer_2d, :drivers)
                 @test typeof(p.dss_buffer_2d) == typeof(
                     ClimaCore.Spaces.create_dss_buffer(
                         ClimaCore.Fields.zeros(domain.space.surface),


### PR DESCRIPTION
## Purpose 
Add driver variables to the cache

## To-do


## Content
1. Creates a function which specifies the driver variables based on driver type (`driver_cache`)
2. Creates a function which returns the drivers for a model (`get_drivers`)
3. Employs these functions in `add_drivers_to_cache` which is called in `initialize`


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
