### PR TITLE
add driver update callback and functions, tests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ tutorials = [
         "Intro to standalone models" => "standalone/Usage/model_tutorial.jl",
         "Intro to multi-component models" => "standalone/Usage/LSM_single_column_tutorial.jl",
         "Intro to ClimaLSM Domains" => "standalone/Usage/domain_tutorial.jl",
+        "Intro to forced site-level runs" => "shared_utilities/driver_tutorial.jl",
     ],
     "Running simulations" => [
         "Bucket LSM" => [

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -77,4 +77,5 @@ ClimaLSM.snow_precipitation
 ClimaLSM.surface_temperature
 ClimaLSM.surface_resistance
 ClimaLSM.surface_specific_humidity
+ClimaLSM.make_update_drivers
 ```

--- a/docs/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/tutorials/shared_utilities/driver_tutorial.jl
@@ -1,0 +1,142 @@
+# # Using atmospheric and radiative drivers
+# The goal of this is to outline how to set up simulations driven by
+# prescribed forcing data (``drivers"). These are grouped into
+# radiative forcing and atmospheric forcing. We will first cover
+# the types of forcing we support, followed by how to specify the
+# driver structs given the forcing data and how to update the values
+# used during a simulation.
+
+# # Types of forcing data
+
+# We currently support site-level simulations and have two site-level
+# driver types, `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`.
+
+# The atmosphere driver stores the atmospheric state data as a 
+# function of time, including the liquid precipitation rate (m/s), the
+# snow precipitation rate converted into an equivalent rate of liquid 
+# water (m/s), the atmopheric pressure (Pa), specific humidity, horizontal
+# wind speed (m/s), temperature (K), CO2 concentration (mol/mol), and the
+# height at which these measurements were taken (currently assumed to be the
+# same value for all variables).
+
+# The radiative fluxes driver stores the data required to specify the
+# radiative forcing. We currently support only a single downwelling
+# shortwave and longwave flux (W/m^2). The radiative driver is also where
+# a function which computes the zenith angle for the site is stored.
+
+# Both drivers store the reference time for the data/simulation. 
+# This is the DateTime object which corresponds to the time at which t=0 
+# in the simulation. Additionally, for site-level runs, both drivers store the
+# forcing data as a spline function fit to the data which takes the time
+# `t` as an argument, where `t` is the simulation time measured in seconds since
+# the reference time. The reference time should be in UTC.
+
+# Note: for coupled runs, corresponding types `CoupledAtmosphere` 
+# and `CoupledRadiativeFluxes` exist. However, these are not defined 
+# in ClimaLSM, but rather inside of the Clima Coupler repository.
+
+
+# # Creating site-level drivers for radiation
+
+# First, assume that we have data stored for the longwave and shortwave radiation
+# at a particular site, and that we have read it in to an array, along with the
+# times at which the observations were made and the latitude and longitude of the site.
+using Dates
+using Insolation # for computing zenith angle given lat, lon, time.
+using Dierckx # for fitting splines
+using ClimaLSM
+import ClimaLSM.Parameters as LSMP
+include(joinpath(pkgdir(ClimaLSM), "parameters", "create_parameters.jl"));
+
+# Assume the local_datetime array is read in from the data file.
+local_datetime = DateTime(2013):Dates.Hour(1):DateTime(2013, 1, 7); # one week, hourly data
+# Timezone (offset of local time from UTC in hrs)
+time_offset = 7;
+# Site latitude and longitude
+lat = 38.7441; # degree
+long = -92.2000; # degree
+# Compute the reference time in UTC, and convert local datetime
+# vector into a vector of seconds since the reference time
+ref_time = local_datetime[1] + Dates.Hour(time_offset);
+data_dt = 3600.0;
+seconds = 0:data_dt:((length(local_datetime) - 1) * data_dt);
+
+# Assume the downwelling long and shortwave radiation are read in from the file
+# and are measured at the times in local_datetime. Here, we'll just make them up
+# periodic on daily timescales:
+T = @. 298.15 + 5.0 * sin(2π * (seconds - 3600 * 6) / (3600 * 24));
+LW_d = 5.67 * 10^(-8) .* T .^ 4;
+SW_d = @. max(1400 * sin(2π * (seconds - 3600 * 6) / (3600 * 24)), 0.0);
+
+# Next, fit splines to the data. These splines are what are stored in
+# the driver function. Then we can evaluate the radiative forcing
+# at any simulation time (and not just at times coinciding with measurements).
+# Note that this approach will change in the future.
+LW_d_spline = Spline1D(seconds, LW_d)
+SW_d_spline = Spline1D(seconds, SW_d);
+
+# Finally, for many models we also need to specify the function
+# for computing the zenith angle as a function of simulation time.
+# To do so, we use the `Insolation` package as follows:
+earth_param_set = create_lsm_parameters(Float64);
+insol_params = earth_param_set.insol_params # parameters of Earth's orbit required to compute the insolation
+function zenith_angle(
+    t,
+    ref_time;
+    latitude = lat,
+    longitude = long,
+    insol_params = insol_params,
+)
+    current_datetime = ref_time + Dates.Second(round(t)) # Time in UTC
+
+    d, δ, η_UTC = (Insolation.helper_instantaneous_zenith_angle(
+        current_datetime,
+        ref_time,
+        insol_params,
+    ))
+
+
+    return Insolation.instantaneous_zenith_angle(
+        d,
+        δ,
+        η_UTC,
+        longitude,
+        latitude,
+    )[1]
+end;
+
+# Lastly, we store the splines for downwelling fluxes and the zenith angle function
+# in the `PrescribedRadiativeFluxes` struct:
+radiation = ClimaLSM.PrescribedRadiativeFluxes(
+    Float64,
+    SW_d_spline,
+    LW_d_spline,
+    ref_time;
+    θs = zenith_angle,
+);
+
+# # Updating the driver variables during the simulation
+# The values for LW_d, SW_d, and zenith angle θ_s are stored
+# in the simulation/model cache `p` under the name `drivers`.
+# When you `initialize` the variables and cache of a model,
+# the cache `p` will be returned with memory allocated but all
+# values set to zero:
+p = (; drivers = (LW_d = [0.0], SW_d = [0.0], θs = [0.0]),);
+
+# In order to update them, we can make use of default update functions:
+update_radiation! = ClimaLSM.make_update_drivers(radiation)
+t0 = seconds[1] # midnight local time
+update_radiation!(p.drivers, t0);
+@show(p.drivers);
+
+# During a simulation, the drivers are updated in place in `p.drivers`
+# via a "callback", which is a function which is called a specified times or when
+# certain criteria are met during a simulation.
+# In general, then, we don't update drivers every timestep, but less frequently.
+# For example, the simulation timestep may be 10 minutes, but we may only update
+# the drivers every three hours:
+updateat = collect(seconds[1]:(3600 * 3):seconds[end]);
+updatefunc = update_radiation!;
+cb = ClimaLSM.DriverUpdateCallback(updateat, updatefunc);
+
+# This callback must then be provided to the simulation [`solve`](https://docs.sciml.ai/DiffEqCallbacks/stable/) function.

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -27,3 +27,93 @@ FT = Float32
     @test ClimaLSM.initialize_drivers(pa, pr, coords) ==
           NamedTuple{papr_keys}(papr_vals)
 end
+
+## Driver update callback tests
+@testset "driver callback cond, affect! test, FT = $FT" begin
+    mutable struct Integrator{FT}
+        t::Any
+        dt::Any
+        p::NamedTuple
+    end
+
+    function upd_integrator(integrator::Integrator{FT}, dt) where {FT}
+        integrator.t += dt
+    end
+
+    t0 = Float64(0)
+    dt = Float64(1)
+    tf = Float64(100)
+    t_range = collect(t0:dt:tf)
+    nsteps = Int((tf - t0) / dt)
+    # specify when to update in the callback
+    updateat = collect((t0 + dt * 0.5):(5.5 * dt):tf)
+
+    # set up components of callback
+    cond = ClimaLSM.update_condition(updateat)
+    @test cond(nothing, t0 - dt, nothing) == false
+    @test cond(nothing, tf, nothing) == false
+    @test cond(nothing, t0 + 0.5 * dt, nothing) == true
+    @test cond(nothing, updateat[end], nothing) == true
+    updatefunc = (drivers, t) -> drivers.q .= [t]
+    affect! = ClimaLSM.DriverAffect(updateat, updatefunc)
+    @test affect!.updateat == updateat
+    @test affect!.updatefunc == updatefunc
+
+    p_init = (; drivers = (; q = [FT(-1)]))
+    integrator = Integrator{FT}(t0, dt, p_init)
+    cb = (; affect! = affect!)
+    ClimaLSM.driver_initialize(cb, nothing, t0, integrator)
+    @test integrator.p.drivers.q == [t0]
+    # simulate callback behavior
+    for i in 1:nsteps
+        t = integrator.t
+        if cond(0, t, 0)
+            next_t = first(affect!.updateat)
+            affect!(integrator)
+            @test integrator.p.drivers.q == [next_t]
+        end
+        upd_integrator(integrator, dt)
+    end
+end
+
+@testset "Driver update functions" begin
+    f = (t) -> 10.0
+    pa = ClimaLSM.PrescribedAtmosphere(f, f, f, f, f, f, f, FT(1);)
+    pr = ClimaLSM.PrescribedRadiativeFluxes(FT, f, f, f)
+    coords = (; surface = [1])
+    drivers = ClimaLSM.initialize_drivers(nothing, nothing, coords)
+    nothing_update! = ClimaLSM.make_update_drivers(nothing, nothing)
+    nothing_update!(drivers, 0.0)
+    @test drivers == (;)
+    drivers = ClimaLSM.initialize_drivers(pa, nothing, coords)
+    atmos_only_update! = ClimaLSM.make_update_drivers(pa, nothing)
+    atmos_only_update!(drivers, 0.0)
+    @test drivers.P_liq == [FT(10)]
+    @test drivers.P_snow == [FT(10)]
+    @test drivers.P == [FT(10)]
+    @test drivers.T == [FT(10)]
+    @test drivers.q == [FT(10)]
+    @test drivers.u == [FT(10)]
+    @test drivers.c_co2 == [FT(4.2e-4)]
+
+    drivers = ClimaLSM.initialize_drivers(pa, pr, coords)
+    update! = ClimaLSM.make_update_drivers(pa, pr)
+    update!(drivers, 0.0)
+    @test drivers.P_liq == [FT(10)]
+    @test drivers.P_snow == [FT(10)]
+    @test drivers.P == [FT(10)]
+    @test drivers.T == [FT(10)]
+    @test drivers.q == [FT(10)]
+    @test drivers.u == [FT(10)]
+    @test drivers.c_co2 == [FT(4.2e-4)]
+    @test drivers.SW_d == [FT(10)]
+    @test drivers.LW_d == [FT(10)]
+    @test drivers.θs == [FT(0)]
+
+    drivers = ClimaLSM.initialize_drivers(nothing, pr, coords)
+    rad_only_update! = ClimaLSM.make_update_drivers(nothing, pr)
+    rad_only_update!(drivers, 0.0)
+    @test drivers.SW_d == [FT(10)]
+    @test drivers.LW_d == [FT(10)]
+    @test drivers.θs == [FT(0)]
+end


### PR DESCRIPTION
## Purpose 
Adds the capability to update the drivers (atmospheric and radiative) with a callback. In the future, we will use this instead of updating each timestep as part of the tendency (i.e. instead of within`update_aux!`).


## To-do
- [x] double check logic of when we update the drivers and whether the times should be multiples of the timestep
- [x] Tutorial explaining drivers
- future PR: move all updating of drivers outside of update aux and use the callback instead.


## Content
1. Adds a callback which updates the p.driver fields at the times passed to the callback (`updateat`), which do not need to be a multiple of the timestep. Note that nothing restricts the user from wanting to update the drivers multiple times per step (even though this wouldnt make sense to do - the point of this is to update the drivers less frequently than the number of timesteps). 
2. Creates `update_driver!` functions for our different supported drivers: PrescribedAtmosphere, PrescribedRadiativeFluxes.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [x] I have read and checked the items on the review checklist.
