### PR TITLE
Use callback to update drivers & store rather than doing on the fly in tendency

### DIFF
--- a/docs/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/tutorials/shared_utilities/driver_tutorial.jl
@@ -126,7 +126,7 @@ p = (; drivers = (LW_d = [0.0], SW_d = [0.0], θs = [0.0]));
 # In order to update them, we can make use of default update functions:
 update_radiation! = ClimaLSM.make_update_drivers(radiation)
 t0 = seconds[1] # midnight local time
-update_radiation!(p.drivers, t0);
+update_radiation!(p, t0);
 @show(p.drivers);
 
 # During a simulation, the drivers are updated in place in `p.drivers`

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -329,12 +329,19 @@ set_initial_cache!(p, Y, t0);
 
 n = 16
 saveat = Array(t0:(n * dt):tf)
-
 sv = (;
     t = Array{Float64}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),
 )
-cb = ClimaLSM.NonInterpSavingCallback(sv, saveat);
+saving_cb = ClimaLSM.NonInterpSavingCallback(sv, saveat);
+
+# Create the callback function which updates the forcing variables,
+# or drivers.
+updateat = Array(t0:1800:tf)
+updatefunc = ClimaLSM.make_update_drivers(atmos, radiation)
+driver_cb = ClimaLSM.DriverUpdateCallback(updateat, updatefunc)
+cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
+
 
 # Select a timestepping algorithm and setup the ODE problem.
 

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -174,11 +174,15 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     ode_algo = CTS.ExplicitAlgorithm(timestepper)
 
     saveat = collect(t0:FT(10 * dt):tf)
-    saved_values = (;
+    sv = (;
         t = Array{Float64}(undef, length(saveat)),
         saveval = Array{NamedTuple}(undef, length(saveat)),
     )
-    cb = ClimaLSM.NonInterpSavingCallback(saved_values, saveat)
+    saving_cb = ClimaLSM.NonInterpSavingCallback(sv, saveat)
+    updateat = deepcopy(saveat)
+    updatefunc = ClimaLSM.make_update_drivers(atmos, nothing)
+    driver_cb = ClimaLSM.DriverUpdateCallback(updateat, updatefunc)
+    cb = SciMLBase.CallbackSet(driver_cb, saving_cb)
 
     prob = SciMLBase.ODEProblem(
         CTS.ClimaODEFunction(T_exp! = Soil_bio_exp_tendency!),

--- a/src/ClimaLSM.jl
+++ b/src/ClimaLSM.jl
@@ -204,9 +204,12 @@ per component model.
 function make_set_initial_cache(land::AbstractLandModel)
     components = land_components(land)
     # These functions also call update_aux
+    (atmos, radiation) = get_drivers(land)
+    update_drivers! = make_update_drivers(atmos, radiation)
     set_initial_cache_function_list =
         map(x -> make_set_initial_cache(getproperty(land, x)), components)
     function set_initial_cache!(p, Y0, t0)
+        update_drivers!(p, t0)
         for f! in set_initial_cache_function_list
             f!(p, Y0, t0)
         end

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -48,6 +48,7 @@ of the function `soil_boundary_fluxes` in this case.
 """
 struct CanopyRadiativeFluxes{FT} <: AbstractRadiativeDrivers{FT} end
 
+
 """
     SoilCanopyModel{FT}(;
         soilco2_type::Type{MM},
@@ -325,8 +326,8 @@ function lsm_radiant_energy_fluxes!(
     radiation = canopy.radiation
     earth_param_set = canopy.parameters.earth_param_set
     _σ = LSMP.Stefan(earth_param_set)
-    LW_d = FT(radiation.LW_d(t))
-    SW_d = FT(radiation.SW_d(t))
+    LW_d = p.drivers.LW_d
+    SW_d = p.drivers.SW_d
     c = LSMP.light_speed(earth_param_set)
     h = LSMP.planck_constant(earth_param_set)
     N_a = LSMP.avogadro_constant(earth_param_set)
@@ -415,7 +416,7 @@ function soil_boundary_fluxes(
     soil_conditions = turbulent_fluxes(bc.atmos, soil, Y, p, t)
     infiltration = soil_surface_infiltration(
         bc.runoff,
-        FT.(bc.atmos.liquid_precip(t)) .+ p.soil.turbulent_fluxes.vapor_flux,
+        p.drivers.P_liq .+ p.soil.turbulent_fluxes.vapor_flux,
         Y,
         p,
         t,

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -159,16 +159,6 @@ function make_update_boundary_fluxes(model::AbstractModel)
     return update_boundary_fluxes!
 end
 
-"""
-    make_update_drivers(model::AbstractModel)
-
-Return an `update_drivers!` function that updates the cache parameters in `p`
-corresponding to forcing at the surface.
-"""
-function make_update_drivers(model::AbstractModel)
-    function update_drivers!(p, Y, t) end
-    return update_drivers!
-end
 
 """
      make_update_cache(model::AbstractModel)
@@ -178,11 +168,14 @@ currently only used in `set_initial_cache` since not all
 cache variables are updated at the same time.
 """
 function make_update_cache(model::AbstractModel)
-    update_drivers! = make_update_drivers(model)
+    # if not forced using atmospheric/radiatiave drivers
+    # this return (nothing, nothing)
+    (atmos, radiation) = get_drivers(model)
+    update_drivers! = make_update_drivers(atmos, radiation)
     update_aux! = make_update_aux(model)
     update_boundary_fluxes! = make_update_boundary_fluxes(model)
     function update_cache!(p, Y, t)
-        update_drivers!(p, Y, t)
+        update_drivers!(p, t)
         update_aux!(p, Y, t)
         update_boundary_fluxes!(p, Y, t)
     end

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -200,7 +200,7 @@ function dss_helper!(
 
 This struct is used by `DriverUpdateCallback` to update the values of
 `p.drivers` at different timesteps specified by `updateat`, using the
-function `updatefunc` which takes as arguments (p.drivers, t).
+function `updatefunc` which takes as arguments (p, t).
 """
 mutable struct DriverAffect{updateType, updateFType}
     updateat::updateType
@@ -224,7 +224,7 @@ function (affect!::DriverAffect)(integrator)
         cond = curr_t <= integrator.t && curr_t > (integrator.t - integrator.dt)
         if cond
             # update all drivers to curr_t
-            affect!.updatefunc(integrator.p.drivers, curr_t)
+            affect!.updatefunc(integrator.p, curr_t)
         end
     end
 end
@@ -233,7 +233,7 @@ end
     DriverUpdateCallback(updateat::Vector{FT}, updatefunc)
 
 Constructs a DiscreteCallback which updates the cache `p.drivers` at each time
-specified by `updateat`, using the function `updatefunc` which takes as arguments (p.drivers,t).
+specified by `updateat`, using the function `updatefunc` which takes as arguments (p,t).
 """
 function DriverUpdateCallback(updateat::Vector{FT}, updatefunc) where {FT}
     cond = update_condition(updateat)
@@ -253,7 +253,7 @@ end
 This function updates `p.drivers` at the start of the simulation.
 """
 function driver_initialize(cb, u, t, integrator)
-    cb.affect!.updatefunc(integrator.p.drivers, t)
+    cb.affect!.updatefunc(integrator.p, t)
 end
 
 """

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -64,8 +64,8 @@ function ClimaLSM.surface_air_density(
 ) where {FT}
     thermo_params =
         LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    ts_in = construct_atmos_ts(atmos, t, thermo_params)
-    return compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
+    ts_in = construct_atmos_ts(atmos, p, thermo_params)
+    return compute_ρ_sfc.(thermo_params, ts_in, T_sfc)
 end
 
 """

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -408,7 +408,7 @@ end
 Returns the prescribed air pressure at the top boundary condition at time (t).
 """
 function air_pressure(driver::PrescribedAtmosphere, p, Y, t) # not sure if/why p and Y are needed?
-    return driver.P.(t) # not sure broadcast (.) is needed
+    return p.drivers.P
 end
 
 """

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -334,7 +334,7 @@ function soil_boundary_fluxes(
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, model, Y, p, t)
     p.soil.R_n .= net_radiation(bc.radiation, model, Y, p, t)
     # We are ignoring sublimation for now
-    precip = FT.(bc.atmos.liquid_precip(t))
+    precip = p.drivers.P_liq
     infiltration = soil_surface_infiltration(
         bc.runoff,
         precip .+ p.soil.turbulent_fluxes.vapor_flux,

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -622,8 +622,8 @@ function ClimaLSM.surface_air_density(
 ) where {FT}
     thermo_params =
         LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    ts_in = construct_atmos_ts(atmos, t, thermo_params)
-    return compute_ρ_sfc.(thermo_params, Ref(ts_in), T_sfc)
+    ts_in = construct_atmos_ts(atmos, p, thermo_params)
+    return compute_ρ_sfc.(thermo_params, ts_in, T_sfc)
 end
 
 """

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -63,8 +63,8 @@ function ClimaLSM.surface_resistance(model::CanopyModel{FT}, Y, p, t) where {FT}
     earth_param_set = model.parameters.earth_param_set
     R = FT(LSMP.gas_constant(earth_param_set))
     ρ_liq = FT(LSMP.ρ_cloud_liq(earth_param_set))
-    P_air::FT = model.atmos.P(t)
-    T_air::FT = model.atmos.T(t)
+    P_air = p.drivers.P
+    T_air = p.drivers.T
     leaf_conductance = p.canopy.conductance.gs
     canopy_conductance =
         upscale_leaf_conductance.(
@@ -136,8 +136,8 @@ function ClimaLSM.surface_air_density(
 )
     thermo_params =
         LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    ts_in = construct_atmos_ts(atmos, t, thermo_params)
-    return compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_canopy)
+    ts_in = construct_atmos_ts(atmos, p, thermo_params)
+    return compute_ρ_sfc.(thermo_params, ts_in, T_canopy)
 end
 
 function make_update_boundary_fluxes(canopy::CanopyModel)

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -163,8 +163,9 @@ end
 
 """
     compute_PAR(
-        model::{FT}},
+        model::AbstractRadiationModel,
         solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+        p,
         t,
     )
 
@@ -174,17 +175,19 @@ for a radiative transfer model.
 The estimated PAR is half of the incident shortwave radiation.
 """
 function compute_PAR(
-    model::AbstractRadiationModel{FT},
-    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes{FT},
+    model::AbstractRadiationModel,
+    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+    p,
     t,
-) where {FT}
-    return FT(solar_radiation.SW_d(t) / 2)
+)
+    return p.drivers.SW_d ./ 2
 end
 
 """
     compute_NIR(
-        model::AbstractRadiationModel{FT},
-        solar_radiation::ClimaLSM.PrescribedRadiativeFluxes{FT},
+        model::AbstractRadiationModel,
+        solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+        p,
         t,
     )
 
@@ -194,11 +197,12 @@ for a radiative transfer model.
 The estimated PNIR is half of the incident shortwave radiation.
 """
 function compute_NIR(
-    model::AbstractRadiationModel{FT},
-    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes{FT},
+    model::AbstractRadiationModel,
+    solar_radiation::ClimaLSM.PrescribedRadiativeFluxes,
+    p,
     t,
-) where {FT}
-    return FT(solar_radiation.SW_d(t) / 2)
+)
+    return p.drivers.SW_d ./ 2
 end
 
 # Make radiation models broadcastable
@@ -271,7 +275,7 @@ function canopy_radiant_energy_fluxes!(
     T_soil::FT = s.T(t)
     ϵ_soil = s.ϵ
     _σ = FT(LSMP.Stefan(earth_param_set))
-    LW_d::FT = canopy.radiation.LW_d(t)
+    LW_d = p.drivers.LW_d
 
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p, t)
     LW_d_canopy = @. (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -54,7 +54,7 @@ end
     @test cond(nothing, tf, nothing) == false
     @test cond(nothing, t0 + 0.5 * dt, nothing) == true
     @test cond(nothing, updateat[end], nothing) == true
-    updatefunc = (drivers, t) -> drivers.q .= [t]
+    updatefunc = (p, t) -> p.drivers.q .= [t]
     affect! = ClimaLSM.DriverAffect(updateat, updatefunc)
     @test affect!.updateat == updateat
     @test affect!.updatefunc == updatefunc
@@ -81,39 +81,39 @@ end
     pa = ClimaLSM.PrescribedAtmosphere(f, f, f, f, f, f, f, FT(1);)
     pr = ClimaLSM.PrescribedRadiativeFluxes(FT, f, f, f)
     coords = (; surface = [1])
-    drivers = ClimaLSM.initialize_drivers(nothing, nothing, coords)
+    p = (; drivers = ClimaLSM.initialize_drivers(nothing, nothing, coords))
     nothing_update! = ClimaLSM.make_update_drivers(nothing, nothing)
-    nothing_update!(drivers, 0.0)
-    @test drivers == (;)
-    drivers = ClimaLSM.initialize_drivers(pa, nothing, coords)
+    nothing_update!(p, 0.0)
+    @test p.drivers == (;)
+    p = (; drivers = ClimaLSM.initialize_drivers(pa, nothing, coords))
     atmos_only_update! = ClimaLSM.make_update_drivers(pa, nothing)
-    atmos_only_update!(drivers, 0.0)
-    @test drivers.P_liq == [FT(10)]
-    @test drivers.P_snow == [FT(10)]
-    @test drivers.P == [FT(10)]
-    @test drivers.T == [FT(10)]
-    @test drivers.q == [FT(10)]
-    @test drivers.u == [FT(10)]
-    @test drivers.c_co2 == [FT(4.2e-4)]
+    atmos_only_update!(p, 0.0)
+    @test p.drivers.P_liq == [FT(10)]
+    @test p.drivers.P_snow == [FT(10)]
+    @test p.drivers.P == [FT(10)]
+    @test p.drivers.T == [FT(10)]
+    @test p.drivers.q == [FT(10)]
+    @test p.drivers.u == [FT(10)]
+    @test p.drivers.c_co2 == [FT(4.2e-4)]
 
-    drivers = ClimaLSM.initialize_drivers(pa, pr, coords)
+    p = (; drivers = ClimaLSM.initialize_drivers(pa, pr, coords))
     update! = ClimaLSM.make_update_drivers(pa, pr)
-    update!(drivers, 0.0)
-    @test drivers.P_liq == [FT(10)]
-    @test drivers.P_snow == [FT(10)]
-    @test drivers.P == [FT(10)]
-    @test drivers.T == [FT(10)]
-    @test drivers.q == [FT(10)]
-    @test drivers.u == [FT(10)]
-    @test drivers.c_co2 == [FT(4.2e-4)]
-    @test drivers.SW_d == [FT(10)]
-    @test drivers.LW_d == [FT(10)]
-    @test drivers.θs == [FT(0)]
+    update!(p, 0.0)
+    @test p.drivers.P_liq == [FT(10)]
+    @test p.drivers.P_snow == [FT(10)]
+    @test p.drivers.P == [FT(10)]
+    @test p.drivers.T == [FT(10)]
+    @test p.drivers.q == [FT(10)]
+    @test p.drivers.u == [FT(10)]
+    @test p.drivers.c_co2 == [FT(4.2e-4)]
+    @test p.drivers.SW_d == [FT(10)]
+    @test p.drivers.LW_d == [FT(10)]
+    @test p.drivers.θs == [FT(0)]
 
-    drivers = ClimaLSM.initialize_drivers(nothing, pr, coords)
+    p = (; drivers = ClimaLSM.initialize_drivers(nothing, pr, coords))
     rad_only_update! = ClimaLSM.make_update_drivers(nothing, pr)
-    rad_only_update!(drivers, 0.0)
-    @test drivers.SW_d == [FT(10)]
-    @test drivers.LW_d == [FT(10)]
-    @test drivers.θs == [FT(0)]
+    rad_only_update!(p, 0.0)
+    @test p.drivers.SW_d == [FT(10)]
+    @test p.drivers.LW_d == [FT(10)]
+    @test p.drivers.θs == [FT(0)]
 end

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -154,6 +154,15 @@ for FT in (Float32, Float64)
             init_soil!(Y, coords.subsurface.z, model.parameters)
             set_initial_cache! = make_set_initial_cache(model)
             set_initial_cache!(p, Y, t)
+            space = axes(p.drivers.P_liq)
+            @test p.drivers.P_liq == zeros(space) .+ FT(1e-8)
+            @test p.drivers.P_snow == zeros(space) .+ FT(0)
+            @test p.drivers.T == zeros(space) .+ FT(285)
+            @test p.drivers.u == zeros(space) .+ FT(3)
+            @test p.drivers.q == zeros(space) .+ FT(0.005)
+            @test p.drivers.P == zeros(space) .+ FT(101325)
+            @test p.drivers.LW_d == zeros(space) .+ FT(5.67e-8 * 280.0^4.0)
+            @test p.drivers.SW_d == zeros(space) .+ FT(500)
             face_space = ClimaLSM.Domains.obtain_face_space(
                 model.domain.space.subsurface,
             )
@@ -178,8 +187,8 @@ for FT in (Float32, Float64)
 
             thermo_params =
                 LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-            ts_in = construct_atmos_ts(atmos, t, thermo_params)
-            ρ_sfc = compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
+            ts_in = construct_atmos_ts(atmos, p, thermo_params)
+            ρ_sfc = compute_ρ_sfc.(thermo_params, ts_in, T_sfc)
             @test ClimaLSM.surface_air_density(
                 model.boundary_conditions.top.atmos,
                 model,

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -258,8 +258,8 @@ for FT in (Float32, Float64)
         Rn = FT(shortwave_radiation(t0))
         G = FT(0.0)
         thermo_params = canopy.parameters.earth_param_set.thermo_params
-        ts_in = construct_atmos_ts(atmos, t0, thermo_params)
-        ρa = Thermodynamics.air_density(thermo_params, ts_in)
+        ts_in = construct_atmos_ts(atmos, p, thermo_params)
+        ρa = Thermodynamics.air_density.(thermo_params, ts_in)
         cp =
             FT(cp_m(thermo_params, Thermodynamics.PhasePartition.(q_atmos(t0))))
 
@@ -271,8 +271,8 @@ for FT in (Float32, Float64)
             )
         ea =
             Thermodynamics.partial_pressure_vapor.(
-                Ref(thermo_params),
-                FT.(P_atmos(t0)),
+                thermo_params,
+                FT(P_atmos(t0)),
                 Thermodynamics.PhasePartition.(FT.(q_atmos(t0))),
             )
 
@@ -296,7 +296,7 @@ for FT in (Float32, Float64)
         )[1]
         Lv = FT(2453e6) #J/m^3
 
-        ET = penman_monteith(
+        ET = penman_monteith.(
             Δ, # Rate of change of saturation specific humidity with air temperature. (Pa K−1)
             Rn, # Net irradiance (W m−2), the external source of energy flux
             G, # Ground heat flux (W m−2)
@@ -310,7 +310,7 @@ for FT in (Float32, Float64)
         )
 
         @test abs(
-            (Array(parent(evapotranspiration))[1] - ET) /
+            (Array(parent(evapotranspiration .- ET))[1]) /
             Array(parent(evapotranspiration))[1],
         ) < 0.5
 
@@ -334,7 +334,7 @@ for FT in (Float32, Float64)
             ρ_sfc,
             Ref(Thermodynamics.Liquid()),
         )
-        @test ρ_sfc == compute_ρ_sfc.(Ref(thermo_params), Ref(ts_in), T_sfc)
+        @test ρ_sfc == compute_ρ_sfc.(thermo_params, ts_in, T_sfc)
     end
 
 


### PR DESCRIPTION
## Purpose 
Prior to this PR, we computed the forcing variables on the fly wherever we needed them. This means they were computed at many points within the soil, canopy, etc tendency functions (in update_aux, or update_boundary_fluxes, etc). In previous PRs, we created a spot in the cache `p.drivers` for these variables, and wrote a callback which updates them in place. This PR now uses callbacks in our simulations (experiments and docs) and correctly updates the drivers prior to any tendency computation (change to `set_initial_cache`). It also adjusted the tendency functions (update aux, update boundary fluxes, the actual tendency) to pull the values needed from `p.drivers` instead of computing them, e.g.
`P_liq = FT(atmos.P_liq(t)) -> P_liq = p.drivers.P_liq`

## To-do
[X] add callback to experiments and tutorials
[X] verify results
[X] go over changed tests
[X] optimize the turbulent fluxes computation FUTURE PR
## Content
1. `src/integrated` and `src/standalone` files: remove all examples of computing the drivers at time `t` in any update_aux, update_boundary_fluxes, etc functions [anywhere in a function that is evaluated at each timestep] 
2. `src/shared_utilties/drivers`: similar changes to [1], since these functions are called at each step
3. `src/shared_utilities/models.jl`: update `p.drivers` with `update_drivers!(p.drivers, t0)` correctly with `set_initial_cache` 
4. update tests to adjust for changes in `construct_atmos_ps`, etc, functions
5. update docs and experiments to create a Driver update callback & use it in the simulations.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
