### PR TITLE
add global prescribed atmos and radiation

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -63,7 +63,7 @@ ClimaLSM.get_drivers
 
 ## Drivers
 ```@docs
-ClimaLSM.PrescribedAtmosphere
+ClimaLSM.PrescribedAtmosSite
 ClimaLSM.PrescribedRadiativeFluxes
 ClimaLSM.AbstractAtmosphericDrivers
 ClimaLSM.AbstractRadiativeDrivers

--- a/docs/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/tutorials/shared_utilities/driver_tutorial.jl
@@ -9,11 +9,11 @@
 # # Types of forcing data
 
 # We currently support site-level simulations and have two site-level
-# driver types, `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`.
+# driver types, `PrescribedAtmosSite` and `PrescribedRadiativeFluxes`.
 
-# The atmosphere driver stores the atmospheric state data as a 
+# The atmosphere driver stores the atmospheric state data as a
 # function of time, including the liquid precipitation rate (m/s), the
-# snow precipitation rate converted into an equivalent rate of liquid 
+# snow precipitation rate converted into an equivalent rate of liquid
 # water (m/s), the atmopheric pressure (Pa), specific humidity, horizontal
 # wind speed (m/s), temperature (K), CO2 concentration (mol/mol), and the
 # height at which these measurements were taken (currently assumed to be the
@@ -24,15 +24,15 @@
 # shortwave and longwave flux (W/m^2). The radiative driver is also where
 # a function which computes the zenith angle for the site is stored.
 
-# Both drivers store the reference time for the data/simulation. 
-# This is the DateTime object which corresponds to the time at which t=0 
+# Both drivers store the reference time for the data/simulation.
+# This is the DateTime object which corresponds to the time at which t=0
 # in the simulation. Additionally, for site-level runs, both drivers store the
 # forcing data as a spline function fit to the data which takes the time
 # `t` as an argument, where `t` is the simulation time measured in seconds since
 # the reference time. The reference time should be in UTC.
 
-# Note: for coupled runs, corresponding types `CoupledAtmosphere` 
-# and `CoupledRadiativeFluxes` exist. However, these are not defined 
+# Note: for coupled runs, corresponding types `CoupledAtmosphere`
+# and `CoupledRadiativeFluxes` exist. However, these are not defined
 # in ClimaLSM, but rather inside of the Clima Coupler repository.
 
 

--- a/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
@@ -148,7 +148,7 @@ using ClimaLSM:
     make_update_aux,
     make_exp_tendency,
     make_set_initial_cache,
-    PrescribedAtmosphere,
+    PrescribedAtmosSite,
     PrescribedRadiativeFluxes
 # We also want to plot the solution
 using Plots
@@ -218,7 +218,7 @@ soil_depth = FT(3.5);
 bucket_domain = Column(; zlim = (-soil_depth, FT(0.0)), nelements = 10);
 
 
-# The PrescribedAtmosphere and PrescribedRadiation need to take in a reference
+# The PrescribedAtmosSite and PrescribedRadiation need to take in a reference
 # time, the date of the start of the simulation. In this tutorial we will
 # consider this January 1, 2005.
 ref_time = DateTime(2005);
@@ -245,7 +245,7 @@ u_atmos = (t) -> 3.0;
 q_atmos = (t) -> 0.005;
 h_atmos = FT(2);
 P_atmos = (t) -> 101325;
-bucket_atmos = PrescribedAtmosphere(
+bucket_atmos = PrescribedAtmosSite(
     precip,
     snow_precip,
     T_atmos,

--- a/docs/tutorials/standalone/Bucket/coupled_bucket.jl
+++ b/docs/tutorials/standalone/Bucket/coupled_bucket.jl
@@ -63,13 +63,13 @@ FT = Float32;
 # The user first creates the prescribed atmosphere and prescribed radiation drivers. In
 # pseudo code, this might look something like:
 
-# ` prescribed_atmos = PrescribedAtmosphere{FT}(*driver functions passed in here*)`
+# ` prescribed_atmos = PrescribedAtmosSite{FT}(*driver functions passed in here*)`
 # ` prescribed_radiation = PrescribedRadiativeFluxes{FT}(*driver functions passed in here*) `
 
 # These are stored in the [BucketModel](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.BucketModel) object,
 # along with [BucketParameters](https://clima.github.io/ClimaLSM.jl/dev/APIs/Bucket/#ClimaLSM.Bucket.BucketParameters).
 # In order to compute turbulent surface fluxes, we call [turbulent_fluxes](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.turbulent_fluxes),
-# with arguments including `prescribed_atmosphere`. Since this argument is of the type `PrescribedAtmosphere`, the method of `turbulent_fluxes` which is executed is one which computes the turbulent surface fluxes
+# with arguments including `prescribed_atmosphere`. Since this argument is of the type `PrescribedAtmosSite`, the method of `turbulent_fluxes` which is executed is one which computes the turbulent surface fluxes
 # using MOST. We have a similar function for [net_radiation](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.net_radiation) and which computes the net radiation based on the prescribed downwelling radiative fluxes, stored in an argument
 # `prescribed_radiation`, which is of type `PrescribedRadiation`.
 
@@ -112,7 +112,7 @@ end
 # we call the functions [`surface_air_density`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.surface_air_density),
 #  [`liquid_precipitation`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.liquid_precipitation), and
 # [`snow_precipitation`](https://clima.github.io/ClimaLSM.jl/dev/APIs/shared_utilities/#ClimaLSM.snow_precipitation).
-# When the `atmos` type is `PrescribedAtmosphere`, these
+# When the `atmos` type is `PrescribedAtmosSite`, these
 # return the prescribed values for these quantities.
 
 # In the coupled case, we need to extend these functions with a `CoupledAtmosphere` method:

--- a/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
+++ b/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
@@ -52,7 +52,7 @@ labels = (
     :CO2,
 )
 
-# For every data column to be collected, name of the column in the file, 
+# For every data column to be collected, name of the column in the file,
 # transformation function to desired unit, and string of final unit
 collect_args = [
     ("TA_F", (x) -> x .+ 273.15, "K")
@@ -73,8 +73,8 @@ collect_args = [
     ("CO2_F_MDS", (x) -> x .* 1e-6, "mol")
 ]
 
-# Named tuple mapping every label to a DataColumn with the correct transformed 
-# unit and data status. Automatically fills gaps in the data 
+# Named tuple mapping every label to a DataColumn with the correct transformed
+# unit and data status. Automatically fills gaps in the data
 drivers = (;
     zip(
         labels,
@@ -104,7 +104,7 @@ for (name, column) in required
     end
 end
 if length(missing_drivers) != 0
-    error("Driver data missing for columns: $([missing_drivers[i] * " " for 
+    error("Driver data missing for columns: $([missing_drivers[i] * " " for
         i in 1:length(missing_drivers)]...)")
 end
 
@@ -118,7 +118,7 @@ esat =
 e = @. esat - drivers.VPD.values
 q = @. 0.622 * e ./ (drivers.PA.values - 0.378 * e)
 
-# Create splines for each atmospheric driver needed for PrescribedAtmosphere
+# Create splines for each atmospheric driver needed for PrescribedAtmosSite
 # and for PrescribedRadiation
 seconds = FT.(0:DATA_DT:((length(UTC_DATETIME) - 1) * DATA_DT));
 p_spline = Spline1D(seconds, -drivers.P.values[:]) # m/s
@@ -134,7 +134,7 @@ snow_precip(t) = FT(0) # this is likely not correct
 
 # Construct the drivers. For the reference time we will use the UTC time at the
 # start of the simulation
-atmos = ClimaLSM.PrescribedAtmosphere(
+atmos = ClimaLSM.PrescribedAtmosSite(
     precipitation_function,
     snow_precip,
     atmos_T,

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -99,7 +99,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     co2_boundary_conditions =
         (; top = (CO2 = co2_top_bc,), bottom = (CO2 = co2_bot_bc,))
 
-    # Make a PrescribedAtmosphere - we only care about atmos_p though
+    # Make a PrescribedAtmosSite - we only care about atmos_p though
     precipitation_function = (t) -> 1.0
     snow_precip = (t) -> 1.0
     atmos_T = (t) -> 1.0
@@ -110,7 +110,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     atmos_h = FT(30)
     atmos_co2 = (t) -> 1.0
 
-    atmos = ClimaLSM.PrescribedAtmosphere(
+    atmos = ClimaLSM.PrescribedAtmosSite(
         precipitation_function,
         snow_precip,
         atmos_T,

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -86,7 +86,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     h_atmos = FT(0.1)
     P_atmos = (t) -> 101325
     gustiness = FT(1e-2)
-    atmos = PrescribedAtmosphere(
+    atmos = PrescribedAtmosSite(
         precip,
         precip,
         T_atmos,

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -226,7 +226,7 @@ lsm_aux_domain_names(m::SoilCanopyModel) =
 A method which makes a function; the returned function
 updates the additional auxiliary variables for the integrated model,
 as well as updates the boundary auxiliary variables for all component
-models. 
+models.
 
 This function is called each ode function evaluation, prior to the tendency function
 evaluation.
@@ -389,7 +389,7 @@ end
 ### Extensions of existing functions to account for prognostic soil/canopy
 """
     soil_boundary_fluxes(
-        bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:CanopyRadiativeFluxes},
+        bc::AtmosDrivenFluxBC{<:AbstractAtmosphericDrivers, <:CanopyRadiativeFluxes},
         boundary::ClimaLSM.TopBoundary,
         model::EnergyHydrology{FT},
         Δz,
@@ -404,7 +404,10 @@ energy and water flux at the surface of the soil for use as boundary
 conditions.
 """
 function soil_boundary_fluxes(
-    bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:CanopyRadiativeFluxes},
+    bc::AtmosDrivenFluxBC{
+        <:AbstractAtmosphericDrivers,
+        <:CanopyRadiativeFluxes,
+    },
     boundary::ClimaLSM.TopBoundary,
     soil::EnergyHydrology{FT},
     Δz,

--- a/src/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/src/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -90,7 +90,7 @@ end
 function ClimaLSM.get_drivers(model::LandSoilBiogeochemistry)
     bc = model.soil.boundary_conditions.top
     if typeof(bc) <: AtmosDrivenFluxBC{
-        <:PrescribedAtmosphere,
+        <:AbstractAtmosphericDrivers,
         <:AbstractRadiativeDrivers,
         <:Soil.AbstractRunoffModel,
     }

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -26,7 +26,6 @@ using ClimaLSM:
     compute_ρ_sfc,
     AbstractExpModel,
     heaviside,
-    PrescribedAtmosphere,
     add_dss_buffer_to_aux
 import ClimaLSM:
     make_update_aux,

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -183,7 +183,7 @@ function BulkAlbedoTemporal{FT}(
     t_start,
     space::ClimaCore.Spaces.AbstractSpace;
     get_infile = Bucket.cesm2_albedo_dataset_path,
-    varname = "sw_alb",
+    varnames::Vector{String} = ["sw_alb"],
 ) where {FT}
     # Verify inputs
     if typeof(space) <: ClimaCore.Spaces.PointSpace
@@ -194,7 +194,7 @@ function BulkAlbedoTemporal{FT}(
     data_info = PrescribedDataTemporal{FT}(
         regrid_dirpath,
         get_infile,
-        varname,
+        varnames,
         date_ref,
         t_start,
         space,
@@ -402,14 +402,14 @@ function set_initial_parameter_field!(
     space = axes(surface_coords)
     comms_ctx = ClimaComms.context(space)
     α_sfc = albedo.α_sfc
-    (; infile_path, regrid_dirpath, varname) = α_sfc.file_info
+    (; infile_path, regrid_dirpath, varnames) = α_sfc.file_info
 
     p.bucket.α_sfc .= regrid_netcdf_to_field(
         FT,
         regrid_dirpath,
         comms_ctx,
         infile_path,
-        varname,
+        varnames,
         space,
     )
 end

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -55,7 +55,7 @@ a helper function which computes and returns the surface air density for the buc
 model.
 """
 function ClimaLSM.surface_air_density(
-    atmos::PrescribedAtmosphere{FT},
+    atmos::AbstractAtmosphericDrivers{FT},
     model::BucketModel,
     Y,
     p,

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -310,7 +310,7 @@ struct SoilDrivers{
     FT,
     MET <: AbstractSoilDriver,
     SOC <: AbstractSoilDriver,
-    ATM <: PrescribedAtmosphere{FT},
+    ATM <: AbstractAtmosphericDrivers{FT},
 }
     "Soil temperature and moisture drivers - Prescribed or Prognostic"
     met::MET
@@ -403,11 +403,11 @@ function soil_SOM_C(driver::PrescribedSOC, p, Y, t, z)
 end
 
 """
-    air_pressure(driver::PrescribedAtmosphere, t)
+    air_pressure(::AbstractAtmosphericDrivers, t)
 
 Returns the prescribed air pressure at the top boundary condition at time (t).
 """
-function air_pressure(driver::PrescribedAtmosphere, p, Y, t) # not sure if/why p and Y are needed?
+function air_pressure(::AbstractAtmosphericDrivers, p, Y, t) # TODO remove Y, t?
     return p.drivers.P
 end
 

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -26,7 +26,7 @@ model auxiliary state, which defaults to adding storage for the
 but which can be extended depending on the type of boundary condition used.
 
 Note that `:top_bc` must be present, with the default type and domain name,
-for both the RichardsModel and the 
+for both the RichardsModel and the
 EnergyHydrology soil models.
 
  Use this function in the exact same way you would use `auxiliary_vars`.
@@ -44,7 +44,7 @@ but which can be extended depending on the type of boundary condition used.
 Use this function in the exact same way you would use `auxiliary_vars`.
 
 Note that `:bottom_bc` must be present, with the default type and domain name,
-for both the RichardsModel and the 
+for both the RichardsModel and the
 EnergyHydrology soil models.
 """
 boundary_vars(::NamedTuple, ::ClimaLSM.BottomBoundary) = (:bottom_bc,)
@@ -230,7 +230,7 @@ end
 A helper function which takes in two scalar values of `water_flux`
 and `heat_flux`, and creates a named tuple out of them.
 
-When broadcasted over two ClimaCore.Fields.Field objects, 
+When broadcasted over two ClimaCore.Fields.Field objects,
 this returns a Field of NamedTuples which we can access like
 x.water, x.heat, to obtain the boundary condition fields.
 """
@@ -289,7 +289,7 @@ boundary_var_types(
 """
     soil_boundary_fluxes(
         bc::AtmosDrivenFluxBC{
-            <:PrescribedAtmosphere,
+            <:AbstractAtmosphericDrivers,
             <:PrescribedRadiativeFluxes,
         },
         boundary::ClimaLSM.TopBoundary,
@@ -305,8 +305,9 @@ flux (W/m^2) for the soil `EnergyHydrology` model at the top
 of the soil domain.
 
 This  method of `soil_boundary_fluxes` is for use with
-a  `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`
-struct; for example, this is to be used when driving
+structs that are subtypes of `AbstractAtmosphericDrivers`
+and of `PrescribedRadiativeFluxes`;
+for example, this is to be used when driving
 the soil model in standalone mode with reanalysis data.
 
 If you wish to compute surface fluxes taking into account the
@@ -320,7 +321,7 @@ compute the surface fluxes using Monin Obukhov Surface Theory.
 """
 function soil_boundary_fluxes(
     bc::AtmosDrivenFluxBC{
-        <:PrescribedAtmosphere{FT},
+        <:AbstractAtmosphericDrivers{FT},
         <:PrescribedRadiativeFluxes{FT},
     },
     boundary::ClimaLSM.TopBoundary,

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -593,7 +593,7 @@ end
 
 """
     ClimaLSM.surface_air_density(
-        atmos::PrescribedAtmosphere{FT},
+        atmos::AbstractAtmosphericDrivers{FT},
         model::EnergyHydrology{FT},
         Y,
         p,
@@ -603,7 +603,7 @@ end
 
 Returns the surface air density field of the
 `EnergyHydrology` soil model for the
-`PrescribedAtmosphere` case.
+`AbstractAtmosphericDrivers` case.
 
 This assumes the ideal gas law and hydrostatic
 balance to estimate the air density at the surface
@@ -613,7 +613,7 @@ because the surface air density is not a prognostic
 variable of the soil model.
 """
 function ClimaLSM.surface_air_density(
-    atmos::PrescribedAtmosphere{FT},
+    atmos::AbstractAtmosphericDrivers{FT},
     model::EnergyHydrology{FT},
     Y,
     p,
@@ -700,7 +700,7 @@ end
 function ClimaLSM.get_drivers(model::EnergyHydrology)
     bc = model.boundary_conditions.top
     if typeof(bc) <: AtmosDrivenFluxBC{
-        <:PrescribedAtmosphere,
+        <:AbstractAtmosphericDrivers,
         <:AbstractRadiativeDrivers,
         <:AbstractRunoffModel,
     }

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -78,8 +78,8 @@ prognostically solves Richards equation in the plant is available.
 between canopy model components or those needed to compute boundary
 fluxes.
 - The atmospheric conditions, which are either prescribed
-(of type `PrescribedAtmosphere`) or computed via a coupled simulation
-(of type `CoupledAtmosphere`).
+(of type `PrescribedAtmosSite` or `PrescribedAtmosGlobal`) or computed
+via a coupled simulation (of type `CoupledAtmosphere`).
 - The radiative flux conditions, which are either prescribed
 (of type `PrescribedRadiativeFluxes`) or computed via a coupled simulation
 (of type `CoupledRadiativeFluxes`).
@@ -165,8 +165,9 @@ function CanopyModel{FT}(;
     },
 ) where {FT, PSE}
     if typeof(energy) <: PrescribedCanopyTempModel{FT}
-        @info "Using the PrescribedAtmosphere air temperature as the canopy temperature"
-        @assert typeof(atmos) <: PrescribedAtmosphere{FT}
+        @info "Using the PrescribedAtmos air temperature as the canopy temperature"
+        @assert typeof(atmos) <:
+                Union{PrescribedAtmosSite{FT}, PrescribedAtmosGlobal{FT}}
     end
 
     args = (

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -23,7 +23,7 @@ function ClimaLSM.displacement_height(model::CanopyModel{FT}, Y, p) where {FT}
 end
 
 """
-    canopy_turbulent_fluxes(atmos::PrescribedAtmosphere{FT},
+    canopy_turbulent_fluxes(atmos::AbstractAtmosphericDrivers{FT},
                           model::CanopyModel,
                           Y,
                           p,
@@ -33,7 +33,7 @@ Computes canopy transpiration using Monin-Obukhov Surface Theory,
 the prescribed atmospheric conditions, and the canopy conductance.
 """
 function canopy_turbulent_fluxes(
-    atmos::PrescribedAtmosphere{FT},
+    atmos::AbstractAtmosphericDrivers{FT},
     model::CanopyModel,
     Y,
     p,
@@ -121,13 +121,15 @@ function ClimaLSM.surface_specific_humidity(
 end
 
 """
-    ClimaLSM.surface_air_density(model::CanopyModel, Y, p)
+    ClimaLSM.surface_air_density(
+        atmos::AbstractAtmosphericDrivers,
+        model::CanopyModel, Y, p, t, T_canopy)
 
 A helper function which computes and returns the surface air density for the canopy
 model.
 """
 function ClimaLSM.surface_air_density(
-    atmos::PrescribedAtmosphere,
+    atmos::AbstractAtmosphericDrivers,
     model::CanopyModel,
     Y,
     p,
@@ -159,7 +161,7 @@ end
                                 <:Union{PrescribedCanopyTempModel,BigLeafEnergyModel}
                             },
                             radiation::PrescribedRadiativeFluxes,
-                            atmos::PrescribedAtmosphere,
+                            atmos::AbstractAtmosphericDrivers,
                             Y::ClimaCore.Fields.FieldVector,
                             t,
                             ) where {FT}
@@ -190,7 +192,7 @@ function canopy_boundary_fluxes!(
         <:Union{PrescribedCanopyTempModel, BigLeafEnergyModel},
     },
     radiation::PrescribedRadiativeFluxes,
-    atmos::PrescribedAtmosphere,
+    atmos::AbstractAtmosphericDrivers,
     Y::ClimaCore.Fields.FieldVector,
     t,
 ) where {FT}

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -81,7 +81,7 @@ for FT in (Float32, Float64)
         co2_boundary_conditions =
             (; (top = (; CO2 = co2_top_bc)), (bottom = (; CO2 = co2_bot_bc)))
 
-        # Make a PrescribedAtmosphere - we only care about atmos_p though
+        # Make a PrescribedAtmosSite - we only care about atmos_p though
         precipitation_function = (t) -> 1.0
         snow_precip = (t) -> 1.0
         atmos_T = (t) -> 1.0
@@ -92,7 +92,7 @@ for FT in (Float32, Float64)
         atmos_h = FT(30)
         atmos_co2 = (t) -> 1.0
 
-        atmos = ClimaLSM.PrescribedAtmosphere(
+        atmos = ClimaLSM.PrescribedAtmosSite(
             precipitation_function,
             snow_precip,
             atmos_T,

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -5,7 +5,7 @@ using ClimaLSM
 
 FT = Float32
 @testset "Default model, FT = $FT" begin
-    pa = ClimaLSM.PrescribedAtmosphere(
+    pa = ClimaLSM.PrescribedAtmosSite(
         nothing,
         nothing,
         nothing,
@@ -78,7 +78,7 @@ end
 
 @testset "Driver update functions" begin
     f = (t) -> 10.0
-    pa = ClimaLSM.PrescribedAtmosphere(f, f, f, f, f, f, f, FT(1);)
+    pa = ClimaLSM.PrescribedAtmosSite(f, f, f, f, f, f, f, FT(1);)
     pr = ClimaLSM.PrescribedRadiativeFluxes(FT, f, f, f)
     coords = (; surface = [1])
     p = (; drivers = ClimaLSM.initialize_drivers(nothing, nothing, coords))

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -25,7 +25,7 @@ using ClimaLSM:
     initialize,
     make_update_aux,
     make_set_initial_cache,
-    PrescribedAtmosphere,
+    PrescribedAtmosSite,
     PrescribedRadiativeFluxes
 
 # Bucket model parameters
@@ -305,7 +305,7 @@ if !Sys.iswindows()
             q_atmos = (t) -> 0.0 # no atmos water
             h_atmos = FT(1e-8)
             P_atmos = (t) -> 101325
-            bucket_atmos = PrescribedAtmosphere(
+            bucket_atmos = PrescribedAtmosSite(
                 precip,
                 precip,
                 T_atmos,
@@ -452,7 +452,7 @@ if !Sys.iswindows()
                 h_atmos = FT(1e-8)
                 P_atmos = (t) -> 101325
                 ref_time = DateTime(2005)
-                bucket_atmos = PrescribedAtmosphere(
+                bucket_atmos = PrescribedAtmosSite(
                     precip,
                     precip,
                     T_atmos,

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -15,7 +15,7 @@ using ClimaLSM:
     initialize,
     make_exp_tendency,
     make_set_initial_cache,
-    PrescribedAtmosphere,
+    PrescribedAtmosSite,
     PrescribedRadiativeFluxes
 
 # Bucket model parameters
@@ -71,7 +71,7 @@ for FT in (Float32, Float64)
             q_atmos = (t) -> 0.03
             h_atmos = FT(3)
             P_atmos = (t) -> 101325 # Pa
-            bucket_atmos = PrescribedAtmosphere(
+            bucket_atmos = PrescribedAtmosSite(
                 liquid_precip,
                 snow_precip,
                 T_atmos,
@@ -179,7 +179,7 @@ for FT in (Float32, Float64)
             q_atmos = (t) -> 0.03
             h_atmos = FT(3)
             P_atmos = (t) -> 101325 # Pa
-            bucket_atmos = PrescribedAtmosphere(
+            bucket_atmos = PrescribedAtmosSite(
                 liquid_precip,
                 snow_precip,
                 T_atmos,
@@ -287,7 +287,7 @@ for FT in (Float32, Float64)
         q_atmos = (t) -> 0.03
         h_atmos = FT(3)
         P_atmos = (t) -> 101325 # Pa
-        bucket_atmos = PrescribedAtmosphere(
+        bucket_atmos = PrescribedAtmosSite(
             liquid_precip,
             snow_precip,
             T_atmos,

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -11,7 +11,7 @@ using ClimaLSM:
     initialize,
     make_exp_tendency,
     make_set_initial_cache,
-    PrescribedAtmosphere,
+    PrescribedAtmosSite,
     PrescribedRadiativeFluxes
 
 # Bucket model parameters
@@ -63,7 +63,7 @@ for FT in (Float32, Float64)
             q_atmos = (t) -> 0.0 # no atmos water
             h_atmos = FT(1e-8)
             P_atmos = (t) -> 101325
-            bucket_atmos = PrescribedAtmosphere(
+            bucket_atmos = PrescribedAtmosSite(
                 precip,
                 precip,
                 T_atmos,
@@ -156,7 +156,7 @@ for FT in (Float32, Float64)
             q_atmos = (t) -> 0.01
             h_atmos = FT(30)
             P_atmos = (t) -> 101325
-            bucket_atmos = PrescribedAtmosphere(
+            bucket_atmos = PrescribedAtmosSite(
                 precip,
                 precip_snow,
                 T_atmos,

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -35,7 +35,7 @@ for FT in (Float32, Float64)
         boundary_conditions =
             (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
 
-        # Make a PrescribedAtmosphere - we only care about atmos_p though
+        # Make a PrescribedAtmosSite - we only care about atmos_p though
         precipitation_function = (t) -> 1.0
         snow_precip = (t) -> 1.0
         atmos_T = (t) -> 1.0
@@ -46,7 +46,7 @@ for FT in (Float32, Float64)
         atmos_h = FT(30)
         atmos_co2 = (t) -> 1.0
 
-        atmos = ClimaLSM.PrescribedAtmosphere(
+        atmos = ClimaLSM.PrescribedAtmosSite(
             precipitation_function,
             snow_precip,
             atmos_T,
@@ -106,7 +106,7 @@ for FT in (Float32, Float64)
         boundary_conditions =
             (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
 
-        # Make a PrescribedAtmosphere - we only care about atmos_p though
+        # Make a PrescribedAtmosSite - we only care about atmos_p though
         precipitation_function = (t) -> 1.0
         snow_precip = (t) -> 1.0
         atmos_T = (t) -> 1.0
@@ -117,7 +117,7 @@ for FT in (Float32, Float64)
         atmos_h = FT(30)
         atmos_co2 = (t) -> 1.0
 
-        atmos = ClimaLSM.PrescribedAtmosphere(
+        atmos = ClimaLSM.PrescribedAtmosSite(
             precipitation_function,
             snow_precip,
             atmos_T,

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -74,7 +74,7 @@ for FT in (Float32, Float64)
         q_atmos = (t) -> 0.005
         h_atmos = FT(3)
         P_atmos = (t) -> 101325
-        atmos = PrescribedAtmosphere(
+        atmos = PrescribedAtmosSite(
             precip,
             precip_snow,
             T_atmos,

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -5,7 +5,7 @@ using Thermodynamics
 using Dates
 using StaticArrays
 using ClimaLSM
-using ClimaLSM: PrescribedAtmosphere, PrescribedRadiativeFluxes
+using ClimaLSM: PrescribedAtmosSite, PrescribedRadiativeFluxes
 using ClimaLSM.Canopy
 using ClimaLSM.Canopy.PlantHydraulics
 using ClimaLSM.Domains: Point
@@ -90,7 +90,7 @@ for FT in (Float32, Float64)
         h_atmos = h_int # m
         c_atmos = (t) -> 4.11e-4 # mol/mol
         ref_time = DateTime(2005)
-        atmos = PrescribedAtmosphere(
+        atmos = PrescribedAtmosSite(
             liquid_precip,
             snow_precip,
             T_atmos,
@@ -536,7 +536,7 @@ for FT in (Float32, Float64)
         h_atmos = h_int # m
         c_atmos = (t) -> 4.11e-4 # mol/mol
         ref_time = DateTime(2005)
-        atmos = PrescribedAtmosphere(
+        atmos = PrescribedAtmosSite(
             liquid_precip,
             snow_precip,
             T_atmos,

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -184,7 +184,7 @@ for FT in (Float32, Float64)
         h_atmos = h_int # m
         c_atmos = (t) -> 4.11e-4 # mol/mol
         ref_time = DateTime(2005)
-        atmos = PrescribedAtmosphere(
+        atmos = PrescribedAtmosSite(
             liquid_precip,
             snow_precip,
             T_atmos,
@@ -477,7 +477,7 @@ for FT in (Float32, Float64)
         h_atmos = h_int # m
         c_atmos = (t) -> 4.11e-4 # mol/mol
         ref_time = DateTime(2005)
-        atmos = PrescribedAtmosphere(
+        atmos = PrescribedAtmosSite(
             liquid_precip,
             snow_precip,
             T_atmos,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add types for global atmos and radiation. Write new methods to initialize and update them.

I'll implement this for atmos first and then duplicate for radiation.

closes #442

## To Do
- [x] PrescribedAtmosphere becomes PrescribedAtmosSite, PrescribedRadiation becomes PrescribedRadSite
- [ ] add new types PrescribedAtmosGlobal and PrescribedRadGlobal
  - these will be somewhat analogous to BulkAlbedoFunction and BulkAlbedoTemporal, where one stores FT-valued parameters, and the other stored Field-valued parameters over the entire globe
- [ ] extend `PrescribedDataTemporal/FileInfo/hdwrite_regridfile_rll_to_cgll` to work for files with multiple `varname`s
- [ ] implement methods of [initialize_drivers](https://github.com/CliMA/ClimaLSM.jl/blob/main/src/shared_utilities/drivers.jl#L529-L540) to initialize global atmos and radiation types
- [ ] implement methods of [make_update_drivers](https://github.com/CliMA/ClimaLSM.jl/blob/main/src/shared_utilities/drivers.jl#L626-L637) to update global atmos and radiation types
  - analogous to `next_albedo` (maybe rename to `update_albedo` for consistency)
    - uses read_data_fields!(::PrescribedDataTemporal, date, space)

## Notes
- `PrescribedAtmosGlobal` is largely following `BulkAlbedoTemporal`, but needs an array of `varname`s since the input file contains many variables we want to read in
  - extend `PrescribedDataTemporal` constructor to dispatch on `varname` type?
  - `varname` goes into `FileInfo` --> loop over weights in hdwrite_regridfile_rll_to_cgll (avoids having to recreate regridding objects)
  - can we assume all variables in same file will be on same grid, or do we need to create new weight matrix for each? --> assume same grid since output from same simulation
- should probably regrid only the dates we want to use in our simulation, rather than everything in file (as we've been doing)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
