### PR TITLE
Sign convention on precip and melt flux

### DIFF
--- a/docs/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/tutorials/shared_utilities/driver_tutorial.jl
@@ -121,7 +121,7 @@ radiation = ClimaLSM.PrescribedRadiativeFluxes(
 # When you `initialize` the variables and cache of a model,
 # the cache `p` will be returned with memory allocated but all
 # values set to zero:
-p = (; drivers = (LW_d = [0.0], SW_d = [0.0], θs = [0.0]),);
+p = (; drivers = (LW_d = [0.0], SW_d = [0.0], θs = [0.0]));
 
 # In order to update them, we can make use of default update functions:
 update_radiation! = ClimaLSM.make_update_drivers(radiation)

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -63,8 +63,8 @@ for FT in (Float32, Float64)
             LW_d = (t) -> 20
             bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time)
             "Atmos"
-            liquid_precip = (t) -> 1e-8 # precipitation
-            snow_precip = (t) -> 1e-7 # precipitation
+            liquid_precip = (t) -> -1e-8 # precipitation
+            snow_precip = (t) -> -1e-7 # precipitation
 
             T_atmos = (t) -> 280.0
             u_atmos = (t) -> 10.0
@@ -134,13 +134,13 @@ for FT in (Float32, Float64)
                 )
             F_melt = partitioned_fluxes.F_melt
             F_into_snow =
-                partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* FT(snow_precip(t0))
+                partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
             G = partitioned_fluxes.G
             F_sfc =
-                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
+                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .-
                 _ρLH_f0 .* FT(snow_precip(t0))
             F_water_sfc =
-                FT(liquid_precip(t0)) + FT(snow_precip(t0)) .-
+                FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+
                 p.bucket.evaporation
 
             if i == 1
@@ -156,7 +156,7 @@ for FT in (Float32, Float64)
             @test sum(de_soil) ≈ sum(-1 .* G) / A_point
 
             dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
-            @test sum(dWL) / A_point ≈ sum(F_water_sfc) / A_point
+            @test sum(dWL) / A_point ≈ -sum(F_water_sfc) / A_point
 
             dIL = sum(dIsnow) / A_point .+ sum(de_soil)
             @test dIL ≈ sum(-1 .* F_sfc) / A_point
@@ -171,8 +171,8 @@ for FT in (Float32, Float64)
             LW_d = (t) -> 20
             bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time)
             "Atmos"
-            liquid_precip = (t) -> 1e-8 # precipitation
-            snow_precip = (t) -> 1e-7 # precipitation
+            liquid_precip = (t) -> -1e-8 # precipitation
+            snow_precip = (t) -> -1e-7 # precipitation
 
             T_atmos = (t) -> 280
             u_atmos = (t) -> 10
@@ -242,13 +242,13 @@ for FT in (Float32, Float64)
                 )
             F_melt = partitioned_fluxes.F_melt
             F_into_snow =
-                partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* FT(snow_precip(t0))
+                partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
             G = partitioned_fluxes.G
             F_sfc =
-                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
+                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .-
                 _ρLH_f0 .* FT(snow_precip(t0))
             F_water_sfc =
-                FT(liquid_precip(t0)) + FT(snow_precip(t0)) .-
+                FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+
                 p.bucket.evaporation
 
             if i == 1
@@ -264,7 +264,7 @@ for FT in (Float32, Float64)
             @test sum(de_soil) ≈ sum(-1 .* G) / A_point
 
             dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
-            @test sum(dWL) / A_point ≈ sum(F_water_sfc) / A_point
+            @test sum(dWL) / A_point ≈ -sum(F_water_sfc) / A_point
 
             dIL = sum(dIsnow) / A_point .+ sum(de_soil)
             @test dIL ≈ sum(-1 .* F_sfc) / A_point
@@ -279,8 +279,8 @@ for FT in (Float32, Float64)
         LW_d = (t) -> 20
         bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time)
         "Atmos"
-        liquid_precip = (t) -> 1e-8 # precipitation
-        snow_precip = (t) -> 1e-7 # precipitation
+        liquid_precip = (t) -> -1e-8 # precipitation
+        snow_precip = (t) -> -1e-7 # precipitation
 
         T_atmos = (t) -> 280
         u_atmos = (t) -> 10
@@ -354,13 +354,13 @@ for FT in (Float32, Float64)
             )
         F_melt = partitioned_fluxes.F_melt
         F_into_snow =
-            partitioned_fluxes.F_into_snow .+ _ρLH_f0 .* FT(snow_precip(t0))
+            partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
         G = partitioned_fluxes.G
         F_sfc =
-            p.bucket.turbulent_energy_flux .+ p.bucket.R_n .+
+            p.bucket.turbulent_energy_flux .+ p.bucket.R_n .-
             _ρLH_f0 .* FT(snow_precip(t0))
         F_water_sfc =
-            FT(liquid_precip(t0)) + FT(snow_precip(t0)) .- p.bucket.evaporation
+            FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+ p.bucket.evaporation
 
         dIsnow = -_ρLH_f0 .* dY.bucket.σS
         @test sum(dIsnow) ≈ sum(-1 .* F_into_snow)
@@ -369,7 +369,7 @@ for FT in (Float32, Float64)
         @test sum(de_soil) ≈ sum(-1 .* G)
 
         dWL = dY.bucket.W .+ dY.bucket.Ws .+ dY.bucket.σS
-        @test sum(dWL) ≈ sum(F_water_sfc)
+        @test sum(dWL) ≈ -sum(F_water_sfc)
 
         dIL = sum(dIsnow) .+ sum(de_soil)
         @test dIL ≈ sum(-1 .* F_sfc)

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -149,7 +149,7 @@ for FT in (Float32, Float64)
             LW_d = (t) -> 300
             bucket_rad = PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time)
             "Atmos"
-            precip = (t) -> 1e-6
+            precip = (t) -> -1e-6
             precip_snow = (t) -> 0
             T_atmos = (t) -> 298
             u_atmos = (t) -> 4
@@ -197,8 +197,8 @@ for FT in (Float32, Float64)
             set_initial_cache!(p, Y, t0)
             dY = similar(Y)
             exp_tendency!(dY, Y, p, t0)
-            F_water_sfc = FT(precip(t0)) .- p.bucket.evaporation
-            F_sfc = -1 .* (p.bucket.turbulent_energy_flux .+ p.bucket.R_n)
+            F_water_sfc = FT(precip(t0)) .+ p.bucket.evaporation
+            F_sfc = p.bucket.turbulent_energy_flux .+ p.bucket.R_n
             surface_space = model.domain.space.surface
             A_sfc = sum(ones(surface_space))
             # For the point space, we actually want the flux itself, since our variables are per unit area.
@@ -207,8 +207,8 @@ for FT in (Float32, Float64)
                 F_sfc .= F_sfc ./ A_sfc
             end
 
-            @test sum(F_water_sfc) ≈ sum(dY.bucket.W .+ dY.bucket.Ws)
-            @test sum(F_sfc) ≈ sum(dY.bucket.T .* ρc_soil)
+            @test -sum(F_water_sfc) ≈ sum(dY.bucket.W .+ dY.bucket.Ws)
+            @test -sum(F_sfc) ≈ sum(dY.bucket.T .* ρc_soil)
         end
     end
 end


### PR DESCRIPTION
## Purpose 
Conform to agreed upon convention that fluxes are positive if towards atmos and negative if towards ground. 
Therefore, precipitation should be negative and snow melt should be negative (corresponds to an increase in the energy of snow, or a negative heat flux).

Doc updated as well https://www.overleaf.com/project/625c5f7677155b314c98eb75
## To-do


## Content
Propagate sign changes from the doc throughout the repo - src/standalone/Bucket files, and the tests and tutorials for the bucket.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
