### PR TITLE
Refactor how we handle radiation, especially under a canopy

### DIFF
--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -31,7 +31,7 @@ struct SoilCanopyModel{
     "The canopy model to be used"
     canopy::VM
 end
-
+#Perhaps remove this
 """
     CanopyRadiativeFluxes{FT} <: AbstractRadiativeDrivers{FT}
 


### PR DESCRIPTION
## Purpose 
We currently do some confusing things for handling soil boundary conditions under a canopy, specifically when it comes to radiation. In the standalone case, we use a boundary condition type satisfying
`typeof(bc) = AtmosDrivenFluxBC{<:PrescribedAtmos, <:PrescribedRadiativeFluxes}` and call `soil_boundary_fluxes`, which dispatches of of this type. This then calls two functions internally,
`turbulent_fluxes(bc.atmos, soil, Y, p, t)` and `net_radiation(bc.radiation, soil, Y, p, t)`.

The `turbulent_fluxes` and `net_radiation` functions are used also in the BucketModel and they will be used in the snow standalone model too. So, these functions dispatch off of the type of the model and off of the type of atmos/radiation and have some reusability. For the canopy, we use a specialized radiation function but also use `turbulent_fluxes`. For land models we dont use either, i.e. there is no `turbulent_fluxes(atmos, land_model, Y, p,t)` method.

The central issue seems to be that for soil under canopy, we need to compute the radiation in a different way. The `net_radiation` function doesnt accomodate this very well (because we still have the same type of soil model and `PrescribedRadiativeFluxes` as forcing). In our current code, we made up a `CanopyRadiativeFluxes` type of `AbstractRadiativeDriver` to get around this, but not even at the `net_radiation` level. Instead, it is at the `soil_boundary_fluxes(AtmosDrivenFluxBC{<:PrescribedAtmos, <:CanopyRadiativeFluxes})` level

The issues are that 
- we dont use `net_radiation` in this case. It also might be nice if we could consistently use `net_radiation` here and for the canopy model as well, instead of having a one off special function. But the canopy model has more complex radiation (shortwave handled in a different place than longwave radiation), so Im not sure.
- `CanopyRadiativeFluxes` isnt really a "driver". The model is still forced with PrescribedRadiation. `update_drivers` doesnt make sense for `CanopyRadiativeFluxes`. This leads to some weird things when we set the initial cache in land models.
- more?

It seems like a solution would allow us to distinguish between being under a canopy vs not, since we do different computations here, probably with a type and with multiple dispatch, but that that new type shouldnt really be an `AbstractRadiativeDriver`. Maybe it should be a new type of soil BC, e.g. `CanopyFluxBC`?



## To-do
Workshop a solution with @juliasloan25 

## Content



Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [ ] I have read and checked the items on the review checklist.
