### PR TITLE
default initialize_drivers

### DIFF
--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -567,11 +567,14 @@ function initialize_drivers(r::PrescribedRadiativeFluxes{FT}, coords) where {FT}
 end
 
 """
-    initialize_drivers(d::Nothing, coords)
+    initialize_drivers(d::Union{AbstractAtmosphericDrivers, AbstractRadiativeDrivers, Nothing}, coords)
 
 Creates and returns a NamedTuple with `nothing` when no driver cache variables are needed.
 """
-function initialize_drivers(d::Nothing, coords)
+function initialize_drivers(
+    d::Union{AbstractAtmosphericDrivers, AbstractRadiativeDrivers, Nothing},
+    coords,
+)
     return (;)
 end
 


### PR DESCRIPTION
## Purpose 
Right now, the `make_update_drivers` update function defualt is not compatible with the `initialize_drivers` function default. The first case is a default for any AbstractDriver or a Nothing type, which the latter is a specific method for drivers of type Nothing.


## To-do



## Content
Adjust type specification


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
