### PR TITLE
Move driver interface code from the Coupler to ClimaLSM

### DIFF
--- a/docs/src/APIs/canopy/Canopy.md
+++ b/docs/src/APIs/canopy/Canopy.md
@@ -14,7 +14,6 @@ ClimaLSM.Canopy.SharedCanopyParameters
 
 ```@docs
 ClimaLSM.Canopy.DiagnosticTranspiration
-ClimaLSM.Canopy.canopy_turbulent_fluxes
 ```
 
 ## Canopy Model Soil Drivers

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -65,6 +65,8 @@ ClimaLSM.get_drivers
 ```@docs
 ClimaLSM.PrescribedAtmosphere
 ClimaLSM.PrescribedRadiativeFluxes
+ClimaLSM.CoupledAtmosphere
+ClimaLSM.CoupledRadiativeFluxes
 ClimaLSM.AbstractAtmosphericDrivers
 ClimaLSM.AbstractRadiativeDrivers
 ClimaLSM.turbulent_fluxes

--- a/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
@@ -349,16 +349,20 @@ Ws = [parent(sol.u[k].bucket.Ws)[1] for k in 1:length(sol.t)];
 T_sfc =
     [parent(saved_values.saveval[k].bucket.T_sfc)[1] for k in 1:length(sol.t)];
 evaporation = [
-    parent(saved_values.saveval[k].bucket.evaporation)[1] for
-    k in 1:length(sol.t)
+    parent(saved_values.saveval[k].bucket.turbulent_fluxes.vapor_flux)[1]
+    for k in 1:length(sol.t)
 ];
 R_n = [parent(saved_values.saveval[k].bucket.R_n)[1] for k in 1:length(sol.t)];
 # The turbulent energy flux is the sum of latent and sensible heat fluxes.
-turbulent_energy_flux = [
-    parent(saved_values.saveval[k].bucket.turbulent_energy_flux)[1] for
+LHF = [
+    parent(saved_values.saveval[k].bucket.turbulent_fluxes.lhf)[1] for
     k in 1:length(sol.t)
 ];
-
+SHF = [
+    parent(saved_values.saveval[k].bucket.turbulent_fluxes.shf)[1] for
+    k in 1:length(sol.t)
+];
+turbulent_energy_flux = SHF .+ LHF
 
 plot(
     sol.t ./ 86400,

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -49,26 +49,6 @@ function ClimaLSM.surface_height(model::BucketModel{FT}, Y, p) where {FT}
 end
 
 """
-    ClimaLSM.surface_air_density(model::BucketModel, Y, p)
-
-a helper function which computes and returns the surface air density for the bucket
-model.
-"""
-function ClimaLSM.surface_air_density(
-    atmos::PrescribedAtmosphere{FT},
-    model::BucketModel,
-    Y,
-    p,
-    t,
-    T_sfc,
-) where {FT}
-    thermo_params =
-        LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    ts_in = construct_atmos_ts(atmos, p, thermo_params)
-    return compute_ρ_sfc.(thermo_params, ts_in, T_sfc)
-end
-
-"""
     ClimaLSM.surface_evaporative_scaling(model::BucketModel, Y, p)
 
 a helper function which computes and returns the surface evaporative scaling

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -86,7 +86,6 @@ import ClimaLSM:
     surface_specific_humidity,
     surface_albedo,
     surface_emissivity,
-    surface_air_density,
     surface_height,
     surface_resistance,
     get_drivers

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -262,7 +262,7 @@ boundary_var_domain_names(bc::AtmosDrivenFluxBC, ::ClimaLSM.TopBoundary) =
 """
     boundary_var_types(
         ::AtmosDrivenFluxBC{
-            <:AbstractAtmosphericDrivers{FT},
+            <:PrescribedAtmosphere{FT},
             <:AbstractRadiativeDrivers{FT},
             <:AbstractRunoffModel,
         }, ::ClimaLSM.TopBoundary,
@@ -274,7 +274,7 @@ specifies the type of the additional variables.
 boundary_var_types(
     model::EnergyHydrology{FT},
     bc::AtmosDrivenFluxBC{
-        <:AbstractAtmosphericDrivers{FT},
+        <:PrescribedAtmosphere{FT},
         <:AbstractRadiativeDrivers{FT},
         <:AbstractRunoffModel,
     },
@@ -293,21 +293,16 @@ boundary_var_types(
             <:PrescribedRadiativeFluxes,
         },
         boundary::ClimaLSM.TopBoundary,
-        model::EnergyHydrology{FT},
+        model::EnergyHydrology,
         Δz,
         Y,
         p,
         t,
-    ) where {FT}
+    )
 
 Returns the net volumetric water flux (m/s) and net energy
 flux (W/m^2) for the soil `EnergyHydrology` model at the top
 of the soil domain.
-
-This  method of `soil_boundary_fluxes` is for use with
-a  `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`
-struct; for example, this is to be used when driving
-the soil model in standalone mode with reanalysis data.
 
 If you wish to compute surface fluxes taking into account the
 presence of a canopy, snow, etc, as in a land surface model,
@@ -315,21 +310,18 @@ this is not the correct method to be using.
 
 This function calls the `turbulent_fluxes` and `net_radiation`
 functions, which use the soil surface conditions as well as
-the prescribed atmos and radiation conditions in order to
+the atmos and radiation conditions in order to
 compute the surface fluxes using Monin Obukhov Surface Theory.
 """
 function soil_boundary_fluxes(
-    bc::AtmosDrivenFluxBC{
-        <:PrescribedAtmosphere{FT},
-        <:PrescribedRadiativeFluxes{FT},
-    },
+    bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:PrescribedRadiativeFluxes},
     boundary::ClimaLSM.TopBoundary,
-    model::EnergyHydrology{FT},
+    model::EnergyHydrology,
     Δz,
     Y,
     p,
     t,
-) where {FT}
+)
 
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, model, Y, p, t)
     p.soil.R_n .= net_radiation(bc.radiation, model, Y, p, t)

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -592,41 +592,6 @@ function ClimaLSM.surface_albedo(model::EnergyHydrology{FT}, Y, p) where {FT}
 end
 
 """
-    ClimaLSM.surface_air_density(
-        atmos::PrescribedAtmosphere{FT},
-        model::EnergyHydrology{FT},
-        Y,
-        p,
-        t,
-        T_sfc
-    ) where {FT}
-
-Returns the surface air density field of the
-`EnergyHydrology` soil model for the
-`PrescribedAtmosphere` case.
-
-This assumes the ideal gas law and hydrostatic
-balance to estimate the air density at the surface
-from the values of surface temperature and the atmospheric
-thermodynamic state,
-because the surface air density is not a prognostic
-variable of the soil model.
-"""
-function ClimaLSM.surface_air_density(
-    atmos::PrescribedAtmosphere{FT},
-    model::EnergyHydrology{FT},
-    Y,
-    p,
-    t,
-    T_sfc,
-) where {FT}
-    thermo_params =
-        LSMP.thermodynamic_parameters(model.parameters.earth_param_set)
-    ts_in = construct_atmos_ts(atmos, p, thermo_params)
-    return compute_ρ_sfc.(thermo_params, ts_in, T_sfc)
-end
-
-"""
     ClimaLSM.surface_specific_humidity(
         model::EnergyHydrology{FT},
         Y,

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -133,8 +133,9 @@ for FT in (Float32, Float64)
                     p.bucket.T_sfc,
                     model.parameters.τc,
                     snow_cover_fraction.(Y.bucket.σS),
-                    p.bucket.evaporation,
-                    p.bucket.turbulent_energy_flux .+ p.bucket.R_n,
+                    p.bucket.turbulent_fluxes.vapor_flux,
+                    p.bucket.turbulent_fluxes.lhf .+
+                    p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n,
                     _ρLH_f0,
                     _T_freeze,
                 )
@@ -143,11 +144,12 @@ for FT in (Float32, Float64)
                 partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
             G = partitioned_fluxes.G
             F_sfc =
-                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .-
+                p.bucket.turbulent_fluxes.lhf .+
+                p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n .-
                 _ρLH_f0 .* FT(snow_precip(t0))
             F_water_sfc =
                 FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+
-                p.bucket.evaporation
+                p.bucket.turbulent_fluxes.vapor_flux
 
             if i == 1
                 A_point = sum(ones(bucket_domains[i].space.surface))
@@ -246,8 +248,9 @@ for FT in (Float32, Float64)
                     p.bucket.T_sfc,
                     model.parameters.τc,
                     snow_cover_fraction.(Y.bucket.σS),
-                    p.bucket.evaporation,
-                    p.bucket.turbulent_energy_flux .+ p.bucket.R_n,
+                    p.bucket.turbulent_fluxes.vapor_flux,
+                    p.bucket.turbulent_fluxes.lhf .+
+                    p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n,
                     _ρLH_f0,
                     _T_freeze,
                 )
@@ -256,11 +259,12 @@ for FT in (Float32, Float64)
                 partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
             G = partitioned_fluxes.G
             F_sfc =
-                p.bucket.turbulent_energy_flux .+ p.bucket.R_n .-
+                p.bucket.turbulent_fluxes.lhf .+
+                p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n .-
                 _ρLH_f0 .* FT(snow_precip(t0))
             F_water_sfc =
                 FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+
-                p.bucket.evaporation
+                p.bucket.turbulent_fluxes.vapor_flux
 
             if i == 1
                 A_point = sum(ones(bucket_domains[i].space.surface))
@@ -347,7 +351,7 @@ for FT in (Float32, Float64)
         random = zeros(bucket_domains[i].space.surface)
         ArrayType = ClimaComms.array_type(Y)
         parent(random) .= ArrayType(rand(FT, size(parent(random))))
-        p.bucket.evaporation .= random .* 1e-7
+        p.bucket.turbulent_fluxes.vapor_flux .= random .* 1e-7
         compute_exp_tendency!(dY, Y, p, t0)
         _LH_f0 = LSMP.LH_f0(model.parameters.earth_param_set)
         _ρ_liq = LSMP.ρ_cloud_liq(model.parameters.earth_param_set)
@@ -363,8 +367,9 @@ for FT in (Float32, Float64)
                 p.bucket.T_sfc,
                 model.parameters.τc,
                 snow_cover_fraction.(Y.bucket.σS),
-                p.bucket.evaporation,
-                p.bucket.turbulent_energy_flux .+ p.bucket.R_n,
+                p.bucket.turbulent_fluxes.vapor_flux,
+                p.bucket.turbulent_fluxes.lhf .+
+                p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n,
                 _ρLH_f0,
                 _T_freeze,
             )
@@ -373,10 +378,11 @@ for FT in (Float32, Float64)
             partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
         G = partitioned_fluxes.G
         F_sfc =
-            p.bucket.turbulent_energy_flux .+ p.bucket.R_n .-
-            _ρLH_f0 .* FT(snow_precip(t0))
+            p.bucket.turbulent_fluxes.lhf .+ p.bucket.turbulent_fluxes.shf .+
+            p.bucket.R_n .- _ρLH_f0 .* FT(snow_precip(t0))
         F_water_sfc =
-            FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+ p.bucket.evaporation
+            FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+
+            p.bucket.turbulent_fluxes.vapor_flux
 
         dIsnow = -_ρLH_f0 .* dY.bucket.σS
         @test sum(dIsnow) ≈ sum(-1 .* F_into_snow)

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -208,8 +208,10 @@ for FT in (Float32, Float64)
             set_initial_cache!(p, Y, t0)
             dY = similar(Y)
             exp_tendency!(dY, Y, p, t0)
-            F_water_sfc = FT(precip(t0)) .+ p.bucket.evaporation
-            F_sfc = p.bucket.turbulent_energy_flux .+ p.bucket.R_n
+            F_water_sfc = FT(precip(t0)) .+ p.bucket.turbulent_fluxes.vapor_flux
+            F_sfc =
+                p.bucket.turbulent_fluxes.lhf .+
+                p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n
             surface_space = model.domain.space.surface
             A_sfc = sum(ones(surface_space))
             # For the point space, we actually want the flux itself, since our variables are per unit area.


### PR DESCRIPTION
## Purpose 
Add Coupled Driver types to ClimaLSM (currently they are defined in ClimaCoupler). There are also methods that are defined in ClimaCoupler for these types, which this PR moves into ClimaLSM.

Lastly, we unify use of `turbulent_fluxes` and `surface_air_density` between standalone models in ClimaLSM here, which slightly changes how these are stored in the Bucket model cache.

See issue #449 


## To-do
[] unit tests

## Content
I think self-explanatory from the description of purpose. some variables are present only in prescribed vs coupled runs, but ideally we can handle that with dispatch off of the Atmos type. (rho_sfc, e.g.)

Note that the `PrescribedAtmos` etc driver types have methods for `update_drivers!` which are called during callbacks. In coupled runs, we do not need to do any updating on the ClimaLSM side, so these methods do not exist and we would not set a callback.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [ ] I have read and checked the items on the review checklist.
