### PR TITLE
Pass the last GPU test

### DIFF
--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -168,6 +168,7 @@ function turbulent_fluxes(
     ts_air = construct_atmos_ts(atmos, p, thermo_params)
     u_air = p.drivers.u
     h_air = atmos.h
+
     return turbulent_fluxes_at_a_point.(
         T_sfc,
         q_sfc,
@@ -180,7 +181,9 @@ function turbulent_fluxes(
         u_air,
         h_air,
         atmos.gustiness,
-        Ref(model.parameters),
+        model.parameters.z_0m,
+        model.parameters.z_0b,
+        Ref(model.parameters.earth_param_set),
     )
 end
 
@@ -196,18 +199,20 @@ end
                                 u::FT,
                                 h::FT,
                                 gustiness::FT,
-                                parameters::P,
+                                z_0m::FT,
+                                z_0b::FT,
+                                earth_param_set::EP,
                                ) where {FT <: AbstractFloat, P}
 
 Computes turbulent surface fluxes at a point on a surface given
-(1) the surface temperature (T_sfc), specific humidity (q_sfc), 
+(1) the surface temperature (T_sfc), specific humidity (q_sfc),
     and air density (ρ_sfc),
-(2) Other surface properties, such as the factor 
+(2) Other surface properties, such as the factor
     β_sfc  which scales the evaporation from the potential rate
     (used in bucket models), and the surface resistance r_sfc (used
-    in more complex land models), and the topographical height of the surface (h_sfc).
-(3) the parameter set for the model, which must have fields `earth_param_set`,
-    and roughness lengths `z_0m, z_0b`.
+    in more complex land models), and the topographical height of the surface (h_sfc)
+(3) the roughness lengths `z_0m, z_0b`, and the Earth parameter set for the model
+    `earth_params`.
 (4) the prescribed atmospheric state, `ts_in`, u, h the height
     at which these measurements are made, and the gustiness parameter (m/s).
 (5) the displacement height for the model d_sfc
@@ -227,9 +232,10 @@ function turbulent_fluxes_at_a_point(
     u::FT,
     h::FT,
     gustiness::FT,
-    parameters::P,
-) where {FT <: AbstractFloat, P}
-    (; z_0m, z_0b, earth_param_set) = parameters
+    z_0m::FT,
+    z_0b::FT,
+    earth_param_set::EP,
+) where {FT <: AbstractFloat, EP}
     thermo_params = LSMP.thermodynamic_parameters(earth_param_set)
     ts_sfc = Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sfc)
 

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -551,7 +551,11 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
                 p.bucket.T_sfc,
                 Y.bucket.σS,
                 p.bucket.ρ_sfc,
-                Ref(model.parameters),
+                Ref(
+                    LSMP.thermodynamic_parameters(
+                        model.parameters.earth_param_set,
+                    ),
+                ),
             )
 
         # Compute turbulent surface fluxes

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -177,7 +177,7 @@ function β(W::FT, W_f::FT) where {FT}
 end
 
 """
-    saturation_specific_humidity(T::FT, σS::FT, ρ_sfc::FT, parameters::PE)::FT where {FT, PE}
+    saturation_specific_humidity(T::FT, σS::FT, ρ_sfc::FT, thermo_parameters::TPE)::FT where {FT, TPE}
 
 Computes the saturation specific humidity for the land surface, over ice
 if snow is present (σS>0), and over water for a snow-free surface.
@@ -186,9 +186,8 @@ function saturation_specific_humidity(
     T::FT,
     σS::FT,
     ρ_sfc::FT,
-    parameters::PE,
-)::FT where {FT, PE}
-    thermo_params = LSMP.thermodynamic_parameters(parameters.earth_param_set)
+    thermo_params::TPE,
+)::FT where {FT, TPE}
     return (1 - heaviside(σS)) * Thermodynamics.q_vap_saturation_generic(
         thermo_params,
         T,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,6 @@ using SafeTestsets
 
 import ClimaComms
 
-gpu_broken = ClimaComms.device() isa ClimaComms.CUDADevice
-
 # Performance and code quality tests
 @safetestset "Aqua tests" begin
     include("aqua.jl")
@@ -33,7 +31,7 @@ end
 end
 
 # Standalone Bucket model tests
-gpu_broken || @safetestset "Bucket albedo types tests" begin
+@safetestset "Bucket albedo types tests" begin
     include("standalone/Bucket/albedo_types.jl")
 end
 @safetestset "Bucket snow tests" begin


### PR DESCRIPTION
This PR fixed GPU-incompatibility in the `albedo_type` tests. With this, all the tests and experiments run on GPU. At the moment, all the remapping and file reading is still done on CPU.